### PR TITLE
Add policy engine API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod blockchain;
 pub mod client;
 pub mod keys;
 pub mod local_client;
+pub mod policy_engine;
 pub mod protocol;
 pub mod remote_client;
 pub mod server;
@@ -22,7 +23,6 @@ mod cli;
 mod config;
 mod defaults;
 mod key_mgmt;
-mod policy_engine;
 
 /// Logs used to verify that an operation completed in the integration tests.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod cli;
 mod config;
 mod defaults;
 mod key_mgmt;
+mod policy_engine;
 
 /// Logs used to verify that an operation completed in the integration tests.
 #[derive(Debug)]

--- a/src/policy_engine.rs
+++ b/src/policy_engine.rs
@@ -1,0 +1,59 @@
+//! Black-box policy engine API and supporting types.
+//!
+//! The key server will interact with a [`PolicyEngine`] instantiation.
+
+use crate::transaction::TransactionApprovalRequest;
+use thiserror::Error;
+
+/// A `PolicyEngine` is the entity responsible for coordination and management
+/// of operations requested on digital asset keys with
+/// [`SharedControl`](crate::keys::SharedControl).
+///
+/// This trait describes the interactions between a key server and the policy
+/// engine, but doesn't encompass the entire behavior of a policy engine -- this
+/// would also include interactions with service providers and asset
+/// fiduciaries.
+///
+/// Assumption: any policy engine implementation will have one or more API
+/// endpoints that correspond to the trait methods. Instantiation of this trait
+/// will call out to the appropriate endpoints, and will handle any retries and
+/// waiting behavior dictated by the external implementation.
+trait PolicyEngine {
+    fn request_transaction_approval(
+        &self,
+        request: TransactionApprovalRequest,
+    ) -> Result<TransactionApprovalDecision, PolicyEngineError>;
+}
+
+/// The set of valid outcomes from a [`PolicyEngine`] decision.
+///
+/// TODO : Expand these variants with the appropriate context - approval
+/// signatures or a note to describe the rejection.
+#[derive(Debug)]
+#[allow(unused)]
+enum TransactionApprovalDecision {
+    Approve(Vec<ApprovalSignature>),
+    Reject(RejectionContext),
+}
+
+/// Signature from an asset fiduciary over a [`TransactionApprovalRequest`].
+///
+/// Assumption: The signature is from an asset fiduciary. The set of asset
+/// fiduciaries is fixed and defined in the system configuraiton. This type
+/// must not be instantiated if the underlying signature does not correspond
+/// to one of the specified fiduciaries.
+#[derive(Debug)]
+struct ApprovalSignature;
+
+/// Context for why a the [`PolicyEngine`] rejected a
+/// [`TransactionApprovalRequest`].
+#[derive(Debug)]
+struct RejectionContext;
+
+/// Errors that can arise during a transaction approval request to a policy
+/// engine.
+///
+/// This does not include rejection of a request! That is covered by a
+/// [`TransactionApprovalDecision`].
+#[derive(Debug, Error)]
+enum PolicyEngineError {}

--- a/src/policy_engine.rs
+++ b/src/policy_engine.rs
@@ -3,7 +3,49 @@
 //! The key server will interact with a [`PolicyEngine`] instantiation.
 
 use crate::transaction::TransactionApprovalRequest;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+/// Configuration for an asset fiduciary.
+///
+/// This must include public key information that can be used to verify approvals.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssetFiduciaryConfig;
+
+/// Configuration for a policy engine.
+///
+/// Assumption: The access control structure for asset fiduciaries requires approval
+/// from all fiduciaries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyEngineConfig {
+    /// Indicates whether unilateral control keys are allowed in the system.
+    #[serde(default)]
+    unilateral_control_allowed: bool,
+    /// The number of [`SelfCustodial`](crate::keys::SelfCustodial) keys each user can create.
+    #[serde(default)]
+    max_self_custodial: u16,
+    /// The number of [`Delegated`](crate::keys::Delegated) keys each user can create.
+    #[serde(default)]
+    max_delegated: u16,
+    /// The set of asset fiduciaries.
+    asset_fiduciaries: Vec<AssetFiduciaryConfig>,
+}
+
+#[allow(unused)]
+impl PolicyEngineConfig {
+    pub fn unilateral_control_allowed(&self) -> bool {
+        self.unilateral_control_allowed
+    }
+    pub fn max_self_custodial(&self) -> u16 {
+        self.max_self_custodial
+    }
+    pub fn max_delegated(&self) -> u16 {
+        self.max_delegated
+    }
+    pub fn asset_fiduciaries(&self) -> &Vec<AssetFiduciaryConfig> {
+        &self.asset_fiduciaries
+    }
+}
 
 /// A `PolicyEngine` is the entity responsible for coordination and management
 /// of operations requested on digital asset keys with
