### PR TITLE
197 db uniqueness

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,9 @@ jobs:
           components: clippy
           default: true
 
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.7.0
+
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/dams-key-server/src/database.rs
+++ b/dams-key-server/src/database.rs
@@ -3,6 +3,7 @@
 //! This database will hold information on users and the secret material
 //! they have stored in the key server.
 
+use dams::config::server::DatabaseSpec;
 use mongodb::{options::ClientOptions, Client, Database};
 
 use crate::error::DamsServerError;
@@ -11,16 +12,12 @@ pub(crate) mod user;
 
 /// Connect to the MongoDB instance and database specified by your environment
 /// variables
-pub async fn connect_to_mongo(
-    mongodb_uri: &str,
-    db_name: &str,
-) -> Result<Database, DamsServerError> {
+pub async fn connect_to_mongo(database_spec: &DatabaseSpec) -> Result<Database, DamsServerError> {
     // Parse a connection string into an options struct
-    let client_options = ClientOptions::parse(mongodb_uri).await?;
+    let client_options = ClientOptions::parse(&database_spec.mongodb_uri).await?;
     // Get a handle to the deployment
     let client = Client::with_options(client_options)?;
     // Get a handle to the database
-    let db = client.database(db_name);
-
+    let db = client.database(&database_spec.db_name);
     Ok(db)
 }

--- a/dams-key-server/src/database/user.rs
+++ b/dams-key-server/src/database/user.rs
@@ -112,7 +112,10 @@ mod test {
         let mut rng = rand::thread_rng();
         let mongodb_uri = "mongodb://localhost:27017";
         let db_name = "multiple_connections_dont_overwrite";
-        let db_spec = DatabaseSpec::new(mongodb_uri.to_string(), db_name.to_string());
+        let db_spec = DatabaseSpec {
+            mongodb_uri: mongodb_uri.to_string(),
+            db_name: db_name.to_string(),
+        };
 
         // Clean up previous runs and make fresh connection
         drop_db(mongodb_uri, db_name).await?;
@@ -165,7 +168,10 @@ mod test {
         let mut rng = rand::thread_rng();
         let mongodb_uri = "mongodb://localhost:27017";
         let db_name = "unique_indices_are_enforced";
-        let db_spec = DatabaseSpec::new(mongodb_uri.to_string(), db_name.to_string());
+        let db_spec = DatabaseSpec {
+            mongodb_uri: mongodb_uri.to_string(),
+            db_name: db_name.to_string(),
+        };
 
         // Clean up previous runs and make fresh connection
         drop_db(mongodb_uri, db_name).await?;

--- a/dams-key-server/src/database/user.rs
+++ b/dams-key-server/src/database/user.rs
@@ -68,6 +68,8 @@ mod test {
 
     use super::create_user;
 
+    /// Locally simulates OPAQUE registration to get a valid
+    /// `ServerRegistration` for remaining tests.
     fn server_registration(
         rng: &mut (impl CryptoRng + RngCore),
     ) -> ServerRegistration<OpaqueCipherSuite> {
@@ -192,7 +194,6 @@ mod test {
         );
 
         // Matching both can't be added.
-        eprintln!("one conn:: no match both");
         assert!(
             create_user(&db, &user_id, &account_name, &server_registration)
                 .await

--- a/dams-key-server/src/database/user.rs
+++ b/dams-key-server/src/database/user.rs
@@ -17,8 +17,6 @@ use opaque_ke::ServerRegistration;
 
 /// Create a new [`User`] with their authentication information and insert it
 /// into the MongoDB database.
-///
-/// TODO: add constraint that user id and account name are both unique.
 pub async fn create_user(
     db: &Database,
     user_id: &UserId,
@@ -50,4 +48,157 @@ pub async fn find_user_by_id(db: &Database, user_id: &UserId) -> Result<Option<U
     let query = doc! {"user_id": user_id.to_string()};
     let user = collection.find_one(query, None).await?;
     Ok(user)
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use dams::{
+        config::{opaque::OpaqueCipherSuite, server::DatabaseSpec},
+        user::{AccountName, User, UserId},
+    };
+    use mongodb::{options::ClientOptions, Client};
+    use opaque_ke::{
+        ClientRegistration, ClientRegistrationFinishParameters, ServerRegistration, ServerSetup,
+    };
+    use rand::{CryptoRng, RngCore};
+
+    use crate::{constants, database::connect_to_mongo, DamsServerError};
+
+    use super::create_user;
+
+    fn server_registration(
+        rng: &mut (impl CryptoRng + RngCore),
+    ) -> ServerRegistration<OpaqueCipherSuite> {
+        let server_setup = ServerSetup::<OpaqueCipherSuite>::new(rng);
+        let client_reg_start_result =
+            ClientRegistration::<OpaqueCipherSuite>::start(rng, b"password").unwrap();
+        let server_reg_start_result = ServerRegistration::<OpaqueCipherSuite>::start(
+            &server_setup,
+            client_reg_start_result.message,
+            b"email@email.com",
+        )
+        .unwrap();
+        let client_reg_finish_result = client_reg_start_result
+            .state
+            .finish(
+                rng,
+                b"password",
+                server_reg_start_result.message,
+                ClientRegistrationFinishParameters::default(),
+            )
+            .unwrap();
+        ServerRegistration::<OpaqueCipherSuite>::finish(client_reg_finish_result.message)
+    }
+
+    // Delete the entire db to avoid leftover issues from previous runs.
+    async fn drop_db(mongodb_uri: &str, db_name: &str) -> Result<(), DamsServerError> {
+        // Parse a connection string into an options struct
+        let client_options = ClientOptions::parse(mongodb_uri).await?;
+        // Get a handle to the deployment
+        let client = Client::with_options(client_options)?;
+        // Get a handle to the database
+        let db = client.database(db_name);
+        db.drop(None).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn multiple_connections_do_not_overwrite_db() -> Result<(), DamsServerError> {
+        let mut rng = rand::thread_rng();
+        let mongodb_uri = "mongodb://localhost:27017";
+        let db_name = "multiple_connections_dont_overwrite";
+        let db_spec = DatabaseSpec::new(mongodb_uri.to_string(), db_name.to_string());
+
+        // Clean up previous runs and make fresh connection
+        drop_db(mongodb_uri, db_name).await?;
+        let db = connect_to_mongo(&db_spec).await?;
+
+        let server_registration = &server_registration(&mut rng);
+
+        // Add two users
+        let uid1 = UserId::new(&mut rng)?;
+        let _ = create_user(
+            &db,
+            &uid1,
+            &AccountName::from_str("test user 1")?,
+            server_registration,
+        )
+        .await?;
+
+        let uid2 = UserId::new(&mut rng)?;
+        let _ = create_user(
+            &db,
+            &uid2,
+            &AccountName::from_str("test user 2")?,
+            server_registration,
+        )
+        .await?;
+
+        // Check that the database holds two users.
+        assert_eq!(
+            2,
+            db.collection::<User>(constants::USERS)
+                .estimated_document_count(None)
+                .await?
+        );
+
+        // Reconnect and make sure it still has two users.
+        let reconnected_db = connect_to_mongo(&db_spec).await?;
+        assert_eq!(
+            2,
+            reconnected_db
+                .collection::<User>(constants::USERS)
+                .estimated_document_count(None)
+                .await?
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unique_indices_enforced() -> Result<(), DamsServerError> {
+        let mut rng = rand::thread_rng();
+        let mongodb_uri = "mongodb://localhost:27017";
+        let db_name = "unique_indices_are_enforced";
+        let db_spec = DatabaseSpec::new(mongodb_uri.to_string(), db_name.to_string());
+
+        // Clean up previous runs and make fresh connection
+        drop_db(mongodb_uri, db_name).await?;
+        let db = connect_to_mongo(&db_spec).await?;
+
+        // Add the "baseline" user.
+        let user_id = UserId::new(&mut rng)?;
+        let account_name = AccountName::from_str("unique@email.com")?;
+        let server_registration = server_registration(&mut rng);
+        let _ = create_user(&db, &user_id, &account_name, &server_registration).await?;
+
+        // Matching UserIds can't be added.
+        let different_an = AccountName::from_str("other@email.com")?;
+        assert!(
+            create_user(&db, &user_id, &different_an, &server_registration)
+                .await
+                .is_err()
+        );
+
+        // Matching AccountNames can't be added.
+        let different_uid = UserId::new(&mut rng)?;
+        assert!(
+            create_user(&db, &different_uid, &account_name, &server_registration)
+                .await
+                .is_err()
+        );
+
+        // Matching both can't be added.
+        eprintln!("one conn:: no match both");
+        assert!(
+            create_user(&db, &user_id, &account_name, &server_registration)
+                .await
+                .is_err()
+        );
+
+        Ok(())
+    }
 }

--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -81,8 +81,7 @@ impl DamsRpc for DamsKeyServer {
 }
 
 pub async fn start_tonic_server(config: Config) -> Result<(), DamsServerError> {
-    let db =
-        database::connect_to_mongo(&config.database.mongodb_uri, &config.database.db_name).await?;
+    let db = database::connect_to_mongo(&config.database).await?;
     // Collect the futures for the result of running each specified server
     let mut server_futures: FuturesUnordered<_> = config
         .services

--- a/dams-tests/tests/main.rs
+++ b/dams-tests/tests/main.rs
@@ -16,12 +16,9 @@ use thiserror::Error;
 pub async fn integration_tests() {
     // Read environment variables from .env file
     let server_config = common::server_test_config().await;
-    let db = database::connect_to_mongo(
-        &server_config.database.mongodb_uri,
-        &server_config.database.db_name,
-    )
-    .await
-    .expect("Unable to connect to Mongo");
+    let db = database::connect_to_mongo(&server_config.database)
+        .await
+        .expect("Unable to connect to Mongo");
     let server_future = common::setup(db.clone(), server_config).await;
     let client_config = common::client_test_config().await;
 

--- a/dams/Cargo.toml
+++ b/dams/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 toml = "0.5"
 tonic = "0.8.0"
+uuid = "1.1.2"
 webpki = "0.22"
 
 [build-dependencies]

--- a/dams/src/config/server.rs
+++ b/dams/src/config/server.rs
@@ -19,7 +19,6 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-#[non_exhaustive]
 pub struct DatabaseSpec {
     pub mongodb_uri: String,
     pub db_name: String,
@@ -74,15 +73,6 @@ impl FromStr for Config {
     fn from_str(config_string: &str) -> Result<Self, Self::Err> {
         let config: Config = toml::from_str(config_string)?;
         Ok(config)
-    }
-}
-
-impl DatabaseSpec {
-    pub fn new(mongodb_uri: String, db_name: String) -> Self {
-        Self {
-            mongodb_uri,
-            db_name,
-        }
     }
 }
 

--- a/dams/src/config/server.rs
+++ b/dams/src/config/server.rs
@@ -77,6 +77,15 @@ impl FromStr for Config {
     }
 }
 
+impl DatabaseSpec {
+    pub fn new(mongodb_uri: String, db_name: String) -> Self {
+        Self {
+            mongodb_uri,
+            db_name,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -13,10 +13,11 @@ use opaque_ke::ServerRegistration;
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
+use uuid::Uuid;
 
 /// Unique ID for a user.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
-pub struct UserId(Box<[u8; 16]>);
+pub struct UserId(Uuid);
 
 impl Display for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -29,7 +30,8 @@ impl UserId {
         let mut id = [0_u8; 16];
         rng.try_fill(&mut id)
             .map_err(|_| CryptoError::RandomNumberGeneratorFailed)?;
-        Ok(Self(Box::new(id)))
+        let uuid = Uuid::from_bytes(id);
+        Ok(Self(uuid))
     }
 
     pub fn as_bytes(&self) -> &[u8] {


### PR DESCRIPTION
Closes #197 

Wraps the UserId in a Uuid so it doesn't serialize to an array and we can use the MongoDB unique index on it.

Question: Is there a way to make the `DatabaseSpec::new()` function I wrote in `dams` only available to tests? It didn't seem to work when I put `cfg[test]` over it, and I think it's because the unit tests I'm using it for are in a different crate.