### PR TITLE
Add generate cryptography

### DIFF
--- a/dams/src/crypto.rs
+++ b/dams/src/crypto.rs
@@ -322,7 +322,7 @@ impl MasterKey {
         user_id: &UserId,
     ) -> Result<Encrypted<StorageKey>, CryptoError> {
         let associated_data = AssociatedData::new()
-            .with_str(&user_id.to_string())
+            .with_bytes(user_id.clone())
             .with_str(StorageKey::domain_separator());
 
         Encrypted::encrypt(rng, &self.0, storage_key, &associated_data)
@@ -366,7 +366,7 @@ impl StorageKey {
         key_id: &KeyId,
     ) -> Result<Encrypted<Secret>, CryptoError> {
         let ad = AssociatedData::new()
-            .with_str(&user_id.to_string())
+            .with_bytes(user_id.clone())
             .with_bytes(key_id.clone())
             .with_str("client-generated");
 
@@ -386,7 +386,7 @@ impl StorageKey {
         key_id: &KeyId,
     ) -> Result<Encrypted<Secret>, CryptoError> {
         let ad = AssociatedData::new()
-            .with_str(&user_id.to_string())
+            .with_bytes(user_id.clone())
             .with_bytes(key_id.clone())
             .with_str("client-generated");
         let secret = Secret::generate(rng, 32, ad);
@@ -973,7 +973,7 @@ mod test {
 
         // Encrypt the secret
         let ad = AssociatedData::new()
-            .with_str(&user_id.to_string())
+            .with_bytes(user_id.clone())
             .with_bytes(key_id.clone())
             .with_str("client-generated");
         let secret = Secret::generate(&mut rng, 32, ad);

--- a/dams/src/transaction.rs
+++ b/dams/src/transaction.rs
@@ -31,18 +31,6 @@ pub struct TransactionApprovalRequest {
     transaction: Transaction,
 }
 
-impl Default for TransactionApprovalRequest {
-    fn default() -> Self {
-        Self {
-            key_id: KeyId,
-            user_id: UserId::default(),
-            asset_id: AssetId,
-            tar_id: TarId,
-            transaction: Transaction,
-        }
-    }
-}
-
 /// Unique ID for a [`TransactionApprovalRequest`].
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct TarId;

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -48,7 +48,7 @@ impl IntoIterator for UserId {
 
 impl Display for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&format!("{:?}", self.0))
+        write!(f, "{:?}", self.0)
     }
 }
 

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -12,18 +12,12 @@ use crate::{
 use opaque_ke::ServerRegistration;
 use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, str::FromStr};
+use std::{array::IntoIter, fmt::Display, str::FromStr};
 use uuid::Uuid;
 
 /// Unique ID for a user.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct UserId(Uuid);
-
-impl Display for UserId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&format!("{:?}", self.0))
-    }
-}
 
 impl UserId {
     pub fn new(rng: &mut (impl CryptoRng + RngCore)) -> Result<Self, DamsError> {
@@ -39,7 +33,22 @@ impl UserId {
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.0.len()
+        self.as_bytes().len()
+    }
+}
+
+impl IntoIterator for UserId {
+    type Item = u8;
+    type IntoIter = IntoIter<u8, 16>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_bytes().into_iter()
+    }
+}
+
+impl Display for UserId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("{:?}", self.0))
     }
 }
 

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -37,6 +37,10 @@ impl UserId {
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_ref()
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 /// Account name used as human-memorable identifier for a user during OPAQUE.


### PR DESCRIPTION
Closes #134, closes #107 (checks the last box!)

- Updates several type representations to be more compatible with how they need to operate
   - Storage key is now an encryption key, not a secret. This also required updating the to/from `Vec<u8>` on a storage key. For modularity, I also implemented the conversion for an encryption key.
   - Associated data is now a byte array, not a string.
   - The opaque encryption key is now a byte array, not a generic array, and it has a constructor.
- Adds encryption and decryption of secrets under storage keys
- Adds generation of key IDs.

Specific feedback on tests is particularly welcome.