### PR TITLE
Refactor error handling #153

### DIFF
--- a/dams-client/Cargo.toml
+++ b/dams-client/Cargo.toml
@@ -10,7 +10,6 @@ allow_explicit_certificate_trust = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
 argon2 = "0.4"
 async-trait = "0"
 bincode = "1"

--- a/dams-client/src/error.rs
+++ b/dams-client/src/error.rs
@@ -1,0 +1,33 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DamsClientError {
+    #[error("Tried to connect to a server without an https link")]
+    HttpNotAllowed,
+    #[error("Server returned failure")]
+    ServerReturnedFailure,
+
+    // Protocol errors
+    #[error("Registration failed")]
+    RegistrationFailed,
+    #[error("Authentication failed")]
+    AuthenticationFailed,
+
+    // Wrapped errors
+    #[error(transparent)]
+    Dams(#[from] dams::DamsError),
+    #[error(transparent)]
+    DamsChannel(#[from] dams::channel::ChannelError),
+    #[error("OPAQUE protocol error: {}", .0)]
+    OpaqueProtocol(opaque_ke::errors::ProtocolError),
+    #[error(transparent)]
+    TonicStatus(#[from] tonic::Status),
+    #[error(transparent)]
+    TonicTransport(#[from] tonic::transport::Error),
+}
+
+impl From<opaque_ke::errors::ProtocolError> for DamsClientError {
+    fn from(error: opaque_ke::errors::ProtocolError) -> Self {
+        Self::OpaqueProtocol(error)
+    }
+}

--- a/dams-client/src/lib.rs
+++ b/dams-client/src/lib.rs
@@ -6,3 +6,6 @@
 #![forbid(rustdoc::broken_intra_doc_links)]
 
 pub mod api;
+pub mod error;
+
+pub use error::DamsClientError;

--- a/dams-key-server/Cargo.toml
+++ b/dams-key-server/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/bin/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
 argon2 = "0.4"
 async-trait = "0"
 bincode = "1"

--- a/dams-key-server/src/bin/main.rs
+++ b/dams-key-server/src/bin/main.rs
@@ -18,6 +18,6 @@ pub async fn main() {
         Server(cli) => server::main_with_cli(cli).await,
     };
     if let Err(e) = result {
-        error!("{}, caused by: {}", e, e.root_cause());
+        error!("{}", e);
     }
 }

--- a/dams-key-server/src/database.rs
+++ b/dams-key-server/src/database.rs
@@ -5,11 +5,16 @@
 
 use mongodb::{options::ClientOptions, Client, Database};
 
+use crate::error::DamsServerError;
+
 pub(crate) mod user;
 
 /// Connect to the MongoDB instance and database specified by your environment
 /// variables
-pub async fn connect_to_mongo(mongodb_uri: &str, db_name: &str) -> Result<Database, anyhow::Error> {
+pub async fn connect_to_mongo(
+    mongodb_uri: &str,
+    db_name: &str,
+) -> Result<Database, DamsServerError> {
     // Parse a connection string into an options struct
     let client_options = ClientOptions::parse(mongodb_uri).await?;
     // Get a handle to the deployment

--- a/dams-key-server/src/error.rs
+++ b/dams-key-server/src/error.rs
@@ -1,0 +1,42 @@
+use thiserror::Error;
+use tonic::Status;
+
+#[derive(Debug, Error)]
+pub enum DamsServerError {
+    #[error("Could not get service.")]
+    MissingService,
+
+    // Protocol errors
+    #[error("UserID already exists")]
+    UserIdAlreadyExists,
+    #[error("UserID does not exist")]
+    UserIdDoesNotExist,
+
+    // Wrapped errors
+    #[error(transparent)]
+    Dams(#[from] dams::DamsError),
+    #[error(transparent)]
+    DamsChannel(#[from] dams::channel::ChannelError),
+    #[error("OPAQUE protocol error: {}", .0)]
+    OpaqueProtocol(opaque_ke::errors::ProtocolError),
+    #[error(transparent)]
+    TonicStatus(#[from] tonic::Status),
+    #[error(transparent)]
+    TonicTransport(#[from] tonic::transport::Error),
+    #[error(transparent)]
+    EnvVar(#[from] std::env::VarError),
+    #[error(transparent)]
+    MongoDb(#[from] mongodb::error::Error),
+}
+
+impl From<opaque_ke::errors::ProtocolError> for DamsServerError {
+    fn from(error: opaque_ke::errors::ProtocolError) -> Self {
+        Self::OpaqueProtocol(error)
+    }
+}
+
+impl From<DamsServerError> for Status {
+    fn from(error: DamsServerError) -> Status {
+        Status::internal(error.to_string())
+    }
+}

--- a/dams-key-server/src/lib.rs
+++ b/dams-key-server/src/lib.rs
@@ -8,7 +8,10 @@
 pub mod cli;
 pub mod command;
 pub mod database;
+pub mod error;
 pub mod policy_engine;
 pub mod server;
 
 pub(crate) mod constants;
+
+pub use error::DamsServerError;

--- a/dams-tests/Cargo.toml
+++ b/dams-tests/Cargo.toml
@@ -20,4 +20,3 @@ tonic = "0.8.0"
 tracing = "0"
 tracing-futures = "0"
 tracing-subscriber = { version = "0", features = ["env-filter"] }
-

--- a/dams-tests/tests/main.rs
+++ b/dams-tests/tests/main.rs
@@ -4,11 +4,13 @@ use crate::{
     Operation::{Authenticate, Register},
     Party::{Client, Server},
 };
-use anyhow::anyhow;
 use common::{get_logs, LogType, Party};
 
 use dams::{dams_rpc::dams_rpc_client::DamsRpcClient, user::UserId};
-use dams_client::api::{Password, Session};
+use dams_client::{
+    api::{Password, Session},
+    DamsClientError,
+};
 use dams_key_server::database;
 use rand::{prelude::StdRng, SeedableRng};
 use std::{fs::OpenOptions, str::FromStr};
@@ -105,7 +107,7 @@ async fn tests() -> Vec<Test> {
                     ),
                     Outcome {
                         error: Some(Client),
-                        expected_error: Some(anyhow!("RegistrationFailed")),
+                        expected_error: Some(DamsClientError::RegistrationFailed),
                     },
                 ),
             ],
@@ -166,7 +168,7 @@ async fn tests() -> Vec<Test> {
                     ),
                     Outcome {
                         error: Some(Client),
-                        expected_error: Some(anyhow!("AuthenticationFailed")),
+                        expected_error: Some(DamsClientError::AuthenticationFailed),
                     },
                 ),
             ],
@@ -180,7 +182,7 @@ async fn tests() -> Vec<Test> {
                 ),
                 Outcome {
                     error: Some(Client),
-                    expected_error: Some(anyhow!("AuthenticationFailed")),
+                    expected_error: Some(DamsClientError::AuthenticationFailed),
                 },
             )],
         },
@@ -229,7 +231,7 @@ impl Test {
                         expected_outcome
                             .expected_error
                             .as_ref()
-                            .unwrap_or(&anyhow!(""))
+                            .unwrap()
                             .to_string(),
                         e.to_string()
                     );
@@ -278,5 +280,5 @@ struct Outcome {
     /// Which process, if any, had an error? Assumes that exactly one party will
     /// error.
     error: Option<Party>,
-    expected_error: Option<anyhow::Error>,
+    expected_error: Option<DamsClientError>,
 }

--- a/dams/Cargo.toml
+++ b/dams/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
 argon2 = "0.4"
 async-trait = "0"
 bincode = "1"

--- a/dams/src/config/client.rs
+++ b/dams/src/config/client.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use crate::defaults::client as defaults;
+use crate::{defaults::client as defaults, error::DamsError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
@@ -25,7 +25,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub async fn load(config_path: impl AsRef<Path>) -> Result<Config, anyhow::Error> {
+    pub async fn load(config_path: impl AsRef<Path>) -> Result<Config, DamsError> {
         let mut config: Config = toml::from_str(&tokio::fs::read_to_string(&config_path).await?)?;
 
         // Directory containing the configuration path

--- a/dams/src/config/server.rs
+++ b/dams/src/config/server.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use crate::defaults::server as defaults;
+use crate::{defaults::server as defaults, error::DamsError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
@@ -47,7 +47,7 @@ pub struct Service {
 }
 
 impl Config {
-    pub async fn load(config_path: impl AsRef<Path>) -> Result<Config, anyhow::Error> {
+    pub async fn load(config_path: impl AsRef<Path>) -> Result<Config, DamsError> {
         let mut config: Config = toml::from_str(&tokio::fs::read_to_string(&config_path).await?)?;
 
         // Directory containing the configuration path

--- a/dams/src/defaults.rs
+++ b/dams/src/defaults.rs
@@ -5,9 +5,10 @@ use std::{
     time::Duration,
 };
 
-fn project_dirs() -> Result<ProjectDirs, anyhow::Error> {
-    ProjectDirs::from("", shared::ORGANIZATION, shared::APPLICATION)
-        .ok_or_else(|| anyhow::anyhow!("Could not open user's home directory"))
+use crate::error::DamsError;
+
+fn project_dirs() -> Result<ProjectDirs, DamsError> {
+    ProjectDirs::from("", shared::ORGANIZATION, shared::APPLICATION).ok_or(DamsError::ProjectDirs)
 }
 
 pub(crate) mod shared {
@@ -47,7 +48,7 @@ pub mod server {
 
     pub const CONFIG_FILE: &str = "Server.toml";
 
-    pub fn config_path() -> Result<PathBuf, anyhow::Error> {
+    pub fn config_path() -> Result<PathBuf, DamsError> {
         Ok(project_dirs()?.config_dir().join(CONFIG_FILE))
     }
 }
@@ -63,7 +64,7 @@ pub mod client {
 
     pub const CONFIG_FILE: &str = "Client.toml";
 
-    pub fn config_path() -> Result<PathBuf, anyhow::Error> {
+    pub fn config_path() -> Result<PathBuf, DamsError> {
         Ok(project_dirs()?.config_dir().join(CONFIG_FILE))
     }
 

--- a/dams/src/error.rs
+++ b/dams/src/error.rs
@@ -1,0 +1,52 @@
+use thiserror::Error;
+use tonic::Status;
+
+use crate::{channel::ChannelError, crypto::CryptoError};
+
+#[derive(Debug, Error)]
+pub enum DamsError {
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+    #[error(transparent)]
+    Channel(#[from] ChannelError),
+
+    // OPAQUE errors
+    #[error("Could not create opaque path directory")]
+    InvalidOpaqueDirectory,
+    #[error("Could not open user's home directory")]
+    ProjectDirs,
+
+    // Wrapped errors
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("OPAQUE protocol error: {}", .0)]
+    OpaqueProtocol(opaque_ke::errors::ProtocolError),
+    #[error(transparent)]
+    Toml(#[from] toml::de::Error),
+}
+
+impl From<opaque_ke::errors::ProtocolError> for DamsError {
+    fn from(error: opaque_ke::errors::ProtocolError) -> Self {
+        Self::OpaqueProtocol(error)
+    }
+}
+
+impl From<DamsError> for Status {
+    fn from(error: DamsError) -> Self {
+        let message = error.to_string();
+
+        use DamsError::*;
+        match error {
+            Crypto(_)
+            | Channel(_)
+            | InvalidOpaqueDirectory
+            | ProjectDirs
+            | Bincode(_)
+            | Io(_)
+            | OpaqueProtocol(_)
+            | Toml(_) => Status::internal(message),
+        }
+    }
+}

--- a/dams/src/lib.rs
+++ b/dams/src/lib.rs
@@ -17,12 +17,15 @@ pub mod channel;
 pub mod config;
 pub mod crypto;
 pub mod defaults;
+pub mod error;
 pub mod keys;
 pub mod opaque_storage;
 pub mod timeout;
 pub mod transaction;
 pub mod types;
 pub mod user;
+
+pub use error::DamsError;
 
 #[allow(clippy::all)]
 pub mod dams_rpc {
@@ -55,20 +58,18 @@ macro_rules! impl_message_conversion {
     ($($message_type:ty),+) => {
         $(
             impl TryFrom<$crate::types::Message> for $message_type {
-                type Error = tonic::Status;
+                type Error = $crate::DamsError;
 
                 fn try_from(value: $crate::types::Message) -> Result<Self, Self::Error> {
-                    bincode::deserialize(&value.content)
-                        .map_err(|e| tonic::Status::internal(e.to_string()))
+                    Ok(bincode::deserialize(&value.content)?)
                 }
             }
 
             impl TryFrom<$message_type> for $crate::types::Message {
-                type Error = tonic::Status;
+                type Error = $crate::DamsError;
 
                 fn try_from(value: $message_type) -> Result<Self, Self::Error> {
-                    let content = bincode::serialize(&value)
-                        .map_err(|e| tonic::Status::internal(e.to_string()))?;
+                    let content = bincode::serialize(&value)?;
 
                     Ok($crate::types::Message { content })
                 }

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -3,11 +3,11 @@
 //! Includes structs for the various models found in the first round of Mongo
 //! integration. This module will likely be split by model into sub-modules.
 
-use crate::{config::opaque::OpaqueCipherSuite, crypto::Secret};
+use crate::{config::opaque::OpaqueCipherSuite, crypto::Secret, DamsError};
 
 use opaque_ke::ServerRegistration;
 use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, str::FromStr};
+use std::str::FromStr;
 
 /// Unique ID for a user. Assumption: this will be derived from an ID generated
 /// by the Service Provider.
@@ -21,7 +21,7 @@ impl ToString for UserId {
 }
 
 impl FromStr for UserId {
-    type Err = Infallible;
+    type Err = DamsError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(UserId(s.to_string()))


### PR DESCRIPTION
This PR creates custom error types for the three main crates.

The goal of these error types is to be able to use `?` everywhere instead of having to call `map_err`. This is accomplished by wrapping downstream errors  and forwarding their `std::Error` implementation with `#[error(transparent])`.

`anyhow` has been removed from the three library crates. It's still used in the `dams-tests` crate and can be used in binaries in the future. It's not meant for use in libraries.
