### PR TITLE
Message fields now use concrete types #168

### DIFF
--- a/dams-key-server/src/command.rs
+++ b/dams-key-server/src/command.rs
@@ -1,13 +1,2 @@
-use dams::user::UserId;
-use std::str::FromStr;
-use tonic::Status;
-
 pub mod authenticate;
 pub mod register;
-
-pub(crate) fn user_id_from_message(message: &[u8]) -> Result<UserId, Status> {
-    UserId::from_str(
-        std::str::from_utf8(message).map_err(|_| Status::aborted("Unable to convert to UserID"))?,
-    )
-    .map_err(|_| Status::aborted("Unable to convert to UserID"))
-}

--- a/dams/src/lib.rs
+++ b/dams/src/lib.rs
@@ -10,9 +10,7 @@
 #![warn(unused)]
 #![forbid(rustdoc::broken_intra_doc_links)]
 
-use serde::{Deserialize, Serialize};
 use std::fmt;
-use tonic::Status;
 
 pub mod blockchain;
 pub mod channel;
@@ -48,18 +46,6 @@ impl fmt::Display for TestLogs {
             }
         )
     }
-}
-
-pub fn deserialize_from_bytes<'a, T: Deserialize<'a>>(message: &'a [u8]) -> Result<T, Status> {
-    let deserialized: T = bincode::deserialize(message)
-        .map_err(|_| Status::aborted("Unable to deserialize message"))?;
-    Ok(deserialized)
-}
-
-pub fn serialize_to_bytes<T: Serialize>(message: &T) -> Result<Vec<u8>, Status> {
-    let serialized: Vec<u8> =
-        bincode::serialize(message).map_err(|_| Status::aborted("Unable to serialize message"))?;
-    Ok(serialized)
 }
 
 /// Generates `TryFrom` implementations to and from the `Message` type for a

--- a/dams/src/types/authenticate.rs
+++ b/dams/src/types/authenticate.rs
@@ -1,32 +1,34 @@
 pub mod client {
-    use crate::impl_message_conversion;
+    use crate::{config::opaque::OpaqueCipherSuite, impl_message_conversion, user::UserId};
+    use opaque_ke::{CredentialFinalization, CredentialRequest};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
     /// pass user ID and registration-start message from OPAQUE
     pub struct AuthenticateStart {
-        pub message: Vec<u8>,
-        pub user_id: Vec<u8>,
+        pub credential_request: CredentialRequest<OpaqueCipherSuite>,
+        pub user_id: UserId,
     }
 
     #[derive(Debug, Deserialize, Serialize)]
     /// pass user ID and registration-finish message from OPAQUE
     pub struct AuthenticateFinish {
-        pub message: Vec<u8>,
-        pub user_id: Vec<u8>,
+        pub credential_finalization: CredentialFinalization<OpaqueCipherSuite>,
+        pub user_id: UserId,
     }
 
     impl_message_conversion!(AuthenticateStart, AuthenticateFinish);
 }
 
 pub mod server {
-    use crate::impl_message_conversion;
+    use crate::{config::opaque::OpaqueCipherSuite, impl_message_conversion};
+    use opaque_ke::CredentialResponse;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
     /// Check if user exists and return successful if not
     pub struct AuthenticateStart {
-        pub message: Vec<u8>,
+        pub credential_response: CredentialResponse<OpaqueCipherSuite>,
     }
 
     #[derive(Debug, Deserialize, Serialize)]

--- a/dams/src/types/register.rs
+++ b/dams/src/types/register.rs
@@ -1,32 +1,34 @@
 pub mod client {
-    use crate::impl_message_conversion;
+    use crate::{config::opaque::OpaqueCipherSuite, impl_message_conversion, user::UserId};
+    use opaque_ke::{RegistrationRequest, RegistrationUpload};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
     /// pass user ID and registration-start message from OPAQUE
     pub struct RegisterStart {
-        pub message: Vec<u8>,
-        pub user_id: Vec<u8>,
+        pub registration_request: RegistrationRequest<OpaqueCipherSuite>,
+        pub user_id: UserId,
     }
 
     #[derive(Debug, Deserialize, Serialize)]
     /// pass user ID and registration-finish message from OPAQUE
     pub struct RegisterFinish {
-        pub message: Vec<u8>,
-        pub user_id: Vec<u8>,
+        pub registration_upload: RegistrationUpload<OpaqueCipherSuite>,
+        pub user_id: UserId,
     }
 
     impl_message_conversion!(RegisterStart, RegisterFinish);
 }
 
 pub mod server {
-    use crate::impl_message_conversion;
+    use crate::{config::opaque::OpaqueCipherSuite, impl_message_conversion};
+    use opaque_ke::RegistrationResponse;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
     /// Check if user exists and return successful if not
     pub struct RegisterStart {
-        pub message: Vec<u8>,
+        pub registration_response: RegistrationResponse<OpaqueCipherSuite>,
     }
 
     #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This PR removes a layer of `bincode` serialization/deserialization and changes the fields within each message type to be a concrete type rather than raw bytes. 

Closes #168 