### PR TITLE
Add develop to CI, remove push trigger #112

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,10 +3,8 @@
 name: Rust
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR addresses half of #112. 

- CI is now triggered on PRs to `develop`.
- The `on.push` trigger was removed since both `main` and `develop` branches are protected from direct pushing.