### PR TITLE
Finish Registration protocol #125

### DIFF
--- a/dams-client/src/api.rs
+++ b/dams-client/src/api.rs
@@ -6,6 +6,7 @@
 //! sent to a separate machine.
 
 pub(crate) mod authenticate;
+pub(crate) mod create_storage_key;
 pub(crate) mod register;
 
 use crate::error::DamsClientError;

--- a/dams-client/src/api/create_storage_key.rs
+++ b/dams-client/src/api/create_storage_key.rs
@@ -1,0 +1,60 @@
+use crate::{client::DamsClient, DamsClientError};
+use dams::{
+    channel::ClientChannel,
+    crypto::OpaqueExportKey,
+    types::create_storage_key::{client, server},
+    user::{AccountName, UserId},
+};
+use rand::{CryptoRng, RngCore};
+
+impl DamsClient {
+    /// Creates a storage key and sends it to the key server
+    pub(crate) async fn handle_create_storage_key<T: CryptoRng + RngCore>(
+        mut channel: ClientChannel,
+        rng: &mut T,
+        account_name: &AccountName,
+        export_key: OpaqueExportKey,
+    ) -> Result<(), DamsClientError> {
+        let user_id = request_user_id(&mut channel, account_name).await?;
+        create_and_send_storage_key(&mut channel, rng, user_id, export_key).await?;
+
+        Ok(())
+    }
+}
+
+async fn request_user_id(
+    channel: &mut ClientChannel,
+    account_name: &AccountName,
+) -> Result<UserId, DamsClientError> {
+    let response = client::RequestUserId {
+        account_name: account_name.clone(),
+    };
+
+    channel.send(response).await?;
+    let request_user_id_result: server::SendUserId = channel.receive().await?;
+
+    Ok(request_user_id_result.user_id)
+}
+
+async fn create_and_send_storage_key<T: CryptoRng + RngCore>(
+    channel: &mut ClientChannel,
+    rng: &mut T,
+    user_id: UserId,
+    export_key: OpaqueExportKey,
+) -> Result<(), DamsClientError> {
+    let storage_key = export_key.create_and_encrypt_storage_key(rng, &user_id)?;
+
+    let response = client::SendStorageKey {
+        user_id,
+        storage_key,
+    };
+    channel.send(response).await?;
+
+    let result: server::CreateStorageKeyResult = channel.receive().await?;
+
+    if result.success {
+        Ok(())
+    } else {
+        Err(DamsClientError::ServerReturnedFailure)
+    }
+}

