### PR TITLE
Added temp flag to disable TLS #220

### DIFF
--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -182,8 +182,55 @@ pub async fn start_tonic_server(config: Config) -> Result<(), DamsServerError> {
     Ok(())
 }
 
+// TODO #220: Remove me!
+pub async fn start_tonic_server_without_tls(config: Config) -> Result<(), DamsServerError> {
+    let db = database::connect_to_mongo(&config.database).await?;
+    // Collect the futures for the result of running each specified server
+    let mut server_futures: FuturesUnordered<_> = config
+        .services
+        .iter()
+        .map(|service| {
+            // Clone `Arc`s for the various resources we need in this server
+            let config = config.clone();
+            let db = db.clone();
+            let service = Arc::new(service.clone());
+
+            async move {
+                let dams_rpc_server = DamsKeyServer::new(db, config, service)?;
+                let addr = dams_rpc_server.service.address;
+                let port = dams_rpc_server.service.port;
+                info!("{}", TestLogs::ServerSpawned(format!("{}:{}", addr, port)));
+                Server::builder()
+                    .add_service(DamsRpcServer::new(dams_rpc_server))
+                    .serve(SocketAddr::new(addr, port))
+                    .await?;
+
+                Ok::<_, DamsServerError>(())
+            }
+        })
+        .collect();
+
+    // Wait for the server to finish
+    tokio::select! {
+        _ = signal::ctrl_c() => info!("Terminated by user"),
+        Some(Err(e)) = server_futures.next() => {
+            error!("Error: {}", e);
+        },
+        else => {
+            info!("Shutting down...")
+        }
+    }
+    Ok(())
+}
+
 pub async fn main_with_cli(cli: Cli) -> Result<(), DamsServerError> {
     let config_path = cli.config.ok_or_else(config_path).or_else(identity)?;
     let config = Config::load(&config_path).await?;
-    start_tonic_server(config).await
+
+    // TODO #220: Remove me!
+    if config.disable_tls {
+        start_tonic_server_without_tls(config).await
+    } else {
+        start_tonic_server(config).await
+    }
 }

--- a/dams/src/config/server.rs
+++ b/dams/src/config/server.rs
@@ -16,6 +16,9 @@ pub struct Config {
     #[serde(rename = "service")]
     pub services: Vec<Service>,
     pub database: DatabaseSpec,
+    // TODO #220: Remove me!
+    #[serde(default)]
+    pub disable_tls: bool,
 }
 
 impl Config {
@@ -125,6 +128,7 @@ mod tests {
                     mongodb_uri,
                     db_name,
                 },
+            disable_tls: _,
         } = Config::from_str(config_str).unwrap();
 
         assert_eq!(mongodb_uri, "mongodb://localhost:27017");
@@ -180,6 +184,7 @@ mod tests {
                     mongodb_uri,
                     db_name,
                 },
+            disable_tls: _,
         } = Config::from_str(config_str).unwrap();
 
         assert_eq!(mongodb_uri, "mongodb://localhost:27017");

--- a/dev/Server.toml
+++ b/dev/Server.toml
@@ -1,3 +1,6 @@
+#TODO #220: Remove me!
+disable_tls = true
+
 [[service]]
 address = "::1"
 port = 1113


### PR DESCRIPTION
We're temporarily disabling TLS for the demo repo. Integration tests still run with TLS enabled but users running the server themselves have the option to disable it now.

This PR simply adds back the old code and puts it in a new function.