### PR TITLE
Refactored integration tests #216

### DIFF
--- a/dams-tests/tests/common.rs
+++ b/dams-tests/tests/common.rs
@@ -13,40 +13,47 @@ use tokio::{task::JoinHandle, time::Duration};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use dams::{defaults::server::LOCAL_SERVER_URI, timeout::WithTimeout, TestLogs};
+use dams::{
+    config::{client::Config as ClientConfig, server::Config as ServerConfig},
+    defaults::server::LOCAL_SERVER_URI,
+    timeout::WithTimeout,
+    TestLogs,
+};
 
 pub const ERROR_FILENAME: &str = "tests/gen/errors.log";
-
 pub const SERVER_ADDRESS: &str = "127.0.0.1";
 
 /// Give a name to the slightly annoying type of the joined server futures
-type ServerFuture = JoinHandle<Result<(), dams_key_server::DamsServerError>>;
+pub type ServerFuture = JoinHandle<Result<(), dams_key_server::DamsServerError>>;
 
-/// Set of processes that run during a test.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Party {
-    Client,
-    Server,
-}
+pub async fn setup() -> TestContext {
+    // Read environment variables from .env file
+    let server_config = server_test_config().await;
+    let database = Database::connect(&server_config.database)
+        .await
+        .expect("Unable to connect to Mongo");
 
-impl Party {
-    pub const fn to_str(self) -> &'static str {
-        match self {
-            Party::Client => "party: client",
-            Party::Server => "party: server",
-        }
+    // Ensure that the test DB is fresh
+    database.drop().await.expect("Failed to drop database");
+
+    generate_files().await;
+
+    let server_future = start_server(server_config).await;
+    let client_config = client_test_config().await;
+
+    TestContext {
+        server_future,
+        client_config,
+        database,
     }
 }
 
-pub async fn setup(db: Database, server_config: dams::config::server::Config) -> ServerFuture {
+async fn generate_files() {
     // Delete data from previous run
     let gen_path = Path::new("tests/gen/");
     // Swallow error if path doesn't exist
     let _ = fs::remove_dir_all(&gen_path);
-    fs::create_dir(&gen_path).expect("Unable to create directory tests/gen");
-
-    // Ensure that the test DB is fresh
-    db.drop().await.expect("Failed to drop database");
+    fs::create_dir_all(&gen_path).expect("Unable to create directory tests/gen");
 
     // Create self-signed SSL certificate in the generated directory
     Command::new("../dev/generate-certificates")
@@ -54,7 +61,9 @@ pub async fn setup(db: Database, server_config: dams::config::server::Config) ->
         .spawn()
         .expect("Failed to generate new certificates");
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+}
 
+async fn start_server(server_config: ServerConfig) -> ServerFuture {
     // set up tracing for all log messages
     tracing_subscriber::fmt()
         .with_writer(Mutex::new(
@@ -63,7 +72,6 @@ pub async fn setup(db: Database, server_config: dams::config::server::Config) ->
         .init();
 
     // Form the server run request and execute
-    #[allow(clippy::infallible_destructuring_match)]
     let server_handle = tokio::spawn(
         dams_key_server::server::start_tonic_server(server_config)
             .instrument(info_span!(Party::Server.to_str())),
@@ -96,14 +104,9 @@ pub async fn setup(db: Database, server_config: dams::config::server::Config) ->
     server_handle
 }
 
-pub async fn teardown(server_future: ServerFuture) {
-    // Ignore the result because we expect it to be an `Expired` error
-    let _result = server_future.with_timeout(Duration::from_secs(1)).await;
-}
-
 /// Encode the customizable fields of the keymgmt client Config struct for
 /// testing.
-pub async fn client_test_config() -> dams::config::client::Config {
+async fn client_test_config() -> ClientConfig {
     let config_str = format!(
         r#"
         server_location = "{}"
@@ -112,12 +115,12 @@ pub async fn client_test_config() -> dams::config::client::Config {
         LOCAL_SERVER_URI
     );
 
-    dams::config::client::Config::from_str(&config_str).expect("Failed to load client config")
+    ClientConfig::from_str(&config_str).expect("Failed to load client config")
 }
 
 /// Encode the customizable fields of the keymgmt server Config struct for
 /// testing.
-pub async fn server_test_config() -> dams::config::server::Config {
+async fn server_test_config() -> ServerConfig {
     let config_str = format!(
         r#"
         [[service]]
@@ -135,7 +138,40 @@ pub async fn server_test_config() -> dams::config::server::Config {
         SERVER_ADDRESS
     );
 
-    dams::config::server::Config::from_str(&config_str).expect("failed to load server config")
+    ServerConfig::from_str(&config_str).expect("failed to load server config")
+}
+
+/// Set of processes that run during a test.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(unused)]
+pub enum Party {
+    Client,
+    Server,
+}
+
+impl Party {
+    pub const fn to_str(self) -> &'static str {
+        match self {
+            Party::Client => "party: client",
+            Party::Server => "party: server",
+        }
+    }
+}
+
+pub struct TestContext {
+    server_future: ServerFuture,
+    pub client_config: ClientConfig,
+    pub database: Database,
+}
+
+impl TestContext {
+    pub async fn teardown(self) {
+        // Ignore the result because we expect it to be an `Expired` error
+        let _result = self
+            .server_future
+            .with_timeout(Duration::from_secs(1))
+            .await;
+    }
 }
 
 #[allow(unused)]

--- a/dams-tests/tests/end_to_end.rs
+++ b/dams-tests/tests/end_to_end.rs
@@ -1,11 +1,8 @@
-pub(crate) mod common;
+mod common;
 
-use crate::{
-    Operation::{Authenticate, Generate, GenerateAndRetrieve, Register},
-    Party::{Client, Server},
-};
 use common::{get_logs, LogType, Party};
-use dams_key_server::database::Database;
+use Operation::{Authenticate, Generate, GenerateAndRetrieve, Register};
+use Party::{Client, Server};
 
 use dams::{config::client::Config, user::AccountName, RetrieveContext};
 use dams_client::{client::Password, DamsClient, DamsClientError};
@@ -13,14 +10,8 @@ use std::{fs::OpenOptions, str::FromStr};
 use thiserror::Error;
 
 #[tokio::test]
-pub async fn integration_tests() {
-    // Read environment variables from .env file
-    let server_config = common::server_test_config().await;
-    let db = Database::connect(&server_config.database)
-        .await
-        .expect("Unable to connect to Mongo");
-    let server_future = common::setup(db.clone(), server_config).await;
-    let client_config = common::client_test_config().await;
+pub async fn end_to_end_tests() {
+    let context = common::setup().await;
 
     // Run every test, printing out details if it fails
     let tests = tests().await;
@@ -35,7 +26,7 @@ pub async fn integration_tests() {
         .unwrap_or_else(|e| panic!("Failed to clear error file at start: {:?}", e));
     for test in tests {
         eprintln!("\n\ntest integration_tests::{} ... ", test.name);
-        let result = test.execute(&client_config).await;
+        let result = test.execute(&context.client_config).await;
         if let Err(error) = &result {
             eprintln!("failed with error: {:?}", error)
         } else {
@@ -55,7 +46,7 @@ pub async fn integration_tests() {
     // _every_ test must run without short-circuiting the execution at first
     // failure
     let mut errors = Vec::with_capacity(results.len());
-    for result in results.iter() {
+    for result in results.into_iter() {
         match result {
             Ok(_) => {}
             Err(err) => {
@@ -64,7 +55,7 @@ pub async fn integration_tests() {
         }
     }
 
-    common::teardown(server_future).await;
+    context.teardown().await;
     if !errors.is_empty() {
         panic!("Test failed: {:?}", errors);
     }


### PR DESCRIPTION
This PR addresses the first two requirements of #216. We can work on the third requirement after the retrieve operation is merged.

- Tests are now divided between end-to-end tests and more general integration tests.
- Setup and teardown code were fully moved to common module.