--- a/dams-client/src/error.rs
+++ b/dams-client/src/error.rs
@@ -17,6 +17,8 @@ pub enum DamsClientError {
     #[error(transparent)]
     Dams(#[from] dams::DamsError),
     #[error(transparent)]
+    DamsCrypto(#[from] dams::crypto::CryptoError),
+    #[error(transparent)]
     DamsChannel(#[from] dams::channel::ChannelError),
     #[error("OPAQUE protocol error: {}", .0)]
     OpaqueProtocol(opaque_ke::errors::ProtocolError),

--- a/dams-key-server/Cargo.toml
+++ b/dams-key-server/Cargo.toml
@@ -33,3 +33,6 @@ tower = "0.4"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+generic-array = "0.14"

--- a/dams-key-server/src/command.rs
+++ b/dams-key-server/src/command.rs
@@ -1,2 +1,3 @@
 pub mod authenticate;
+pub mod create_storage_key;
 pub mod register;

--- a/dams-key-server/src/command/authenticate.rs
+++ b/dams-key-server/src/command/authenticate.rs
@@ -1,4 +1,4 @@
-use crate::{database::user as User, error::DamsServerError, server::Context};
+use crate::{database::user::find_user, error::DamsServerError, server::Context};
 
 use dams::{
     channel::ServerChannel,
@@ -54,7 +54,7 @@ async fn authenticate_start(
     // Check that user with corresponding UserId exists and get their
     // server_registration
     let (server_registration, user_id) =
-        match User::find_user(&context.db, &start_message.account_name).await? {
+        match find_user(&context.db, &start_message.account_name).await? {
             Some(user) => user.into_parts(),
             None => return Err(DamsServerError::AccountDoesNotExist),
         };

--- a/dams-key-server/src/command/create_storage_key.rs
+++ b/dams-key-server/src/command/create_storage_key.rs
@@ -1,0 +1,81 @@
+use crate::{
+    database::user::{find_user, set_storage_key},
+    error::DamsServerError,
+    server::Context,
+};
+
+use dams::{
+    channel::ServerChannel,
+    types::{
+        create_storage_key::{client, server},
+        Message, MessageStream,
+    },
+    user::UserId,
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response};
+
+#[derive(Debug)]
+pub struct CreateStorageKey;
+
+impl CreateStorageKey {
+    pub async fn run<'a>(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+        context: Context,
+    ) -> Result<Response<MessageStream>, DamsServerError> {
+        let (mut channel, rx) = ServerChannel::create(request.into_inner());
+
+        let _ = tokio::spawn(async move {
+            let user_id = send_user_id(&mut channel, &context).await?;
+            store_storage_key(user_id, &mut channel, &context).await?;
+
+            Ok::<(), DamsServerError>(())
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+async fn send_user_id(
+    channel: &mut ServerChannel,
+    context: &Context,
+) -> Result<UserId, DamsServerError> {
+    let request: client::RequestUserId = channel.receive().await?;
+    let user = find_user(&context.db, &request.account_name).await?;
+
+    if let Some(user) = user {
+        if user.storage_key.is_some() {
+            return Err(DamsServerError::StorageKeyAlreadySet);
+        }
+
+        let reply = server::SendUserId {
+            user_id: user.user_id.clone(),
+        };
+
+        channel.send(reply).await?;
+
+        Ok(user.user_id)
+    } else {
+        Err(DamsServerError::AccountDoesNotExist)
+    }
+}
+
+async fn store_storage_key(
+    user_id: UserId,
+    channel: &mut ServerChannel,
+    context: &Context,
+) -> Result<(), DamsServerError> {
+    let client_message: client::SendStorageKey = channel.receive().await?;
+
+    if client_message.user_id != user_id {
+        return Err(DamsServerError::InvalidUserId);
+    }
+
+    set_storage_key(&context.db, &user_id, client_message.storage_key).await?;
+
+    let reply = server::CreateStorageKeyResult { success: true };
+    channel.send(reply).await?;
+
+    Ok(())
+}

--- a/dams-key-server/src/command/register.rs
+++ b/dams-key-server/src/command/register.rs
@@ -55,7 +55,7 @@ async fn register_start(
     let user = User::find_user(&context.db, &start_message.account_name).await?;
 
     if user.is_some() {
-        Err(DamsServerError::AccountAlreadyExists)
+        Err(DamsServerError::InvalidUserId)
     } else {
         // Registration can continue if user ID doesn't exist yet
         let server_registration_start_result = ServerRegistration::<OpaqueCipherSuite>::start(

--- a/dams-key-server/src/error.rs
+++ b/dams-key-server/src/error.rs
@@ -7,10 +7,12 @@ pub enum DamsServerError {
     MissingService,
 
     // Protocol errors
-    #[error("Account already exists")]
-    AccountAlreadyExists,
     #[error("Account does not exist")]
     AccountDoesNotExist,
+    #[error("Invalid user_id")]
+    InvalidUserId,
+    #[error("Storage key is already set")]
+    StorageKeyAlreadySet,
 
     // Wrapped errors
     #[error(transparent)]
@@ -18,9 +20,11 @@ pub enum DamsServerError {
     #[error(transparent)]
     DamsChannel(#[from] dams::channel::ChannelError),
     #[error(transparent)]
-    Hyoer(#[from] hyper::Error),
+    Hyper(#[from] hyper::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Bson(#[from] mongodb::bson::ser::Error),
     #[error("OPAQUE protocol error: {}", .0)]
     OpaqueProtocol(opaque_ke::errors::ProtocolError),
     #[error(transparent)]

--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -62,6 +62,7 @@ pub struct Context {
 impl DamsRpc for DamsKeyServer {
     type RegisterStream = dams::types::MessageStream;
     type AuthenticateStream = dams::types::MessageStream;
+    type CreateStorageKeyStream = dams::types::MessageStream;
 
     async fn register(
         &self,
@@ -77,6 +78,15 @@ impl DamsRpc for DamsKeyServer {
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::AuthenticateStream>, Status> {
         Ok(command::authenticate::Authenticate
+            .run(request, self.context())
+            .await?)
+    }
+
+    async fn create_storage_key(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+    ) -> Result<Response<Self::CreateStorageKeyStream>, Status> {
+        Ok(command::create_storage_key::CreateStorageKey
             .run(request, self.context())
             .await?)
     }

--- a/dams/Cargo.toml
+++ b/dams/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 argon2 = "0.4"
 async-trait = "0.1"
 bincode = "1"
+bson = { version = "2", features = ["uuid-1"] }
 bytes = { version = "1", features = ["serde"] }
 chacha20poly1305 = "0.10"
 directories = "3"

--- a/dams/proto/dams_rpc.proto
+++ b/dams/proto/dams_rpc.proto
@@ -4,6 +4,7 @@ package dams_rpc;
 service DamsRpc {
   rpc Register (stream Message) returns (stream Message);
   rpc Authenticate (stream Message) returns (stream Message);
+  rpc CreateStorageKey (stream Message) returns (stream Message);
 }
 
 message Message {

--- a/dams/src/types.rs
+++ b/dams/src/types.rs
@@ -1,8 +1,9 @@
+pub mod authenticate;
+pub mod create_storage_key;
+pub mod register;
+
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Status;
-
-pub mod authenticate;
-pub mod register;
 
 pub use crate::dams_rpc::Message;
 

--- a/dams/src/types/create_storage_key.rs
+++ b/dams/src/types/create_storage_key.rs
@@ -1,0 +1,41 @@
+pub mod client {
+    use crate::{
+        crypto::{Encrypted, StorageKey},
+        impl_message_conversion,
+        user::{AccountName, UserId},
+    };
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct RequestUserId {
+        pub account_name: AccountName,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct SendStorageKey {
+        pub user_id: UserId,
+        pub storage_key: Encrypted<StorageKey>,
+    }
+
+    // TODO #186: These messages need to be authenticated
+    impl_message_conversion!(RequestUserId, SendStorageKey);
+}
+
+pub mod server {
+    use crate::{impl_message_conversion, user::UserId};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct SendUserId {
+        pub user_id: UserId,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// Return true if successful
+    pub struct CreateStorageKeyResult {
+        pub success: bool,
+    }
+
+    // TODO #186: These messages need to be authenticated
+    impl_message_conversion!(SendUserId, CreateStorageKeyResult);
+}


### PR DESCRIPTION
This PR adds the storage key to the database and implements the registration protocol.

In order to ensure we have an authenticated channel before creating the storage key, I added a new operation called `CreateStorageKey`. The client-side register protocol is now executed in three steps:

1. Register
2. Authenticate
3. CreateStorageKey

I had to change the inner type of `OpaqueExportKey` to `Box<[u8; 64]>` to match the output from OPAQUE. Some testing code had to change as a result of this.

I also had to change the inner type of `UserId` to be a `String` to get it to play nice with the database. The user id I still a UUID generated in the same way. 

This task really needs an integration test case, but there's no way to check database values with the current test harness. Instead of making major changes to the test harness or duplicating all of the setup code, I made a ticket to add this test case #208 . We're currently working on refactoring the integration tests so we can take this requirement into consideration.

Closes #123
Closes #124
Closes #125 