### PR TITLE
Remove table creation from tests #190

### DIFF
--- a/dams-tests/tests/main.rs
+++ b/dams-tests/tests/main.rs
@@ -22,7 +22,6 @@ pub async fn integration_tests() {
     )
     .await
     .expect("Unable to connect to Mongo");
-    let _ = db.create_collection("users", None).await;
     let server_future = common::setup(db.clone(), server_config).await;
     let client_config = common::client_test_config().await;
 


### PR DESCRIPTION
Closes #190 

It seems that creation line didn't need to be there at all. I'm not sure what was causing the tests to fail before.