@@ -19,6 +61,11 @@ use thiserror::Error;
 /// will call out to the appropriate endpoints, and will handle any retries and
 /// waiting behavior dictated by the external implementation.
 pub trait PolicyEngine {
+    /// Initialize the policy engine interface according to the specified configuration.
+    fn initialize(config: PolicyEngineConfig) -> Result<Self, PolicyEngineError>
+    where
+        Self: Sized;
+
     fn request_transaction_approval(
         &self,
         request: TransactionApprovalRequest,
@@ -26,27 +73,26 @@ pub trait PolicyEngine {
 }
 
 /// The set of valid outcomes from a [`PolicyEngine`] decision.
-///
-/// TODO : Expand these variants with the appropriate context - approval
-/// signatures or a note to describe the rejection.
 #[derive(Debug)]
 #[allow(unused)]
 pub enum TransactionApprovalDecision {
+    /// All asset fiduciaries approved the request; there must be exactly one
+    /// signature per asset fiduciary.
     Approve(Vec<ApprovalSignature>),
-    Reject(RejectionContext),
+    /// At least one asset fiduciary rejected the request; the vector cannot be
+    /// empty.
+    Reject(Vec<RejectionContext>),
 }
 
 /// Signature from an asset fiduciary over a [`TransactionApprovalRequest`].
 ///
-/// Assumption: The signature is from an asset fiduciary. The set of asset
-/// fiduciaries is fixed and defined in the system configuration. This type
-/// must not be instantiated if the underlying signature does not correspond
+/// The set of asset fiduciaries is fixed and defined in the [`PolicyEngineConfig`].
+/// This type can only be instantiated if the underlying signature corresponds
 /// to one of the specified fiduciaries.
 #[derive(Debug)]
 pub struct ApprovalSignature;
 
-/// Context for why a the [`PolicyEngine`] rejected a
-/// [`TransactionApprovalRequest`].
+/// Context for why an asset fiduciary rejected a [`TransactionApprovalRequest`].
 #[derive(Debug)]
 pub struct RejectionContext;
 

--- a/src/policy_engine.rs
+++ b/src/policy_engine.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 /// endpoints that correspond to the trait methods. Instantiation of this trait
 /// will call out to the appropriate endpoints, and will handle any retries and
 /// waiting behavior dictated by the external implementation.
-trait PolicyEngine {
+pub trait PolicyEngine {
     fn request_transaction_approval(
         &self,
         request: TransactionApprovalRequest,
@@ -31,7 +31,7 @@ trait PolicyEngine {
 /// signatures or a note to describe the rejection.
 #[derive(Debug)]
 #[allow(unused)]
-enum TransactionApprovalDecision {
+pub enum TransactionApprovalDecision {
     Approve(Vec<ApprovalSignature>),
     Reject(RejectionContext),
 }
@@ -43,12 +43,12 @@ enum TransactionApprovalDecision {
 /// must not be instantiated if the underlying signature does not correspond
 /// to one of the specified fiduciaries.
 #[derive(Debug)]
-struct ApprovalSignature;
+pub struct ApprovalSignature;
 
 /// Context for why a the [`PolicyEngine`] rejected a
 /// [`TransactionApprovalRequest`].
 #[derive(Debug)]
-struct RejectionContext;
+pub struct RejectionContext;
 
 /// Errors that can arise during a transaction approval request to a policy
 /// engine.
@@ -56,4 +56,4 @@ struct RejectionContext;
 /// This does not include rejection of a request! That is covered by a
 /// [`TransactionApprovalDecision`].
 #[derive(Debug, Error)]
-enum PolicyEngineError {}
+pub enum PolicyEngineError {}

--- a/src/policy_engine.rs
+++ b/src/policy_engine.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 /// [`SharedControl`](crate::keys::SharedControl).
 ///
 /// This trait describes the interactions between a key server and the policy
-/// engine, but doesn't encompass the entire behavior of a policy engine -- this
-/// would also include interactions with service providers and asset
+/// engine, but doesn't encompass the entire behavior of a policy engine -- the
+/// policy engine is responsible for all interactions with service providers and asset
 /// fiduciaries.
 ///
 /// Assumption: any policy engine implementation will have one or more API
@@ -39,7 +39,7 @@ enum TransactionApprovalDecision {
 /// Signature from an asset fiduciary over a [`TransactionApprovalRequest`].
 ///
 /// Assumption: The signature is from an asset fiduciary. The set of asset
-/// fiduciaries is fixed and defined in the system configuraiton. This type
+/// fiduciaries is fixed and defined in the system configuration. This type
 /// must not be instantiated if the underlying signature does not correspond
 /// to one of the specified fiduciaries.
 #[derive(Debug)]

--- a/src/policy_engine.rs
+++ b/src/policy_engine.rs
@@ -12,10 +12,13 @@ use thiserror::Error;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssetFiduciaryConfig;
 
-/// Configuration for a policy engine.
+/// System-wide configuration for a policy engine.
 ///
-/// Assumption: The access control structure for asset fiduciaries requires approval
-/// from all fiduciaries.
+/// The policy engine relies on a fixed set of asset fiduciaries; this set is
+/// specified in the `PolicyEngineConfig`. When a key operation is requested,
+/// the [`PolicyEngine`] asks each asset fiduciary for a corresponding approval
+/// decision. Final approval of the operation by the [`PolicyEngine`] requires receipt
+/// of an approval from each asset fiduciary specified in the policy configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyEngineConfig {
     /// Indicates whether unilateral control keys are allowed in the system.
@@ -27,7 +30,7 @@ pub struct PolicyEngineConfig {
     /// The number of [`Delegated`](crate::keys::Delegated) keys each user can create.
     #[serde(default)]
     max_delegated: u16,
-    /// The set of asset fiduciaries.
+    /// The system-wide set of asset fiduciaries.
     asset_fiduciaries: Vec<AssetFiduciaryConfig>,
 }
 
@@ -77,20 +80,20 @@ pub trait PolicyEngine {
 #[allow(unused)]
 pub enum TransactionApprovalDecision {
     /// All asset fiduciaries approved the request; there must be exactly one
-    /// signature per asset fiduciary.
-    Approve(Vec<ApprovalSignature>),
+    /// approval per asset fiduciary.
+    Approve(Vec<FiduciaryApproval>),
     /// At least one asset fiduciary rejected the request; the vector cannot be
     /// empty.
     Reject(Vec<RejectionContext>),
 }
 
-/// Signature from an asset fiduciary over a [`TransactionApprovalRequest`].
+/// Approval from an asset fiduciary over a [`TransactionApprovalRequest`].
 ///
 /// The set of asset fiduciaries is fixed and defined in the [`PolicyEngineConfig`].
-/// This type can only be instantiated if the underlying signature corresponds
-/// to one of the specified fiduciaries.
+/// A `FiduciaryApproval` must be tied to a specific asset fiduciary specified in
+/// that configuration.
 #[derive(Debug)]
-pub struct ApprovalSignature;
+pub struct FiduciaryApproval;
 
 /// Context for why an asset fiduciary rejected a [`TransactionApprovalRequest`].
 #[derive(Debug)]


### PR DESCRIPTION
This PR creates a `PolicyEngine` trait that the key server will interact with. The design intention here is that we will instantiate this trait for the mighty block policy engine, a dummy policy engine for us to test with, and eventually our own policy engine implementation.

I tried to document assumptions and sketch out the basic types this will return. I didn't explicitly make them `Serialize` / `Deserialize` because I don't want to require the external policy engine to create these specific types  -- it's fine if the (internal) trait instantiation takes the types returned from the external engine, vets / validates them, and instantiates the specific return types this API requires.

Fixes #14 