### PR TITLE
Add TLS to tonic server #198

### DIFF
--- a/dams-client/Cargo.toml
+++ b/dams-client/Cargo.toml
@@ -16,6 +16,9 @@ bincode = "1"
 dams = { version = "0.1.0", path = "../dams" }
 futures = "0.3"
 http = "0.2"
+http-body = "0.4"
+hyper = "0.14"
+hyper-rustls = { version = "0.23", features = ["http2"] }
 opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
 prost = "0.11.0"
 rand = "0.8"
@@ -25,7 +28,7 @@ structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-tonic = "0.8.0"
+tonic =  "0.8"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/dams-key-server/Cargo.toml
+++ b/dams-key-server/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1"
 bincode = "1"
 dams = { version = "0.1.0", path = "../dams" }
 futures = "0.3"
+hyper = "0.14"
 mongodb = "2.3.0"
 opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
 prost = "0.11.0"
@@ -25,8 +26,10 @@ serde_with = "1"
 structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
+tokio-rustls = "0.23"
 tokio-stream = "0.1"
 tonic = "0.8.0"
+tower = "0.4"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/dams-key-server/src/error.rs
+++ b/dams-key-server/src/error.rs
@@ -17,6 +17,10 @@ pub enum DamsServerError {
     Dams(#[from] dams::DamsError),
     #[error(transparent)]
     DamsChannel(#[from] dams::channel::ChannelError),
+    #[error(transparent)]
+    Hyoer(#[from] hyper::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
     #[error("OPAQUE protocol error: {}", .0)]
     OpaqueProtocol(opaque_ke::errors::ProtocolError),
     #[error(transparent)]

--- a/dams-tests/tests/common.rs
+++ b/dams-tests/tests/common.rs
@@ -13,7 +13,7 @@ use tokio::{task::JoinHandle, time::Duration};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use dams::{timeout::WithTimeout, TestLogs};
+use dams::{defaults::server::LOCAL_SERVER_URI, timeout::WithTimeout, TestLogs};
 
 pub const ERROR_FILENAME: &str = "tests/gen/errors.log";
 
@@ -104,12 +104,15 @@ pub async fn teardown(server_future: ServerFuture) {
 /// Encode the customizable fields of the keymgmt client Config struct for
 /// testing.
 pub async fn client_test_config() -> dams::config::client::Config {
-    let config_str = r#"
-        server_location = "https://127.0.0.1:1113"
+    let config_str = format!(
+        r#"
+        server_location = "{}"
         trust_certificate = "tests/gen/localhost.crt"
-    "#;
+    "#,
+        LOCAL_SERVER_URI
+    );
 
-    dams::config::client::Config::from_str(config_str).expect("Failed to load client config")
+    dams::config::client::Config::from_str(&config_str).expect("Failed to load client config")
 }
 
 /// Encode the customizable fields of the keymgmt server Config struct for

--- a/dams/Cargo.toml
+++ b/dams/Cargo.toml
@@ -23,15 +23,18 @@ mongodb = "2.3.0"
 opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
 prost = "0.11.0"
 rand = "0.8"
+rustls = "0.20"
+rustls-pemfile = "1"
 serde = { version = "1", features = ["derive"] }
 serde_with = "1"
 sha3 = "0.10"
 tracing = "0.1"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
+tokio-rustls = "0.23"
 tokio-stream = "0.1"
 toml = "0.5"
-tonic = "0.8.0"
+tonic = "0.8"
 uuid = "1.1.2"
 webpki = "0.22"
 

--- a/dams/src/defaults.rs
+++ b/dams/src/defaults.rs
@@ -15,8 +15,8 @@ pub(crate) mod shared {
     use super::*;
 
     pub const ORGANIZATION: &str = "Bolt Labs";
-
     pub const APPLICATION: &str = "key-mgmt";
+    pub const LOCAL_SERVER_URI: &str = "https://localhost:1113";
 
     pub const fn max_pending_connection_retries() -> usize {
         4

--- a/dams/src/lib.rs
+++ b/dams/src/lib.rs
@@ -20,6 +20,7 @@ pub mod defaults;
 pub mod error;
 pub mod keys;
 pub mod opaque_storage;
+pub mod pem_utils;
 pub mod timeout;
 pub mod transaction;
 pub mod types;

--- a/dams/src/pem_utils.rs
+++ b/dams/src/pem_utils.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+use rustls::{Certificate, PrivateKey};
+
+use crate::DamsError;
+
+/// Returns all certificates in the pemfile at the given path
+pub fn read_certificates(path: impl AsRef<Path>) -> Result<Vec<Certificate>, DamsError> {
+    let fd = std::fs::File::open(path.as_ref())?;
+    let mut buf = std::io::BufReader::new(&fd);
+    let certs = rustls_pemfile::certs(&mut buf)?
+        .into_iter()
+        .map(Certificate)
+        .collect();
+
+    Ok(certs)
+}
+
+/// Returns the first private key found in the pemfile at the given path
+pub fn read_private_key(path: impl AsRef<Path>) -> Result<PrivateKey, DamsError> {
+    let fd = std::fs::File::open(path.as_ref())?;
+    let mut buf = std::io::BufReader::new(&fd);
+    let key = rustls_pemfile::pkcs8_private_keys(&mut buf)?
+        .into_iter()
+        .next()
+        .map(PrivateKey)
+        .ok_or(DamsError::InvalidPrivateKey)?;
+
+    Ok(key)
+}

--- a/dev/Client.toml
+++ b/dev/Client.toml
@@ -1,2 +1,2 @@
-server_location = "https://127.0.0.1:1113"
+server_location = "https://localhost:1113"
 trust_certificate = "localhost.crt"


### PR DESCRIPTION
This PR adds TLS back to the server. It's implemented in the `tower` service layer which should allow us to fully leverage the Rustls configuration options in the future.

Adding TLS support to the client muddied up the `DamsRpcClient` generic type a bit so I added a type alias.  I don't think we'll ever have to work with that type directly but it needs to be specified in order to store a `DamsRpcClient`.

I think it would be good to write a test that verifies the channel messages are TLS encrypted. I'm not sure how to do that off the top of my head so it'll take a bit of research, but I can make an issue for it if people agree that it would be useful.

Closes #198 