### PR TITLE
Generate and store

### DIFF
--- a/dams-client/src/api.rs
+++ b/dams-client/src/api.rs
@@ -9,7 +9,7 @@ pub(crate) mod authenticate;
 pub(crate) mod create_storage_key;
 pub(crate) mod register;
 
-pub mod generate;
+pub mod arbitrary_secrets;
 
 use crate::DamsClientError;
 use dams::{

--- a/dams-client/src/api.rs
+++ b/dams-client/src/api.rs
@@ -9,7 +9,9 @@ pub(crate) mod authenticate;
 pub(crate) mod create_storage_key;
 pub(crate) mod register;
 
-use crate::error::DamsClientError;
+pub mod generate;
+
+use crate::DamsClientError;
 use dams::{
     blockchain::Blockchain,
     crypto::KeyId,

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -1,16 +1,11 @@
-use crate::{DamsClient, DamsClientError};
+use crate::{client::ClientAction, DamsClient, DamsClientError};
 use dams::{
-    channel::ClientChannel,
     crypto::{KeyId, OpaqueExportKey, StorageKey},
     dams_rpc::dams_rpc_client::DamsRpcClient,
     types::retrieve_storage_key::{client, server},
     user::UserId,
 };
-use rand::{CryptoRng, RngCore};
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-use tonic::{transport::Channel, Status};
-use crate::client::ClientAction;
+use tonic::transport::Channel;
 
 mod generate;
 
@@ -18,8 +13,8 @@ mod generate;
 const SECRET_LENGTH: u32 = 32;
 
 impl DamsClient {
-    /// Retrieve the [`Encrypted<StorageKey>`] that belongs to the user specified by
-    /// `user_id`
+    /// Retrieve the [`Encrypted<StorageKey>`] that belongs to the user
+    /// specified by `user_id`
     async fn retrieve_storage_key(
         &self,
         client: &mut DamsRpcClient<Channel>,
@@ -33,26 +28,25 @@ impl DamsClient {
         let request = client::Request {
             user_id: user_id.clone(),
         };
-        channel
-            .send(request)
-            .await
-            .map_err(|e| Status::aborted(e.to_string()))?;
+        channel.send(request).await?;
 
         // Get encrypted storage key from server
         let response: server::Response = channel.receive().await?;
 
         // Decrypt storage_key
-        let storage_key = response.ciphertext.decrypt_storage_key(export_key);
+        let storage_key = response
+            .ciphertext
+            .decrypt_storage_key(export_key, user_id)?;
         Ok(storage_key)
     }
 
     /// Generate and store an arbitrary secret at the key server
-    pub async fn generate_and_store<T: CryptoRng + RngCore>(
+    pub async fn generate_and_store(
         &self,
         client: &mut DamsRpcClient<Channel>,
         user_id: &UserId,
         export_key: OpaqueExportKey,
     ) -> Result<KeyId, DamsClientError> {
-        self.handle_generate(client, user_id, export_key)
+        self.handle_generate(client, user_id, export_key).await
     }
 }

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -1,6 +1,6 @@
 use crate::{client::ClientAction, DamsClient, DamsClientError};
 use dams::{
-    crypto::{KeyId, OpaqueExportKey, StorageKey},
+    crypto::{KeyId, OpaqueExportKey, Secret, StorageKey},
     dams_rpc::dams_rpc_client::DamsRpcClient,
     types::retrieve_storage_key::{client, server},
     user::UserId,
@@ -46,7 +46,7 @@ impl DamsClient {
         client: &mut DamsRpcClient<Channel>,
         user_id: &UserId,
         export_key: OpaqueExportKey,
-    ) -> Result<KeyId, DamsClientError> {
+    ) -> Result<(KeyId, Secret), DamsClientError> {
         self.handle_generate(client, user_id, export_key).await
     }
 }

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -3,11 +3,17 @@ use dams::{
     crypto::{KeyId, Secret, StorageKey},
     types::retrieve_storage_key::{client, server},
 };
+use serde::{Deserialize, Serialize};
 
 mod generate;
 
 #[allow(unused)]
 const SECRET_LENGTH: u32 = 32;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LocalStorage {
+    pub(crate) secret: Secret,
+}
 
 impl DamsClient {
     /// Retrieve the [`dams::crypto::Encrypted<StorageKey>`] that belongs to the
@@ -35,7 +41,7 @@ impl DamsClient {
     }
 
     /// Generate and store an arbitrary secret at the key server
-    pub async fn generate_and_store(&self) -> Result<(KeyId, Secret), DamsClientError> {
+    pub async fn generate_and_store(&self) -> Result<(KeyId, LocalStorage), DamsClientError> {
         let mut client_channel =
             Self::create_channel(&mut self.tonic_client(), ClientAction::Generate).await?;
         self.handle_generate(&mut client_channel).await

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -1,7 +1,8 @@
-use crate::{client::ClientAction, DamsClient, DamsClientError};
+use crate::{DamsClient, DamsClientError};
 use dams::{
     crypto::{KeyId, Secret, StorageKey},
     types::retrieve_storage_key::{client, server},
+    ClientAction,
 };
 use serde::{Deserialize, Serialize};
 

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -1,4 +1,4 @@
-use crate::DamsClientError;
+use crate::{DamsClient, DamsClientError};
 use dams::{
     channel::ClientChannel,
     crypto::{KeyId, OpaqueExportKey, StorageKey},
@@ -10,51 +10,49 @@ use rand::{CryptoRng, RngCore};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Channel, Status};
+use crate::client::ClientAction;
 
 mod generate;
 
 #[allow(unused)]
 const SECRET_LENGTH: u32 = 32;
 
-/// Retrieve the [`Encrypted<StorageKey>`] that belongs to the user specified by
-/// `user_id`
-async fn retrieve_storage_key(
-    client: &mut DamsRpcClient<Channel>,
-    export_key: OpaqueExportKey,
-    user_id: &UserId,
-) -> Result<StorageKey, DamsClientError> {
-    // Create channel to send messages to server
-    let (tx, rx) = mpsc::channel(2);
-    let stream = ReceiverStream::new(rx);
+impl DamsClient {
+    /// Retrieve the [`Encrypted<StorageKey>`] that belongs to the user specified by
+    /// `user_id`
+    async fn retrieve_storage_key(
+        &self,
+        client: &mut DamsRpcClient<Channel>,
+        export_key: OpaqueExportKey,
+        user_id: &UserId,
+    ) -> Result<StorageKey, DamsClientError> {
+        // Create channel to send messages to server
+        let mut channel = Self::create_channel(client, ClientAction::RetrieveStorageKey).await?;
 
-    // Server returns its own channel that is uses to send responses
-    let server_receiver = client.retrieve_storage_key(stream).await?.into_inner();
+        // Send UserId to server
+        let request = client::Request {
+            user_id: user_id.clone(),
+        };
+        channel
+            .send(request)
+            .await
+            .map_err(|e| Status::aborted(e.to_string()))?;
 
-    let mut channel = ClientChannel::create(tx, server_receiver);
+        // Get encrypted storage key from server
+        let response: server::Response = channel.receive().await?;
 
-    // Send UserId to server
-    let request = client::Request {
-        user_id: user_id.clone(),
-    };
-    channel
-        .send(request)
-        .await
-        .map_err(|e| Status::aborted(e.to_string()))?;
+        // Decrypt storage_key
+        let storage_key = response.ciphertext.decrypt_storage_key(export_key);
+        Ok(storage_key)
+    }
 
-    // Get encrypted storage key from server
-    let response: server::Response = channel.receive().await?;
-
-    // Decrypt storage_key
-    let storage_key = response.ciphertext.decrypt_storage_key(export_key);
-    Ok(storage_key)
-}
-
-/// Generate and store an arbitrary secret at the key server
-pub async fn generate_and_store<T: CryptoRng + RngCore>(
-    client: &mut DamsRpcClient<Channel>,
-    rng: &mut T,
-    user_id: &UserId,
-    export_key: OpaqueExportKey,
-) -> Result<KeyId, DamsClientError> {
-    generate::handle(client, rng, user_id, export_key).await
+    /// Generate and store an arbitrary secret at the key server
+    pub async fn generate_and_store<T: CryptoRng + RngCore>(
+        &self,
+        client: &mut DamsRpcClient<Channel>,
+        user_id: &UserId,
+        export_key: OpaqueExportKey,
+    ) -> Result<KeyId, DamsClientError> {
+        self.handle_generate(client, user_id, export_key)
+    }
 }

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -30,7 +30,7 @@ impl DamsClient {
         // Decrypt storage_key
         let storage_key = response
             .ciphertext
-            .decrypt_storage_key(self.export_key(), self.user_id())?;
+            .decrypt_storage_key(self.export_key.clone(), self.user_id())?;
         Ok(storage_key)
     }
 

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -11,8 +11,8 @@ mod generate;
 const SECRET_LENGTH: u32 = 32;
 
 impl DamsClient {
-    /// Retrieve the [`Encrypted<StorageKey>`] that belongs to the user
-    /// specified by `user_id`
+    /// Retrieve the [`dams::crypto::Encrypted<StorageKey>`] that belongs to the
+    /// user specified by `user_id`
     async fn retrieve_storage_key(
         &mut self,
         export_key: OpaqueExportKey,

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -1,0 +1,60 @@
+use crate::DamsClientError;
+use dams::{
+    channel::ClientChannel,
+    crypto::{KeyId, OpaqueExportKey, StorageKey},
+    dams_rpc::dams_rpc_client::DamsRpcClient,
+    types::retrieve_storage_key::{client, server},
+    user::UserId,
+};
+use rand::{CryptoRng, RngCore};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{transport::Channel, Status};
+
+mod generate;
+
+#[allow(unused)]
+const SECRET_LENGTH: u32 = 32;
+
+/// Retrieve the [`Encrypted<StorageKey>`] that belongs to the user specified by
+/// `user_id`
+async fn retrieve_storage_key(
+    client: &mut DamsRpcClient<Channel>,
+    export_key: OpaqueExportKey,
+    user_id: &UserId,
+) -> Result<StorageKey, DamsClientError> {
+    // Create channel to send messages to server
+    let (tx, rx) = mpsc::channel(2);
+    let stream = ReceiverStream::new(rx);
+
+    // Server returns its own channel that is uses to send responses
+    let server_receiver = client.retrieve_storage_key(stream).await?.into_inner();
+
+    let mut channel = ClientChannel::create(tx, server_receiver);
+
+    // Send UserId to server
+    let request = client::Request {
+        user_id: user_id.clone(),
+    };
+    channel
+        .send(request)
+        .await
+        .map_err(|e| Status::aborted(e.to_string()))?;
+
+    // Get encrypted storage key from server
+    let response: server::Response = channel.receive().await?;
+
+    // Decrypt storage_key
+    let storage_key = response.ciphertext.decrypt_storage_key(export_key);
+    Ok(storage_key)
+}
+
+/// Generate and store an arbitrary secret at the key server
+pub async fn generate_and_store<T: CryptoRng + RngCore>(
+    client: &mut DamsRpcClient<Channel>,
+    rng: &mut T,
+    user_id: &UserId,
+    export_key: OpaqueExportKey,
+) -> Result<KeyId, DamsClientError> {
+    generate::handle(client, rng, user_id, export_key).await
+}

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -1,6 +1,6 @@
 use crate::{client::ClientAction, DamsClient, DamsClientError};
 use dams::{
-    crypto::{KeyId, OpaqueExportKey, Secret, StorageKey},
+    crypto::{KeyId, Secret, StorageKey},
     types::retrieve_storage_key::{client, server},
     user::UserId,
 };
@@ -15,7 +15,6 @@ impl DamsClient {
     /// user specified by `user_id`
     async fn retrieve_storage_key(
         &mut self,
-        export_key: OpaqueExportKey,
         user_id: &UserId,
     ) -> Result<StorageKey, DamsClientError> {
         // Create channel to send messages to server
@@ -34,7 +33,7 @@ impl DamsClient {
         // Decrypt storage_key
         let storage_key = response
             .ciphertext
-            .decrypt_storage_key(export_key, user_id)?;
+            .decrypt_storage_key(self.export_key.clone(), user_id)?;
         Ok(storage_key)
     }
 
@@ -42,11 +41,9 @@ impl DamsClient {
     pub async fn generate_and_store(
         &mut self,
         user_id: &UserId,
-        export_key: OpaqueExportKey,
     ) -> Result<(KeyId, Secret), DamsClientError> {
         let mut client_channel =
             Self::create_channel(&mut self.tonic_client, ClientAction::Generate).await?;
-        self.handle_generate(&mut client_channel, user_id, export_key)
-            .await
+        self.handle_generate(&mut client_channel, user_id).await
     }
 }

--- a/dams-client/src/api/arbitrary_secrets/generate.rs
+++ b/dams-client/src/api/arbitrary_secrets/generate.rs
@@ -1,4 +1,4 @@
-use crate::{DamsClient, DamsClientError};
+use crate::{client::ClientAction, DamsClient, DamsClientError};
 use dams::{
     channel::ClientChannel,
     crypto::{KeyId, OpaqueExportKey, StorageKey},
@@ -6,36 +6,34 @@ use dams::{
     types::generate::{client, server},
     user::UserId,
 };
-use rand::{CryptoRng, RngCore};
-use tokio::sync::mpsc;
-use tokio_stream::wrappers::ReceiverStream;
-use tonic::{transport::Channel, Status};
-use crate::client::ClientAction;
+use rand::rngs::StdRng;
+use tonic::transport::Channel;
 
 impl DamsClient {
-    pub(crate) async fn handle_generate<T: CryptoRng + RngCore>(
+    pub(crate) async fn handle_generate(
         &self,
         client: &mut DamsRpcClient<Channel>,
         user_id: &UserId,
         export_key: OpaqueExportKey,
     ) -> Result<KeyId, DamsClientError> {
         // Retrieve the storage key
-        let storage_key = self.retrieve_storage_key(client, export_key, user_id).await?;
+        let storage_key = self
+            .retrieve_storage_key(client, export_key, user_id)
+            .await?;
 
         // Create channel to send messages to server
-        let mut channel = Self::create_channel(client, ClientAction::Generate);
+        let mut channel = Self::create_channel(client, ClientAction::Generate).await?;
 
         // Generate step: get new KeyId from server
         let key_id = generate(&mut channel, user_id).await?;
         // Store step: encrypt secret and send to server to store
         {
-            let mut rng = self.rng().lock().await;
-            store(&mut channel, user_id, storage_key, rng, &key_id).await?;
+            let mut rng = self.rng.lock().await;
+            store(&mut channel, user_id, storage_key, &mut rng, &key_id).await?;
         }
 
         Ok(key_id)
     }
-
 }
 
 async fn generate(channel: &mut ClientChannel, user_id: &UserId) -> Result<KeyId, DamsClientError> {
@@ -43,10 +41,7 @@ async fn generate(channel: &mut ClientChannel, user_id: &UserId) -> Result<KeyId
     let generate_message = client::Generate {
         user_id: user_id.clone(),
     };
-    channel
-        .send(generate_message)
-        .await
-        .map_err(|e| Status::aborted(e.to_string()))?;
+    channel.send(generate_message).await?;
 
     // Get KeyId from server
     let generate_result: server::Generate = channel.receive().await?;
@@ -54,18 +49,18 @@ async fn generate(channel: &mut ClientChannel, user_id: &UserId) -> Result<KeyId
     Ok(generate_result.key_id)
 }
 
-async fn store<T: CryptoRng + RngCore>(
+async fn store(
     channel: &mut ClientChannel,
     user_id: &UserId,
     storage_key: StorageKey,
-    rng: &mut T,
+    rng: &mut StdRng,
     key_id: &KeyId,
 ) -> Result<(), DamsClientError> {
     // Generate and encrypt secret
-    let encrypted_secret = storage_key.create_and_encrypt_secret(rng, user_id, key_id);
+    let (_, encrypted) = storage_key.create_and_encrypt_secret(rng, user_id, key_id)?;
     // Serialize and send ciphertext
     let response = client::Store {
-        ciphertext: encrypted_secret,
+        ciphertext: encrypted,
         user_id: user_id.clone(),
     };
     channel.send(response).await?;

--- a/dams-client/src/api/arbitrary_secrets/generate.rs
+++ b/dams-client/src/api/arbitrary_secrets/generate.rs
@@ -1,7 +1,7 @@
 use crate::{DamsClient, DamsClientError};
 use dams::{
     channel::ClientChannel,
-    crypto::{KeyId, OpaqueExportKey, Secret, StorageKey},
+    crypto::{KeyId, Secret, StorageKey},
     types::generate::{client, server},
     user::UserId,
 };
@@ -12,10 +12,9 @@ impl DamsClient {
         &mut self,
         channel: &mut ClientChannel,
         user_id: &UserId,
-        export_key: OpaqueExportKey,
     ) -> Result<(KeyId, Secret), DamsClientError> {
         // Retrieve the storage key
-        let storage_key = self.retrieve_storage_key(export_key, user_id).await?;
+        let storage_key = self.retrieve_storage_key(user_id).await?;
 
         // Generate step: get new KeyId from server
         let key_id = generate(channel, user_id).await?;

--- a/dams-client/src/api/arbitrary_secrets/generate.rs
+++ b/dams-client/src/api/arbitrary_secrets/generate.rs
@@ -16,7 +16,7 @@ impl DamsClient {
         let storage_key = self.retrieve_storage_key().await?;
 
         // Generate step: get new KeyId from server
-        let key_id = generate(channel, self.user_id()).await?;
+        let key_id = get_key_id(channel, self.user_id()).await?;
         // Store step: encrypt secret and send to server to store
         let secret = {
             let rng = self.rng();
@@ -28,7 +28,10 @@ impl DamsClient {
     }
 }
 
-async fn generate(channel: &mut ClientChannel, user_id: &UserId) -> Result<KeyId, DamsClientError> {
+async fn get_key_id(
+    channel: &mut ClientChannel,
+    user_id: &UserId,
+) -> Result<KeyId, DamsClientError> {
     // Send UserId to server
     let generate_message = client::Generate {
         user_id: user_id.clone(),

--- a/dams-client/src/api/arbitrary_secrets/generate.rs
+++ b/dams-client/src/api/arbitrary_secrets/generate.rs
@@ -19,8 +19,7 @@ impl DamsClient {
         let key_id = get_key_id(channel, self.user_id()).await?;
         // Store step: encrypt secret and send to server to store
         let secret = {
-            let rng = self.rng();
-            let mut rng = rng.lock().await;
+            let mut rng = self.rng.lock().await;
             store(channel, self.user_id(), storage_key, &mut rng, &key_id).await?
         };
 

--- a/dams-client/src/api/arbitrary_secrets/generate.rs
+++ b/dams-client/src/api/arbitrary_secrets/generate.rs
@@ -1,7 +1,7 @@
 use crate::DamsClientError;
 use dams::{
     channel::ClientChannel,
-    crypto::{KeyId, StorageKey},
+    crypto::{KeyId, OpaqueExportKey, StorageKey},
     dams_rpc::dams_rpc_client::DamsRpcClient,
     types::generate::{client, server},
     user::UserId,
@@ -11,20 +11,14 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Channel, Status};
 
-const SECRET_LENGTH: u32 = 32;
-
-#[allow(unused)]
-async fn retrieve_storage_key() -> StorageKey {
-    todo!()
-}
-
 pub(crate) async fn handle<T: CryptoRng + RngCore>(
     client: &mut DamsRpcClient<Channel>,
     rng: &mut T,
     user_id: &UserId,
+    export_key: OpaqueExportKey,
 ) -> Result<KeyId, DamsClientError> {
     // Retrieve the storage key
-    let storage_key = retrieve_storage_key().await;
+    let storage_key = super::retrieve_storage_key(client, export_key, user_id).await?;
 
     // Create channel to send messages to server
     let (tx, rx) = mpsc::channel(2);

--- a/dams-client/src/api/arbitrary_secrets/generate.rs
+++ b/dams-client/src/api/arbitrary_secrets/generate.rs
@@ -20,7 +20,7 @@ impl DamsClient {
         // Store step: encrypt secret and send to server to store
         let wrapped_secret = {
             let mut rng = self.rng.lock().await;
-            store(channel, self.user_id(), storage_key, &mut rng, &key_id).await?
+            generate_and_store(channel, self.user_id(), storage_key, &mut rng, &key_id).await?
         };
 
         Ok((key_id, wrapped_secret))
@@ -43,7 +43,7 @@ async fn get_key_id(
     Ok(generate_result.key_id)
 }
 
-async fn store(
+async fn generate_and_store(
     channel: &mut ClientChannel,
     user_id: &UserId,
     storage_key: StorageKey,

--- a/dams-client/src/api/arbitrary_secrets/generate.rs
+++ b/dams-client/src/api/arbitrary_secrets/generate.rs
@@ -9,19 +9,19 @@ use rand::rngs::StdRng;
 
 impl DamsClient {
     pub(crate) async fn handle_generate(
-        &mut self,
+        &self,
         channel: &mut ClientChannel,
-        user_id: &UserId,
     ) -> Result<(KeyId, Secret), DamsClientError> {
         // Retrieve the storage key
-        let storage_key = self.retrieve_storage_key(user_id).await?;
+        let storage_key = self.retrieve_storage_key().await?;
 
         // Generate step: get new KeyId from server
-        let key_id = generate(channel, user_id).await?;
+        let key_id = generate(channel, self.user_id()).await?;
         // Store step: encrypt secret and send to server to store
         let secret = {
-            let mut rng = self.rng.lock().await;
-            store(channel, user_id, storage_key, &mut rng, &key_id).await?
+            let rng = self.rng();
+            let mut rng = rng.lock().await;
+            store(channel, self.user_id(), storage_key, &mut rng, &key_id).await?
         };
 
         Ok((key_id, secret))

--- a/dams-client/src/api/authenticate.rs
+++ b/dams-client/src/api/authenticate.rs
@@ -4,7 +4,7 @@ use crate::DamsClientError;
 use dams::{
     channel::ClientChannel,
     config::opaque::OpaqueCipherSuite,
-    crypto::OpaqueSessionKey,
+    crypto::{OpaqueExportKey, OpaqueSessionKey},
     types::authenticate::{client, server},
     user::{AccountName, UserId},
 };
@@ -19,7 +19,7 @@ impl DamsClient {
         rng: &mut T,
         account_name: &AccountName,
         password: &Password,
-    ) -> Result<(OpaqueSessionKey, UserId), DamsClientError> {
+    ) -> Result<(OpaqueSessionKey, OpaqueExportKey, UserId), DamsClientError> {
         let client_login_start_result =
             ClientLogin::<OpaqueCipherSuite>::start(rng, password.as_bytes())?;
 
@@ -38,11 +38,12 @@ impl DamsClient {
         .await?;
 
         let session_key = client_login_finish_result.session_key.into();
+        let export_key = client_login_finish_result.export_key.into();
 
         // Get user id
         let user_id = retrieve_user_id(&mut channel, &session_key).await?;
 
-        Ok((session_key, user_id))
+        Ok((session_key, export_key, user_id))
     }
 }
 

--- a/dams-client/src/api/authenticate.rs
+++ b/dams-client/src/api/authenticate.rs
@@ -1,10 +1,10 @@
-use crate::client::{DamsClient, Password};
+use crate::client::{AuthenticateResult, DamsClient, Password};
 
 use crate::DamsClientError;
 use dams::{
     channel::ClientChannel,
     config::opaque::OpaqueCipherSuite,
-    crypto::{OpaqueExportKey, OpaqueSessionKey},
+    crypto::OpaqueSessionKey,
     types::authenticate::{client, server},
     user::{AccountName, UserId},
 };
@@ -19,7 +19,7 @@ impl DamsClient {
         rng: &mut T,
         account_name: &AccountName,
         password: &Password,
-    ) -> Result<(OpaqueSessionKey, OpaqueExportKey, UserId), DamsClientError> {
+    ) -> Result<AuthenticateResult, DamsClientError> {
         let client_login_start_result =
             ClientLogin::<OpaqueCipherSuite>::start(rng, password.as_bytes())?;
 
@@ -43,7 +43,11 @@ impl DamsClient {
         // Get user id
         let user_id = retrieve_user_id(&mut channel, &session_key).await?;
 
-        Ok((session_key, export_key, user_id))
+        Ok(AuthenticateResult {
+            session_key,
+            export_key,
+            user_id,
+        })
     }
 }
 

--- a/dams-client/src/api/generate.rs
+++ b/dams-client/src/api/generate.rs
@@ -1,0 +1,87 @@
+use crate::DamsClientError;
+use dams::{
+    channel::ClientChannel,
+    crypto::{KeyId, StorageKey},
+    dams_rpc::dams_rpc_client::DamsRpcClient,
+    types::generate::{client, server},
+    user::UserId,
+};
+use rand::{CryptoRng, RngCore};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{transport::Channel, Status};
+
+const SECRET_LENGTH: u32 = 32;
+
+#[allow(unused)]
+async fn retrieve_storage_key() -> StorageKey {
+    todo!()
+}
+
+pub(crate) async fn handle<T: CryptoRng + RngCore>(
+    client: &mut DamsRpcClient<Channel>,
+    rng: &mut T,
+    user_id: &UserId,
+) -> Result<KeyId, DamsClientError> {
+    // Retrieve the storage key
+    let storage_key = retrieve_storage_key().await;
+
+    // Create channel to send messages to server
+    let (tx, rx) = mpsc::channel(2);
+    let stream = ReceiverStream::new(rx);
+
+    // Server returns its own channel that is uses to send responses
+    let server_receiver = client.generate(stream).await?.into_inner();
+
+    let mut channel = ClientChannel::create(tx, server_receiver);
+
+    // Generate step: get new KeyId from server
+    let key_id = generate(&mut channel, user_id).await?;
+    // Store step: encrypt secret and send to server to store
+    store(&mut channel, user_id, storage_key, rng, &key_id).await?;
+    Ok(key_id)
+}
+
+async fn generate(channel: &mut ClientChannel, user_id: &UserId) -> Result<KeyId, DamsClientError> {
+    // Send UserId to server
+    let generate_message = client::Generate {
+        user_id: user_id.clone(),
+    };
+    channel
+        .send(generate_message)
+        .await
+        .map_err(|e| Status::aborted(e.to_string()))?;
+
+    // Get KeyId from server
+    let generate_result: server::Generate = channel.receive().await?;
+
+    Ok(generate_result.key_id)
+}
+
+async fn store<T: CryptoRng + RngCore>(
+    channel: &mut ClientChannel,
+    user_id: &UserId,
+    storage_key: StorageKey,
+    rng: &mut T,
+    key_id: &KeyId,
+) -> Result<(), DamsClientError> {
+    // Generate and encrypt secret
+    let encrypted_secret = storage_key.create_and_encrypt_secret(rng, user_id, key_id);
+    // Serialize and send ciphertext
+    let response = client::Store {
+        ciphertext: encrypted_secret,
+        user_id: user_id.clone(),
+    };
+    channel.send(response).await?;
+
+    // TODO spec#39 (design, implementation): Store ciphertext in client-side
+    // storage
+
+    // Await Ok from server
+    let result: server::Store = channel.receive().await?;
+    if result.success {
+        Ok(())
+    } else {
+        Err(DamsClientError::ServerReturnedFailure)
+    }
+}

--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -58,8 +58,8 @@ pub struct DamsClient {
     config: Config,
     user_id: UserId,
     tonic_client: DamsRpcClient<DamsRpcClientInner>,
-    rng: Arc<Mutex<StdRng>>,
-    export_key: OpaqueExportKey,
+    pub(crate) rng: Arc<Mutex<StdRng>>,
+    pub(crate) export_key: OpaqueExportKey,
 }
 
 /// Connection type used by `DamsRpcClient`.
@@ -83,16 +83,8 @@ impl DamsClient {
         &self.user_id
     }
 
-    pub fn rng(&self) -> Arc<Mutex<StdRng>> {
-        self.rng.clone()
-    }
-
     pub fn tonic_client(&self) -> DamsRpcClient<DamsRpcClientInner> {
         self.tonic_client.clone()
-    }
-
-    pub fn export_key(&self) -> OpaqueExportKey {
-        self.export_key.clone()
     }
 
     /// Create a `tonic` client object and return it to the client app.

--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -14,11 +14,8 @@ use http_body::combinators::UnsyncBoxBody;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
 use rand::{rngs::StdRng, SeedableRng};
-use std::{
-    str::FromStr,
-    sync::{Arc, Mutex},
-};
-use tokio::sync::mpsc;
+use std::{str::FromStr, sync::Arc};
+use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
 
@@ -60,7 +57,7 @@ pub struct DamsClient {
     session_key: OpaqueSessionKey,
     config: Config,
     tonic_client: DamsRpcClient<DamsRpcClientInner>,
-    rng: Arc<Mutex<StdRng>>,
+    pub(crate) rng: Arc<Mutex<StdRng>>,
     user_id: UserId,
 }
 

--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -57,9 +57,9 @@ pub struct DamsClient {
     session_key: OpaqueSessionKey,
     config: Config,
     user_id: UserId,
-    pub(crate) tonic_client: DamsRpcClient<DamsRpcClientInner>,
-    pub(crate) rng: Arc<Mutex<StdRng>>,
-    pub(crate) export_key: OpaqueExportKey,
+    tonic_client: DamsRpcClient<DamsRpcClientInner>,
+    rng: Arc<Mutex<StdRng>>,
+    export_key: OpaqueExportKey,
 }
 
 /// Connection type used by `DamsRpcClient`.
@@ -75,6 +75,18 @@ impl DamsClient {
     // Get [`UserId`] for the authenticated client.
     pub fn user_id(&self) -> &UserId {
         &self.user_id
+    }
+
+    pub fn rng(&self) -> Arc<Mutex<StdRng>> {
+        self.rng.clone()
+    }
+
+    pub fn tonic_client(&self) -> DamsRpcClient<DamsRpcClientInner> {
+        self.tonic_client.clone()
+    }
+
+    pub fn export_key(&self) -> OpaqueExportKey {
+        self.export_key.clone()
     }
 
     /// Create a `tonic` client object and return it to the client app.
@@ -218,9 +230,5 @@ impl DamsClient {
     /// Outputs: None, if successful.
     pub fn close(self) -> Result<(), DamsClientError> {
         todo!()
-    }
-
-    pub(crate) fn rng(&self) -> Arc<Mutex<StdRng>> {
-        self.rng.clone()
     }
 }

--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -205,6 +205,8 @@ impl DamsClient {
             ClientAction::Register => client.register(stream).await,
             ClientAction::Authenticate => client.authenticate(stream).await,
             ClientAction::CreateStorageKey => client.create_storage_key(stream).await,
+            ClientAction::Generate => client.generate(stream).await,
+            ClientAction::RetrieveStorageKey => client.retrieve_storage_key(stream).await,
         }?
         .into_inner();
 
@@ -217,5 +219,9 @@ impl DamsClient {
     /// Outputs: None, if successful.
     pub fn close(self) -> Result<(), DamsClientError> {
         todo!()
+    }
+
+    pub(crate) fn rng(&self) -> Arc<Mutex<StdRng>> {
+        self.rng.clone()
     }
 }

--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -56,7 +56,7 @@ impl Password {
 pub struct DamsClient {
     session_key: OpaqueSessionKey,
     config: Config,
-    tonic_client: DamsRpcClient<DamsRpcClientInner>,
+    pub(crate) tonic_client: DamsRpcClient<DamsRpcClientInner>,
     pub(crate) rng: Arc<Mutex<StdRng>>,
     user_id: UserId,
 }

--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -70,6 +70,12 @@ type DamsRpcClientInner = hyper::Client<
     UnsyncBoxBody<tonic::codegen::Bytes, tonic::Status>,
 >;
 
+pub(crate) struct AuthenticateResult {
+    pub(crate) session_key: OpaqueSessionKey,
+    pub(crate) export_key: OpaqueExportKey,
+    pub(crate) user_id: UserId,
+}
+
 #[allow(unused)]
 impl DamsClient {
     // Get [`UserId`] for the authenticated client.
@@ -143,7 +149,11 @@ impl DamsClient {
         let result =
             Self::handle_authentication(client_channel, &mut rng, account_name, password).await;
         match result {
-            Ok((session_key, export_key, user_id)) => {
+            Ok(AuthenticateResult {
+                session_key,
+                export_key,
+                user_id,
+            }) => {
                 // TODO #186: receive User ID over authenticated channel (under session_key)
                 let client = DamsClient {
                     session_key,

--- a/dams-key-server/src/command.rs
+++ b/dams-key-server/src/command.rs
@@ -39,7 +39,7 @@ async fn handle_retrieve_storage_key(
         .await?
         .ok_or(DamsServerError::AccountDoesNotExist)?;
     // Send storage key if set
-    let storage_key = user.storage_key.ok_or(DamsServerError::StorageNotSet)?;
+    let storage_key = user.storage_key.ok_or(DamsServerError::StorageKeyNotSet)?;
     let reply = server::Response {
         ciphertext: storage_key,
     };

--- a/dams-key-server/src/command.rs
+++ b/dams-key-server/src/command.rs
@@ -3,27 +3,47 @@ pub mod create_storage_key;
 pub mod generate;
 pub mod register;
 
-use crate::{server::Context, DamsServerError};
+use crate::{database::user as User, server::Context, DamsServerError};
 use dams::{
     channel::ServerChannel,
-    types::{retrieve_storage_key::client, Message, MessageStream},
+    types::{
+        retrieve_storage_key::{client, server},
+        Message, MessageStream,
+    },
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response};
 
 pub async fn retrieve_storage_key(
     request: Request<tonic::Streaming<Message>>,
-    _context: Context,
+    context: Context,
 ) -> Result<Response<MessageStream>, DamsServerError> {
     let (mut channel, rx) = ServerChannel::create(request.into_inner());
 
     let _ = tokio::spawn(async move {
         // Receive user ID and retrieve encrypted storage key for that user
-        let _request: client::Request = channel.receive().await?;
-        // TODO #133 (implementation): get and return storage key from DB once flow has
-        // been decided
+        handle_retrieve_storage_key(&mut channel, &context).await?;
         Ok::<(), DamsServerError>(())
     });
 
     Ok(Response::new(ReceiverStream::new(rx)))
+}
+
+async fn handle_retrieve_storage_key(
+    channel: &mut ServerChannel,
+    context: &Context,
+) -> Result<(), DamsServerError> {
+    let request: client::Request = channel.receive().await?;
+    // Find user by ID
+    let user = User::find_user_by_id(&context.db, &request.user_id)
+        .await?
+        .ok_or(DamsServerError::AccountDoesNotExist)?;
+    // Send storage key if set
+    let storage_key = user.storage_key.ok_or(DamsServerError::StorageNotSet)?;
+    let reply = server::Response {
+        ciphertext: storage_key,
+    };
+    channel.send(reply).await?;
+
+    Ok(())
 }

--- a/dams-key-server/src/command.rs
+++ b/dams-key-server/src/command.rs
@@ -1,3 +1,4 @@
 pub mod authenticate;
 pub mod create_storage_key;
+pub mod generate;
 pub mod register;

--- a/dams-key-server/src/command.rs
+++ b/dams-key-server/src/command.rs
@@ -2,3 +2,28 @@ pub mod authenticate;
 pub mod create_storage_key;
 pub mod generate;
 pub mod register;
+
+use crate::{server::Context, DamsServerError};
+use dams::{
+    channel::ServerChannel,
+    types::{retrieve_storage_key::client, Message, MessageStream},
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response};
+
+pub async fn retrieve_storage_key(
+    request: Request<tonic::Streaming<Message>>,
+    _context: Context,
+) -> Result<Response<MessageStream>, DamsServerError> {
+    let (mut channel, rx) = ServerChannel::create(request.into_inner());
+
+    let _ = tokio::spawn(async move {
+        // Receive user ID and retrieve encrypted storage key for that user
+        let _request: client::Request = channel.receive().await?;
+        // TODO #133 (implementation): get and return storage key from DB once flow has
+        // been decided
+        Ok::<(), DamsServerError>(())
+    });
+
+    Ok(Response::new(ReceiverStream::new(rx)))
+}

--- a/dams-key-server/src/command/generate.rs
+++ b/dams-key-server/src/command/generate.rs
@@ -59,7 +59,7 @@ async fn store(
     context: &Context,
     key_id: KeyId,
 ) -> Result<(), DamsServerError> {
-    // Receive UserId from client
+    // Receive Encrypted<Secret> from client
     let store_message: client::Store = channel.receive().await?;
 
     // Check validity of ciphertext and store in DB

--- a/dams-key-server/src/command/generate.rs
+++ b/dams-key-server/src/command/generate.rs
@@ -1,0 +1,81 @@
+use crate::{database::user as User, server::Context, DamsServerError};
+
+use dams::{
+    channel::ServerChannel,
+    crypto::KeyId,
+    types::{
+        generate::{client, server},
+        Message, MessageStream,
+    },
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+#[derive(Debug)]
+pub struct Generate;
+
+impl Generate {
+    pub async fn run<'a>(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+        context: Context,
+    ) -> Result<Response<MessageStream>, DamsServerError> {
+        let (mut channel, rx) = ServerChannel::create(request.into_inner());
+
+        let _ = tokio::spawn(async move {
+            // Generate step: receive UserId and reply with new KeyId
+            let key_id = generate(&mut channel, &context).await?;
+            // Store step: receive ciphertext from client and store in DB
+            store(&mut channel, &context, key_id).await?;
+
+            Ok::<(), Status>(())
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+async fn generate(
+    channel: &mut ServerChannel,
+    context: &Context,
+) -> Result<KeyId, DamsServerError> {
+    // Receive UserId from client
+    let generate_message: client::Generate = channel.receive().await?;
+    // Generate new KeyId
+    let key_id = {
+        let mut rng = context.rng.lock().await;
+        KeyId::generate(&mut *rng, generate_message.user_id)
+    };
+    // Serialize KeyId and send to client
+    let reply = server::Generate {
+        key_id: key_id.clone(),
+    };
+    channel.send(reply).await?;
+    Ok(key_id)
+}
+
+async fn store(
+    channel: &mut ServerChannel,
+    context: &Context,
+    key_id: KeyId,
+) -> Result<(), DamsServerError> {
+    // Receive UserId from client
+    let store_message: client::Store = channel.receive().await?;
+
+    // Check validity of ciphertext and store in DB
+    User::add_user_secret(
+        &context.db,
+        &store_message.user_id,
+        store_message.ciphertext,
+        key_id,
+    )
+    .await?;
+
+    // Reply with the success:true if successful
+    let reply = server::Store { success: true };
+    channel.send(reply).await?;
+
+    // TODO #67 (implementation): Log that a new key was generated and stored
+
+    Ok(())
+}

--- a/dams-key-server/src/command/generate.rs
+++ b/dams-key-server/src/command/generate.rs
@@ -9,7 +9,7 @@ use dams::{
     },
 };
 use tokio_stream::wrappers::ReceiverStream;
-use tonic::{Request, Response, Status};
+use tonic::{Request, Response};
 
 #[derive(Debug)]
 pub struct Generate;
@@ -28,7 +28,7 @@ impl Generate {
             // Store step: receive ciphertext from client and store in DB
             store(&mut channel, &context, key_id).await?;
 
-            Ok::<(), Status>(())
+            Ok::<(), DamsServerError>(())
         });
 
         Ok(Response::new(ReceiverStream::new(rx)))

--- a/dams-key-server/src/command/generate.rs
+++ b/dams-key-server/src/command/generate.rs
@@ -44,7 +44,7 @@ async fn generate(
     // Generate new KeyId
     let key_id = {
         let mut rng = context.rng.lock().await;
-        KeyId::generate(&mut *rng, generate_message.user_id)
+        KeyId::generate(&mut *rng, &generate_message.user_id)?
     };
     // Serialize KeyId and send to client
     let reply = server::Generate {

--- a/dams-key-server/src/database/user.rs
+++ b/dams-key-server/src/database/user.rs
@@ -14,7 +14,6 @@ use mongodb::{
     Database,
 };
 use opaque_ke::ServerRegistration;
-use tonic::Status;
 
 pub const ACCOUNT_NAME: &str = "account_name";
 pub const STORAGE_KEY: &str = "storage_key";

--- a/dams-key-server/src/database/user.rs
+++ b/dams-key-server/src/database/user.rs
@@ -81,14 +81,13 @@ pub async fn add_user_secret(
     user_id: &UserId,
     secret: Encrypted<Secret>,
     key_id: KeyId,
-) -> Result<(), Status> {
+) -> Result<(), DamsServerError> {
     let collection = db.collection::<User>(constants::USERS);
     let query = doc! { USER_ID: user_id.to_string() };
     let mut user = collection
         .find_one(query, None)
-        .await
-        .map_err(|_| Status::aborted("MongoDB error in add_user_secret()"))?
-        .ok_or_else(|| Status::aborted("User not found"))?;
+        .await?
+        .ok_or(DamsServerError::AccountDoesNotExist)?;
     let stored_secret = StoredSecret::new(secret, key_id);
     user.add_secret(stored_secret);
     Ok(())

--- a/dams-key-server/src/error.rs
+++ b/dams-key-server/src/error.rs
@@ -18,6 +18,8 @@ pub enum DamsServerError {
     InvalidUserId,
     #[error("Storage key is already set")]
     StorageKeyAlreadySet,
+    #[error("Storage key is not set for this user")]
+    StorageNotSet,
 
     // Wrapped errors
     #[error(transparent)]

--- a/dams-key-server/src/error.rs
+++ b/dams-key-server/src/error.rs
@@ -19,7 +19,7 @@ pub enum DamsServerError {
     #[error("Storage key is already set")]
     StorageKeyAlreadySet,
     #[error("Storage key is not set for this user")]
-    StorageNotSet,
+    StorageKeyNotSet,
 
     // Wrapped errors
     #[error(transparent)]

--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -105,7 +105,7 @@ impl DamsRpc for DamsKeyServer {
     async fn retrieve_storage_key(
         &self,
         request: Request<tonic::Streaming<Message>>,
-    ) -> Result<Response<Self::GenerateStream>, Status> {
+    ) -> Result<Response<Self::RetrieveStorageKeyStream>, Status> {
         Ok(command::retrieve_storage_key(request, self.context()).await?)
     }
 }

--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -64,6 +64,7 @@ impl DamsRpc for DamsKeyServer {
     type AuthenticateStream = dams::types::MessageStream;
     type CreateStorageKeyStream = dams::types::MessageStream;
     type GenerateStream = dams::types::MessageStream;
+    type RetrieveStorageKeyStream = dams::types::MessageStream;
 
     async fn register(
         &self,
@@ -99,6 +100,13 @@ impl DamsRpc for DamsKeyServer {
         Ok(command::generate::Generate
             .run(request, self.context())
             .await?)
+    }
+
+    async fn retrieve_storage_key(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+    ) -> Result<Response<Self::GenerateStream>, Status> {
+        Ok(command::retrieve_storage_key(request, self.context()).await?)
     }
 }
 

--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -63,6 +63,7 @@ impl DamsRpc for DamsKeyServer {
     type RegisterStream = dams::types::MessageStream;
     type AuthenticateStream = dams::types::MessageStream;
     type CreateStorageKeyStream = dams::types::MessageStream;
+    type GenerateStream = dams::types::MessageStream;
 
     async fn register(
         &self,
@@ -87,6 +88,15 @@ impl DamsRpc for DamsKeyServer {
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::CreateStorageKeyStream>, Status> {
         Ok(command::create_storage_key::CreateStorageKey
+               .run(request, self.context())
+               .await?)
+    }
+
+    async fn generate(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+    ) -> Result<Response<Self::GenerateStream>, Status> {
+        Ok(command::generate::Generate
             .run(request, self.context())
             .await?)
     }

--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -89,8 +89,8 @@ impl DamsRpc for DamsKeyServer {
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::CreateStorageKeyStream>, Status> {
         Ok(command::create_storage_key::CreateStorageKey
-               .run(request, self.context())
-               .await?)
+            .run(request, self.context())
+            .await?)
     }
 
     async fn generate(

--- a/dams-tests/tests/main.rs
+++ b/dams-tests/tests/main.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use common::{get_logs, LogType, Party};
 
+use crate::Operation::Generate;
 use dams::{config::client::Config, user::AccountName};
 use dams_client::{client::Password, DamsClient, DamsClientError};
 use dams_key_server::database;
@@ -75,6 +76,31 @@ pub async fn integration_tests() {
 /// processes (server).
 async fn tests() -> Vec<Test> {
     vec![
+        Test {
+            name: "Generate a secret".to_string(),
+            operations: vec![
+                (
+                    Register(
+                        AccountName::from_str("generate").unwrap(),
+                        Password::from_str("generatePassword").unwrap(),
+                    ),
+                    Outcome {
+                        error: None,
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Generate(
+                        AccountName::from_str("generate").unwrap(),
+                        Password::from_str("generatePassword").unwrap(),
+                    ),
+                    Outcome {
+                        error: None,
+                        expected_error: None,
+                    },
+                ),
+            ],
+        },
         Test {
             name: "Register the same user twice user".to_string(),
             operations: vec![
@@ -198,6 +224,15 @@ impl Test {
                         .map(|_| ())
                         .map_err(|e| e.into())
                 }
+                Generate(account_name, password) => {
+                    let dams_client =
+                        DamsClient::authenticated_client(account_name, password, config).await?;
+                    dams_client
+                        .generate_and_store()
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| e.into())
+                }
             };
 
             // Get error logs for each party - we make the following assumptions:
@@ -260,6 +295,7 @@ enum TestError {
 enum Operation {
     Register(AccountName, Password),
     Authenticate(AccountName, Password),
+    Generate(AccountName, Password),
 }
 
 #[derive(Debug)]

--- a/dams/proto/dams_rpc.proto
+++ b/dams/proto/dams_rpc.proto
@@ -5,6 +5,7 @@ service DamsRpc {
   rpc Register (stream Message) returns (stream Message);
   rpc Authenticate (stream Message) returns (stream Message);
   rpc CreateStorageKey (stream Message) returns (stream Message);
+  rpc Generate (stream Message) returns (stream Message);
 }
 
 message Message {

--- a/dams/proto/dams_rpc.proto
+++ b/dams/proto/dams_rpc.proto
@@ -6,6 +6,7 @@ service DamsRpc {
   rpc Authenticate (stream Message) returns (stream Message);
   rpc CreateStorageKey (stream Message) returns (stream Message);
   rpc Generate (stream Message) returns (stream Message);
+  rpc RetrieveStorageKey (stream Message) returns (stream Message);
 }
 
 message Message {

--- a/dams/src/lib.rs
+++ b/dams/src/lib.rs
@@ -41,6 +41,8 @@ pub enum ClientAction {
     Register,
     Authenticate,
     CreateStorageKey,
+    Generate,
+    RetrieveStorageKey,
 }
 
 /// Logs used to verify that an operation completed in the integration tests.

--- a/dams/src/types.rs
+++ b/dams/src/types.rs
@@ -2,6 +2,7 @@ pub mod authenticate;
 pub mod create_storage_key;
 pub mod generate;
 pub mod register;
+pub mod retrieve_storage_key;
 
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Status;

--- a/dams/src/types.rs
+++ b/dams/src/types.rs
@@ -1,5 +1,6 @@
 pub mod authenticate;
 pub mod create_storage_key;
+pub mod generate;
 pub mod register;
 
 use tokio_stream::wrappers::ReceiverStream;

--- a/dams/src/types/authenticate.rs
+++ b/dams/src/types/authenticate.rs
@@ -26,7 +26,7 @@ pub mod server {
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
-    /// Check if user exists and return successful if not.
+    /// Check if user exists and return OPAQUE message if so
     pub struct AuthenticateStart {
         pub credential_response: CredentialResponse<OpaqueCipherSuite>,
     }

--- a/dams/src/types/generate.rs
+++ b/dams/src/types/generate.rs
@@ -1,0 +1,42 @@
+pub mod client {
+    use crate::{
+        crypto::{Encrypted, Secret},
+        impl_message_conversion,
+        user::UserId,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// pass user ID to server
+    pub struct Generate {
+        pub user_id: UserId,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// pass user ID and encrypted secret
+    pub struct Store {
+        pub ciphertext: Encrypted<Secret>,
+        pub user_id: UserId,
+    }
+
+    impl_message_conversion!(Generate, Store);
+}
+
+pub mod server {
+    use crate::{crypto::KeyId, impl_message_conversion};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// return new requested key ID
+    pub struct Generate {
+        pub key_id: KeyId,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// Return true if successful
+    pub struct Store {
+        pub success: bool,
+    }
+
+    impl_message_conversion!(Generate, Store);
+}

--- a/dams/src/types/retrieve_storage_key.rs
+++ b/dams/src/types/retrieve_storage_key.rs
@@ -1,0 +1,28 @@
+pub mod client {
+    use crate::{impl_message_conversion, user::UserId};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// pass user ID to server
+    pub struct Request {
+        pub user_id: UserId,
+    }
+
+    impl_message_conversion!(Request);
+}
+
+pub mod server {
+    use crate::{
+        crypto::{Encrypted, StorageKey},
+        impl_message_conversion,
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// return encrypted storage key
+    pub struct Response {
+        pub ciphertext: Encrypted<StorageKey>,
+    }
+
+    impl_message_conversion!(Response);
+}

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -128,10 +128,6 @@ impl User {
     pub fn into_parts(self) -> (ServerRegistration<OpaqueCipherSuite>, UserId) {
         (self.server_registration, self.user_id)
     }
-
-    pub fn add_secret(&mut self, secret: StoredSecret) {
-        self.secrets.push(secret);
-    }
 }
 
 /// Abstraction to wrap around [`UserId`] and [`AccountName`] as user

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     config::opaque::OpaqueCipherSuite,
-    crypto::{CryptoError, Encrypted, Secret, StorageKey},
+    crypto::{CryptoError, Encrypted, KeyId, Secret, StorageKey},
     DamsError,
 };
 
@@ -86,6 +86,19 @@ impl AccountName {
     }
 }
 
+/// Wrapper around an [`Encrypted<Secret>`] and its [`KeyId`]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct StoredSecret {
+    secret: Encrypted<Secret>,
+    key_id: KeyId,
+}
+
+impl StoredSecret {
+    pub fn new(secret: Encrypted<Secret>, key_id: KeyId) -> Self {
+        Self { secret, key_id }
+    }
+}
+
 /// One user with a set of arbitrary secrets and a [`ServerRegistration`] to
 /// authenticate with.
 #[derive(Debug, Deserialize, Serialize)]
@@ -93,7 +106,7 @@ pub struct User {
     pub user_id: UserId,
     pub account_name: AccountName,
     pub storage_key: Option<Encrypted<StorageKey>>,
-    pub secrets: Vec<Secret>,
+    pub secrets: Vec<StoredSecret>,
     pub server_registration: ServerRegistration<OpaqueCipherSuite>,
 }
 
@@ -114,6 +127,10 @@ impl User {
 
     pub fn into_parts(self) -> (ServerRegistration<OpaqueCipherSuite>, UserId) {
         (self.server_registration, self.user_id)
+    }
+
+    pub fn add_secret(&mut self, secret: StoredSecret) {
+        self.secrets.push(secret);
     }
 }
 


### PR DESCRIPTION
Closes #136 

I'm making this draft PR to make it easier to ask questions. This is still missing a few changes from #154, so I'll have to rebase with that once it's merged before I mark this ready for review.

I had the following questions:
- A couple of questions about the crypto module that I'd like @marsella's opinion on:
    - `Secret`, `Secret::generate()`, and `StorageKey::encrypt()` all had to be made public for me to use them in the client. Is that okay or were you envisioning using these in a different way?
    - Is it okay that I added `Clone` to `KeyId`?
    - In the `retrieve_storage_key` step, I need an export key - is this supposed to be part of the client state? (right now I'm passing it as a parameter, but that is just to have something that compiles)
    - Also for `retrieve_storage_key`: not really a question, but I need to store the user's `Encrypted<StorageKey>` in the DB as part of a User record, and I can't do that without the rest of register/auth (or wherever the storage key is first generated) being done. 
- Some general/Rust questions:
    - Is making the client wrapper object (or whatever holds client state) going to be part of #154 or should I do it here?
    - Is it bad practice to have multiple nested modules like I made in the local client API? I wanted to separate the arbitrary secrets functionality from the other API function stubs.
    - I see a `BUFFER_SIZE` constant in the `dams` crate but we still have to specify the size when we make mpsc channels to pass to `Channel::create()`. Can I move that somewhere else or make the `BUFFER_SIZE` constant public?