### PR TITLE
Added wrap_comments and import_granularity to rustfmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,13 +25,20 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
+      # Install stable toolchain
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt, clippy
+          components: clippy
+
+      # Install nightly toolchain
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
 
       - name: Format check
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Clippy lint
         run: cargo clippy --all-features --all-targets --verbose --workspace -- -Dwarnings

--- a/dams-key-server/src/database.rs
+++ b/dams-key-server/src/database.rs
@@ -8,7 +8,8 @@ use std::env;
 
 pub(crate) mod user;
 
-/// Connect to the MongoDB instance and database specified by your environment variables
+/// Connect to the MongoDB instance and database specified by your environment
+/// variables
 pub async fn connect_to_mongo() -> Result<Database, anyhow::Error> {
     let mongodb_url = env::var("MONGODB_URI")?;
     let db_name = env::var("DB_NAME")?;

--- a/dams-key-server/src/database/user.rs
+++ b/dams-key-server/src/database/user.rs
@@ -14,7 +14,8 @@ use mongodb::{
 };
 use opaque_ke::ServerRegistration;
 
-/// Create a new [`User`] with their authentication information and insert it into the MongoDB database.
+/// Create a new [`User`] with their authentication information and insert it
+/// into the MongoDB database.
 pub async fn create_user(
     db: &Database,
     user_id: &UserId,
@@ -26,7 +27,8 @@ pub async fn create_user(
     Ok(insert_one_res.inserted_id.as_object_id())
 }
 
-/// Find a [`User`] by their `user_id`. This is different from the Mongo-assigned `_id` field.
+/// Find a [`User`] by their `user_id`. This is different from the
+/// Mongo-assigned `_id` field.
 pub async fn find_user(db: &Database, user_id: &UserId) -> Result<Option<User>, Error> {
     let collection = db.collection::<User>("users");
     let query = doc! {"user_id": user_id.to_string()};

--- a/dams-key-server/src/policy_engine.rs
+++ b/dams-key-server/src/policy_engine.rs
@@ -8,7 +8,8 @@ use thiserror::Error;
 
 /// Configuration for an asset fiduciary.
 ///
-/// This must include public key information that can be used to verify approvals.
+/// This must include public key information that can be used to verify
+/// approvals.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssetFiduciaryConfig;
 
@@ -17,17 +18,20 @@ pub struct AssetFiduciaryConfig;
 /// The policy engine relies on a fixed set of asset fiduciaries; this set is
 /// specified in the `PolicyEngineConfig`. When a key operation is requested,
 /// the [`PolicyEngine`] asks each asset fiduciary for a corresponding approval
-/// decision. Final approval of the operation by the [`PolicyEngine`] requires receipt
-/// of an approval from each asset fiduciary specified in the policy configuration.
+/// decision. Final approval of the operation by the [`PolicyEngine`] requires
+/// receipt of an approval from each asset fiduciary specified in the policy
+/// configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyEngineConfig {
     /// Indicates whether unilateral control keys are allowed in the system.
     #[serde(default)]
     unilateral_control_allowed: bool,
-    /// The number of [`SelfCustodial`](dams::keys::SelfCustodial) keys each user can create.
+    /// The number of [`SelfCustodial`](dams::keys::SelfCustodial) keys each
+    /// user can create.
     #[serde(default)]
     max_self_custodial: u16,
-    /// The number of [`Delegated`](dams::keys::Delegated) keys each user can create.
+    /// The number of [`Delegated`](dams::keys::Delegated) keys each user can
+    /// create.
     #[serde(default)]
     max_delegated: u16,
     /// The system-wide set of asset fiduciaries.
@@ -56,15 +60,16 @@ impl PolicyEngineConfig {
 ///
 /// This trait describes the interactions between a key server and the policy
 /// engine, but doesn't encompass the entire behavior of a policy engine -- the
-/// policy engine is responsible for all interactions with service providers and asset
-/// fiduciaries.
+/// policy engine is responsible for all interactions with service providers and
+/// asset fiduciaries.
 ///
 /// Assumption: any policy engine implementation will have one or more API
 /// endpoints that correspond to the trait methods. Instantiation of this trait
 /// will call out to the appropriate endpoints, and will handle any retries and
 /// waiting behavior dictated by the external implementation.
 pub trait PolicyEngine {
-    /// Initialize the policy engine interface according to the specified configuration.
+    /// Initialize the policy engine interface according to the specified
+    /// configuration.
     fn initialize(config: PolicyEngineConfig) -> Result<Self, PolicyEngineError>
     where
         Self: Sized;
@@ -89,13 +94,14 @@ pub enum TransactionApprovalDecision {
 
 /// Approval from an asset fiduciary over a [`TransactionApprovalRequest`].
 ///
-/// The set of asset fiduciaries is fixed and defined in the [`PolicyEngineConfig`].
-/// A `FiduciaryApproval` must be tied to a specific asset fiduciary specified in
-/// that configuration.
+/// The set of asset fiduciaries is fixed and defined in the
+/// [`PolicyEngineConfig`]. A `FiduciaryApproval` must be tied to a specific
+/// asset fiduciary specified in that configuration.
 #[derive(Debug)]
 pub struct FiduciaryApproval;
 
-/// Context for why an asset fiduciary rejected a [`TransactionApprovalRequest`].
+/// Context for why an asset fiduciary rejected a
+/// [`TransactionApprovalRequest`].
 #[derive(Debug)]
 pub struct RejectionContext;
 

--- a/dams-local-client/src/api.rs
+++ b/dams-local-client/src/api.rs
@@ -21,8 +21,10 @@ use opaque_ke::{
     ClientRegistrationFinishParameters,
 };
 use rand::{CryptoRng, RngCore};
-use std::fmt::{Display, Formatter};
-use std::str::FromStr;
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 use thiserror::Error;
 use tracing::error;
 
@@ -131,8 +133,8 @@ impl Session {
     /// Open a new mutually authenticated session between a previously
     /// registered user and a key server described in the [`SessionConfig`].
     ///
-    /// Output: If successful, returns an open [`Session`] between the specified [`UserId`]
-    /// and the configured key server.
+    /// Output: If successful, returns an open [`Session`] between the specified
+    /// [`UserId`] and the configured key server.
     pub async fn open<T: CryptoRng + RngCore>(
         rng: &mut T,
         user_id: &UserId,
@@ -222,8 +224,8 @@ impl Session {
     /// This only needs to be called once per user; future sessions can be
     /// created with [`Session::open()`].
     ///
-    /// Output: If successful, returns an open [`Session`] between the specified [`UserId`]
-    /// and the configured key server.
+    /// Output: If successful, returns an open [`Session`] between the specified
+    /// [`UserId`] and the configured key server.
     pub async fn register<T: CryptoRng + RngCore>(
         rng: &mut T,
         user_id: &UserId,
@@ -327,8 +329,8 @@ pub enum Error {
 ///
 /// The [`UserId`] must be the same user who opened the [`Session`].
 ///
-/// Output: If successful, returns the [`KeyInfo`] describing the newly created key.
-///
+/// Output: If successful, returns the [`KeyInfo`] describing the newly created
+/// key.
 #[allow(unused)]
 pub fn create_digital_asset_key(
     session: Session,
@@ -371,10 +373,10 @@ pub fn set_user_key_policy(
 /// owner or a key fiduciary. This request will fail if the calling party
 /// is not from one of those entities.
 ///
-/// Output: If successful, returns a [`TransactionSignature`] as specified in the
-/// original [`TransactionApprovalRequest`] -- that is, over the
-/// [`Transaction`](dams::transaction::Transaction), and using the key corresponding
-/// to the [`KeyId`].
+/// Output: If successful, returns a [`TransactionSignature`] as specified in
+/// the original [`TransactionApprovalRequest`] -- that is, over the
+/// [`Transaction`](dams::transaction::Transaction), and using the key
+/// corresponding to the [`KeyId`].
 #[allow(unused)]
 pub fn request_transaction_signature(
     session: Session,
@@ -392,7 +394,8 @@ pub fn request_transaction_signature(
 /// The [`UserId`] must match the asset owner authenticated in the [`Session`].
 /// This function cannot be used to retrieve keys for a different user.
 ///
-/// Output: If successful, returns the [`KeyInfo`] for every key belonging to the user.
+/// Output: If successful, returns the [`KeyInfo`] for every key belonging to
+/// the user.
 #[allow(unused)]
 pub fn retrieve_public_keys(session: Session, user_id: UserId) -> Result<Vec<KeyInfo>, Error> {
     todo!()

--- a/dams-local-client/src/bin/main.rs
+++ b/dams-local-client/src/bin/main.rs
@@ -1,9 +1,12 @@
 use anyhow::Context;
-use dams::config::client::Config;
-use dams::defaults::client::config_path;
-use dams_local_client::cli::Cli;
-use dams_local_client::cli::Client::{Create, Retrieve};
-use dams_local_client::command::Command;
+use dams::{config::client::Config, defaults::client::config_path};
+use dams_local_client::{
+    cli::{
+        Cli,
+        Client::{Create, Retrieve},
+    },
+    command::Command,
+};
 use futures::FutureExt;
 use std::convert::identity;
 use structopt::StructOpt;

--- a/dams-local-client/src/lib.rs
+++ b/dams-local-client/src/lib.rs
@@ -1,4 +1,5 @@
-//! This crate is an implementation of a local client to a key management system.
+//! This crate is an implementation of a local client to a key management
+//! system.
 #![warn(missing_debug_implementations)]
 #![warn(unused_results)]
 #![warn(future_incompatible)]

--- a/dams-remote-client/src/api.rs
+++ b/dams-remote-client/src/api.rs
@@ -14,12 +14,13 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum Error {}
 
-/// Register a passive user to the service provider authenticated in this session.
+/// Register a passive user to the service provider authenticated in this
+/// session.
 ///
-/// Assumption: a passive user only has [`Passive`][dams::keys::Passive] keys and has
-/// not independently registered with the system, so
-/// the service provider needs to call this function to indicate that they can take
-/// actions on this user's behalf.
+/// Assumption: a passive user only has [`Passive`][dams::keys::Passive] keys
+/// and has not independently registered with the system, so
+/// the service provider needs to call this function to indicate that they can
+/// take actions on this user's behalf.
 ///
 /// Output: none, if successful.
 ///
@@ -59,10 +60,10 @@ pub fn create_passive_digital_asset_key(
 /// In either case, the caller must make the request over an authenticated
 /// session.
 ///
-/// Output: If successful, returns a [`TransactionSignature`] as specified in the
-/// original [`TransactionApprovalRequest`] -- that is, over the
-/// [`Transaction`](dams::transaction::Transaction), and using the key corresponding
-/// to the [`KeyId`].
+/// Output: If successful, returns a [`TransactionSignature`] as specified in
+/// the original [`TransactionApprovalRequest`] -- that is, over the
+/// [`Transaction`](dams::transaction::Transaction), and using the key
+/// corresponding to the [`KeyId`].
 ///
 /// TODO #30 (design, implementation): Pass a session.
 #[allow(unused)]
@@ -77,10 +78,13 @@ pub fn request_transaction_signature(
 /// The key must correspond to a [`Passive`][dams::keys::Passive]
 /// digital asset key.
 ///
-/// Assumption: The [`import_asset_key`] functionality is called by the service provider. This is cryptographically enforced with
-/// an authenticated session between the key server and the service provider. This request will fail otherwise.
+/// Assumption: The [`import_asset_key`] functionality is called by the service
+/// provider. This is cryptographically enforced with an authenticated session
+/// between the key server and the service provider. This request will fail
+/// otherwise.
 ///
-/// Output: If successful, returns the [`KeyInfo`] for the newly imported digital asset key.
+/// Output: If successful, returns the [`KeyInfo`] for the newly imported
+/// digital asset key.
 ///
 /// TODO #30 (design, implementation): Pass a session.
 #[allow(unused)]
@@ -100,9 +104,11 @@ pub fn import_asset_key(
 ///
 /// Assumption: The [`export_asset_key`] functionality is called by the service
 /// provider. This is cryptographically enforced with an authenticated session
-/// between the key server and the service provider. This request will fail otherwise.
+/// between the key server and the service provider. This request will fail
+/// otherwise.
 ///
-/// Output: If successful, returns [`KeyMaterial`] corresponding to the requested key.
+/// Output: If successful, returns [`KeyMaterial`] corresponding to the
+/// requested key.
 ///
 /// TODO #30 (design, implementation): Pass a session.
 #[allow(unused)]
@@ -113,16 +119,16 @@ pub fn export_asset_key(user_id: UserId, key_id: &KeyId) -> Result<KeyMaterial, 
 /// Retrieve the public key info for all keys associated with the specified
 /// user from the key server.
 ///
-/// The [`KeyId`] must correspond to a digital asset key owned by the [`UserId`].
-/// If the key is [`Passive`](dams::keys::Passive), the caller must be the
-/// service provider.
+/// The [`KeyId`] must correspond to a digital asset key owned by the
+/// [`UserId`]. If the key is [`Passive`](dams::keys::Passive), the caller must
+/// be the service provider.
 /// If the key is [`Delegated`](dams::keys::Delegated), the caller must be a
 /// key fiduciary with delegated signing authority for the key.
 /// In either case, the request must be made by the caller over an authenticated
 /// session.
 ///
-/// Output: If successful, returns the [`KeyInfo`] for every key belonging to the
-/// user and delegated (as described) to the caller.
+/// Output: If successful, returns the [`KeyInfo`] for every key belonging to
+/// the user and delegated (as described) to the caller.
 ///
 /// TODO #30 (design, implementation): Pass a session.
 #[allow(unused)]
@@ -133,9 +139,9 @@ pub fn retrieve_public_keys(user_id: UserId) -> Result<Vec<KeyInfo>, Error> {
 /// Retrieve the public key info from the key server for the specified key
 /// associated with the user.
 ///
-/// The [`KeyId`] must correspond to a digital asset key owned by the [`UserId`].
-/// If the key is [`Passive`](dams::keys::Passive), the caller must be the
-/// service provider.
+/// The [`KeyId`] must correspond to a digital asset key owned by the
+/// [`UserId`]. If the key is [`Passive`](dams::keys::Passive), the caller must
+/// be the service provider.
 /// If the key is [`Delegated`](dams::keys::Delegated), the caller must be a
 /// key fiduciary with delegated signing authority for the key.
 /// In either case, the request must be made by the caller over an authenticated
@@ -152,9 +158,9 @@ pub fn retrieve_public_key_by_id(user_id: UserId, key_id: &KeyId) -> Result<KeyI
 /// Retrieve the audit log from the key server for a specified asset owner;
 /// optionally, filter for logs associated with the specified [`KeyId`].
 ///
-/// The [`KeyId`] must correspond to a digital asset key owned by the [`UserId`].
-/// If the key is [`Passive`](dams::keys::Passive), the caller must be the
-/// service provider.
+/// The [`KeyId`] must correspond to a digital asset key owned by the
+/// [`UserId`]. If the key is [`Passive`](dams::keys::Passive), the caller must
+/// be the service provider.
 /// If the key is [`Delegated`](dams::keys::Delegated), the caller must be a
 /// key fiduciary with delegated signing authority for the key.
 /// In either case, the request must be made by the caller over an authenticated

--- a/dams-remote-client/src/lib.rs
+++ b/dams-remote-client/src/lib.rs
@@ -1,6 +1,5 @@
-//! This crate is an implementation of a remote client to a key management system.
-//!
-//!
+//! This crate is an implementation of a remote client to a key management
+//! system.
 #![warn(missing_debug_implementations)]
 #![warn(unused_results)]
 #![warn(future_incompatible)]

--- a/dams-tests/tests/main.rs
+++ b/dams-tests/tests/main.rs
@@ -1,7 +1,9 @@
 pub(crate) mod common;
 
-use crate::Operation::{Authenticate, Create, Register, Retrieve};
-use crate::Party::{Client, Server};
+use crate::{
+    Operation::{Authenticate, Create, Register, Retrieve},
+    Party::{Client, Server},
+};
 use anyhow::anyhow;
 use common::{get_logs, LogType, Party};
 
@@ -11,10 +13,8 @@ use dams_local_client::{
     api::{Password, Session, SessionConfig},
     command::Command,
 };
-use rand::prelude::StdRng;
-use rand::SeedableRng;
-use std::fs::OpenOptions;
-use std::str::FromStr;
+use rand::{prelude::StdRng, SeedableRng};
+use std::{fs::OpenOptions, str::FromStr};
 use structopt::StructOpt;
 use thiserror::Error;
 

--- a/dams-tests/tests/remote_client.rs
+++ b/dams-tests/tests/remote_client.rs
@@ -1,7 +1,9 @@
-use dams::blockchain::Blockchain;
-use dams::keys::{KeyId, KeyMaterial, SharedControl};
-use dams::transaction::TransactionApprovalRequest;
-use dams::user::UserId;
+use dams::{
+    blockchain::Blockchain,
+    keys::{KeyId, KeyMaterial, SharedControl},
+    transaction::TransactionApprovalRequest,
+    user::UserId,
+};
 use dams_remote_client::api::*;
 
 #[test]

--- a/dams/src/blockchain.rs
+++ b/dams/src/blockchain.rs
@@ -1,13 +1,14 @@
 //! Blockchain abstraction.
 //!
-//! Includes options for types of blockchains and defines primitives based on those options.
-//!
+//! Includes options for types of blockchains and defines primitives based on
+//! those options.
 
 use serde::{Deserialize, Serialize};
 
 /// Options for type of blockchain.
 ///
-/// A blockchain option must be specified when creating or importing a digital asset key.
+/// A blockchain option must be specified when creating or importing a digital
+/// asset key.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum Blockchain {
     EVM,
@@ -15,7 +16,8 @@ pub enum Blockchain {
 
 /// Indicator trait to identify objects that represent a signature scheme.
 ///
-/// TODO #43 (implementation, refactor): Move this definition to a crypto module and define signing operations
+/// TODO #43 (implementation, refactor): Move this definition to a crypto module
+/// and define signing operations
 pub trait SignatureScheme {}
 
 /// The ECDSA signature scheme
@@ -27,7 +29,8 @@ impl SignatureScheme for ECDSA {}
 impl Blockchain {
     /// Identify signature scheme that corresponds to each blockchain type.
     ///
-    /// In particular, the blockchain accepts valid transactions that are signed under the given scheme.
+    /// In particular, the blockchain accepts valid transactions that are signed
+    /// under the given scheme.
     pub fn signature_scheme(&self) -> impl SignatureScheme {
         match self {
             Blockchain::EVM => ECDSA,

--- a/dams/src/config/opaque.rs
+++ b/dams/src/config/opaque.rs
@@ -1,6 +1,5 @@
 use argon2::Argon2;
-use opaque_ke::key_exchange::tripledh::TripleDh;
-use opaque_ke::{CipherSuite, Ristretto255};
+use opaque_ke::{key_exchange::tripledh::TripleDh, CipherSuite, Ristretto255};
 
 #[allow(dead_code)]
 #[derive(Debug)]

--- a/dams/src/keys.rs
+++ b/dams/src/keys.rs
@@ -1,7 +1,7 @@
 //! Digital asset keys and descriptions.
 //!
-//! Includes basic key types (both standard keys and shares of keys) and identifiers
-//! and modifiers describing access control and custody.
+//! Includes basic key types (both standard keys and shares of keys) and
+//! identifiers and modifiers describing access control and custody.
 
 use crate::user::UserId;
 
@@ -27,7 +27,8 @@ pub struct KeyInfo {
     public_key: DigitalAssetPublicKey,
 }
 
-/// Wrapper around [`BytesMut`] to represent key material external to the system.
+/// Wrapper around [`BytesMut`] to represent key material external to the
+/// system.
 ///
 /// TODO #49 (design, implementation): Define key material properly.
 #[derive(Debug, Serialize, Deserialize)]

--- a/dams/src/lib.rs
+++ b/dams/src/lib.rs
@@ -1,4 +1,5 @@
-//! This crate is an implementation of a local client to a key management system.
+//! This crate is an implementation of a local client to a key management
+//! system.
 #![warn(missing_debug_implementations)]
 #![warn(unused_results)]
 #![warn(future_incompatible)]

--- a/dams/src/opaque_storage.rs
+++ b/dams/src/opaque_storage.rs
@@ -1,13 +1,17 @@
-use crate::config::opaque::OpaqueCipherSuite;
-use crate::config::server::Service;
-use crate::user::UserId;
+use crate::{
+    config::{opaque::OpaqueCipherSuite, server::Service},
+    user::UserId,
+};
 use anyhow::{anyhow, Context, Error};
 use generic_array::GenericArray;
-use opaque_ke::keypair::PrivateKey;
-use opaque_ke::{Ristretto255, ServerRegistration, ServerRegistrationLen, ServerSetup};
+use opaque_ke::{
+    keypair::PrivateKey, Ristretto255, ServerRegistration, ServerRegistrationLen, ServerSetup,
+};
 use rand::rngs::StdRng;
-use std::fs::File;
-use std::io::{Read, Write};
+use std::{
+    fs::File,
+    io::{Read, Write},
+};
 
 // TODO: replace with decent key-value storage #52.
 
@@ -97,9 +101,11 @@ mod tests {
     use crate::config::server::Service;
     use opaque_ke::{ClientRegistration, ClientRegistrationFinishParameters};
     use rand::SeedableRng;
-    use std::env::temp_dir;
-    use std::net::{IpAddr, Ipv4Addr};
-    use std::str::FromStr;
+    use std::{
+        env::temp_dir,
+        net::{IpAddr, Ipv4Addr},
+        str::FromStr,
+    };
 
     #[tokio::test]
     async fn test_store_and_retrieve() -> Result<(), Error> {

--- a/dams/src/protocol.rs
+++ b/dams/src/protocol.rs
@@ -1,5 +1,4 @@
-use dialectic::prelude::*;
-use dialectic::types::Done;
+use dialectic::{prelude::*, types::Done};
 use opaque_ke::{
     CredentialFinalization, CredentialRequest, CredentialResponse, RegistrationRequest,
     RegistrationResponse, RegistrationUpload,
@@ -95,9 +94,11 @@ impl RegisterStart {
     }
 }
 
-/// The object that the server responds with to the client when ['RegisterStart'] has been received
+/// The object that the server responds with to the client when
+/// ['RegisterStart'] has been received
 pub type RegisterStartReceived = RegistrationResponse<OpaqueCipherSuite>;
-/// The object that the client sends to the server to finish registration using OPAQUE
+/// The object that the client sends to the server to finish registration using
+/// OPAQUE
 pub type RegisterFinish = RegistrationUpload<OpaqueCipherSuite>;
 
 /// The object that the client sends to the server when registering using OPAQUE
@@ -116,9 +117,11 @@ impl AuthStart {
     }
 }
 
-/// The object that the server responds with to the client when ['RegisterStart'] has been received
+/// The object that the server responds with to the client when
+/// ['RegisterStart'] has been received
 pub type AuthStartReceived = CredentialResponse<OpaqueCipherSuite>;
-/// The object that the client sends to the server to finish registration using OPAQUE
+/// The object that the client sends to the server to finish registration using
+/// OPAQUE
 pub type AuthFinish = CredentialFinalization<OpaqueCipherSuite>;
 
 /// The two parties in the protocol.
@@ -157,8 +160,7 @@ impl Party {
 }
 
 // All protocols are from the perspective of the client.
-use crate::config::opaque::OpaqueCipherSuite;
-use crate::user::UserId;
+use crate::{config::opaque::OpaqueCipherSuite, user::UserId};
 pub use authenticate::Authenticate;
 pub use create::Create;
 pub use register::Register;

--- a/dams/src/transaction.rs
+++ b/dams/src/transaction.rs
@@ -3,8 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::keys::KeyId;
-use crate::user::UserId;
+use crate::{keys::KeyId, user::UserId};
 
 /// A transaction approval request is used to log a request for a
 /// [`TransactionSignature`] under the specified key. The key

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -1,7 +1,7 @@
 //! Models for the first pass of MongoDB integration.
 //!
-//! Includes structs for the various models found in the first round of Mongo integration.
-//! This module will likely be split by model into sub-modules.
+//! Includes structs for the various models found in the first round of Mongo
+//! integration. This module will likely be split by model into sub-modules.
 
 use crate::config::opaque::OpaqueCipherSuite;
 
@@ -41,7 +41,8 @@ pub struct Secret {
     material: BytesMut,
 }
 
-/// One user with a set of arbitrary secrets and a [`ServerRegistration`] to authenticate with.
+/// One user with a set of arbitrary secrets and a [`ServerRegistration`] to
+/// authenticate with.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct User {
     user_id: UserId,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,5 @@
 edition = "2018"
+
+unstable_features = true
+wrap_comments = true
+imports_granularity = "Crate"


### PR DESCRIPTION
Issue: #42 

These are unstable features so in order to apply them you have to use `cargo +nightly fmt`.

These new features can be automatically applied by VS Code by adding `+nightly` to the `Rustfmt: Extra Args` setting or directly adding `"rust-analyzer.rustfmt.extraArgs": ["+nightly"]` to your `settings.json`.

One downside to this change is that running `cargo fmt` in your terminal will spam a bunch of the following
```
Warning: can't set `wrap_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
```

