### PR TITLE
Retrieve

### DIFF
--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -2,19 +2,12 @@ use crate::{DamsClient, DamsClientError};
 use dams::{
     crypto::{KeyId, Secret, StorageKey},
     types::retrieve_storage_key::{client, server},
-    ClientAction,
+    ClientAction, RetrieveContext,
 };
 use serde::{Deserialize, Serialize};
 
 mod generate;
 mod retrieve;
-
-/// Options for the asset owner's intended use of a secret
-#[derive(Debug, Deserialize, Serialize)]
-pub enum RetrieveContext {
-    LocalOnly,
-    Export,
-}
 
 /// Ways of returning a key from the retrieval process based on usage
 /// [`Context`]
@@ -66,7 +59,7 @@ impl DamsClient {
     pub async fn retrieve(
         &self,
         key_id: &KeyId,
-        context: Option<RetrieveContext>,
+        context: RetrieveContext,
     ) -> Result<RetrieveResult, DamsClientError> {
         let mut client_channel =
             Self::create_channel(&mut self.tonic_client(), ClientAction::Retrieve).await?;

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -10,7 +10,7 @@ mod generate;
 mod retrieve;
 
 /// Ways of returning a key from the retrieval process based on usage
-/// [`Context`]
+/// [`RetrieveContext`]
 #[derive(Debug, Deserialize, Serialize)]
 pub enum RetrieveResult {
     None,

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -12,6 +12,12 @@ mod generate;
 const SECRET_LENGTH: u32 = 32;
 
 #[derive(Debug, Deserialize, Serialize)]
+pub enum Context {
+    LocalOnly,
+    Export
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct LocalStorage {
     pub(crate) secret: Secret,
 }

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -7,14 +7,22 @@ use dams::{
 use serde::{Deserialize, Serialize};
 
 mod generate;
+mod retrieve;
 
-#[allow(unused)]
-const SECRET_LENGTH: u32 = 32;
-
+/// Options for the asset owner's intended use of a secret
 #[derive(Debug, Deserialize, Serialize)]
 pub enum Context {
     LocalOnly,
-    Export
+    Export,
+}
+
+/// Ways of returning a key from the retrieval process based on usage
+/// [`Context`]
+#[derive(Debug, Deserialize, Serialize)]
+pub enum RetrieveResult {
+    None,
+    ArbitraryKey(LocalStorage),
+    ExportedKey(Vec<u8>),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -52,5 +60,17 @@ impl DamsClient {
         let mut client_channel =
             Self::create_channel(&mut self.tonic_client(), ClientAction::Generate).await?;
         self.handle_generate(&mut client_channel).await
+    }
+
+    /// Retrieve an arbitrary secret from the key server by [`KeyId`]
+    pub async fn retrieve(
+        &self,
+        key_id: &KeyId,
+        context: Option<Context>,
+    ) -> Result<RetrieveResult, DamsClientError> {
+        let mut client_channel =
+            Self::create_channel(&mut self.tonic_client(), ClientAction::Retrieve).await?;
+        self.handle_retrieve(&mut client_channel, key_id, context)
+            .await
     }
 }

--- a/dams-client/src/api/arbitrary_secrets.rs
+++ b/dams-client/src/api/arbitrary_secrets.rs
@@ -11,7 +11,7 @@ mod retrieve;
 
 /// Options for the asset owner's intended use of a secret
 #[derive(Debug, Deserialize, Serialize)]
-pub enum Context {
+pub enum RetrieveContext {
     LocalOnly,
     Export,
 }
@@ -66,7 +66,7 @@ impl DamsClient {
     pub async fn retrieve(
         &self,
         key_id: &KeyId,
-        context: Option<Context>,
+        context: Option<RetrieveContext>,
     ) -> Result<RetrieveResult, DamsClientError> {
         let mut client_channel =
             Self::create_channel(&mut self.tonic_client(), ClientAction::Retrieve).await?;

--- a/dams-client/src/api/arbitrary_secrets/retrieve.rs
+++ b/dams-client/src/api/arbitrary_secrets/retrieve.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::arbitrary_secrets::{Context, LocalStorage, RetrieveResult},
+    api::arbitrary_secrets::{LocalStorage, RetrieveContext, RetrieveResult},
     DamsClient, DamsClientError,
 };
 use dams::{
@@ -13,7 +13,7 @@ impl DamsClient {
         &self,
         channel: &mut ClientChannel,
         key_id: &KeyId,
-        context: Option<Context>,
+        context: Option<RetrieveContext>,
     ) -> Result<RetrieveResult, DamsClientError> {
         // Retrieve the storage key
         let storage_key = self.retrieve_storage_key().await?;
@@ -39,11 +39,11 @@ impl DamsClient {
         // Return appropriate value based on Context
         match context {
             None => Ok(RetrieveResult::None),
-            Some(Context::LocalOnly) => {
+            Some(RetrieveContext::LocalOnly) => {
                 let wrapped_secret = LocalStorage { secret };
                 Ok(RetrieveResult::ArbitraryKey(wrapped_secret))
             }
-            Some(Context::Export) => Ok(RetrieveResult::ExportedKey(secret.into())),
+            Some(RetrieveContext::Export) => Ok(RetrieveResult::ExportedKey(secret.into())),
         }
     }
 }

--- a/dams-client/src/api/arbitrary_secrets/retrieve.rs
+++ b/dams-client/src/api/arbitrary_secrets/retrieve.rs
@@ -1,0 +1,49 @@
+use crate::{
+    api::arbitrary_secrets::{Context, LocalStorage, RetrieveResult},
+    DamsClient, DamsClientError,
+};
+use dams::{
+    channel::ClientChannel,
+    crypto::KeyId,
+    types::retrieve::{client, server},
+};
+
+impl DamsClient {
+    pub(crate) async fn handle_retrieve(
+        &self,
+        channel: &mut ClientChannel,
+        key_id: &KeyId,
+        context: Option<Context>,
+    ) -> Result<RetrieveResult, DamsClientError> {
+        // Retrieve the storage key
+        let storage_key = self.retrieve_storage_key().await?;
+
+        // TODO spec#39 look up key ID in local storage before making request to server
+
+        // Send UserId to server
+        let request = client::Request {
+            user_id: self.user_id().clone(),
+            key_id: key_id.clone(),
+        };
+        channel.send(request).await?;
+
+        // Get StoredSecret from server
+        let server_response: server::Response = channel.receive().await?;
+
+        // Decrypt secret
+        let secret = server_response
+            .stored_secret
+            .secret
+            .decrypt_secret(storage_key)?;
+
+        // Return appropriate value based on Context
+        match context {
+            None => Ok(RetrieveResult::None),
+            Some(Context::LocalOnly) => {
+                let wrapped_secret = LocalStorage { secret };
+                Ok(RetrieveResult::ArbitraryKey(wrapped_secret))
+            }
+            Some(Context::Export) => Ok(RetrieveResult::ExportedKey(secret.into())),
+        }
+    }
+}

--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -219,6 +219,7 @@ impl DamsClient {
             ClientAction::Authenticate => client.authenticate(stream).await,
             ClientAction::CreateStorageKey => client.create_storage_key(stream).await,
             ClientAction::Generate => client.generate(stream).await,
+            ClientAction::Retrieve => client.retrieve(stream).await,
             ClientAction::RetrieveStorageKey => client.retrieve_storage_key(stream).await,
         }?
         .into_inner();

--- a/dams-key-server/src/command.rs
+++ b/dams-key-server/src/command.rs
@@ -2,6 +2,7 @@ pub mod authenticate;
 pub mod create_storage_key;
 pub mod generate;
 pub mod register;
+pub mod retrieve;
 
 use crate::{server::Context, DamsServerError};
 use dams::{

--- a/dams-key-server/src/command/retrieve.rs
+++ b/dams-key-server/src/command/retrieve.rs
@@ -1,0 +1,54 @@
+use crate::{database::user as User, server::Context, DamsServerError};
+
+use dams::{
+    channel::ServerChannel,
+    types::{
+        retrieve::{client, server},
+        Message, MessageStream,
+    },
+};
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response};
+
+#[derive(Debug)]
+pub struct Retrieve;
+
+impl Retrieve {
+    pub async fn run<'a>(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+        context: Context,
+    ) -> Result<Response<MessageStream>, DamsServerError> {
+        let (mut channel, rx) = ServerChannel::create(request.into_inner());
+
+        let _ = tokio::spawn(async move {
+            // Generate step: receive UserId and reply with new KeyId
+            retrieve(&mut channel, &context).await?;
+
+            Ok::<(), DamsServerError>(())
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+}
+
+async fn retrieve(channel: &mut ServerChannel, context: &Context) -> Result<(), DamsServerError> {
+    // Receive UserId from client
+    let request: client::Request = channel.receive().await?;
+    // Find user by ID
+    let user = User::find_user_by_id(&context.db, &request.user_id)
+        .await?
+        .ok_or(DamsServerError::AccountDoesNotExist)?;
+
+    // Find secret based on key_id
+    let stored_secret = user
+        .secrets
+        .into_iter()
+        .find(|x| x.key_id == request.key_id)
+        .ok_or(DamsServerError::KeyNotFound)?;
+
+    // Serialize KeyId and send to client
+    let reply = server::Response { stored_secret };
+    channel.send(reply).await?;
+    Ok(())
+}

--- a/dams-key-server/src/command/retrieve.rs
+++ b/dams-key-server/src/command/retrieve.rs
@@ -1,11 +1,13 @@
 use crate::{server::Context, DamsServerError};
 
+use crate::error::LogExt;
 use dams::{
     channel::ServerChannel,
     types::{
         retrieve::{client, server},
         Message, MessageStream,
     },
+    ClientAction,
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response};
@@ -22,7 +24,6 @@ impl Retrieve {
         let (mut channel, rx) = ServerChannel::create(request.into_inner());
 
         let _ = tokio::spawn(async move {
-            // Generate step: receive UserId and reply with new KeyId
             retrieve(&mut channel, &context).await?;
 
             Ok::<(), DamsServerError>(())
@@ -35,11 +36,21 @@ impl Retrieve {
 async fn retrieve(channel: &mut ServerChannel, context: &Context) -> Result<(), DamsServerError> {
     // Receive UserId from client
     let request: client::Request = channel.receive().await?;
+
+    // TODO #232: move this log so that we log the entire operation
     // Find secret based on key_id
     let stored_secret = context
         .db
-        .get_user_secret(&request.user_id, request.key_id)
+        .get_user_secret(&request.user_id, &request.key_id)
+        .await
+        .log(
+            &context.db,
+            &request.user_id,
+            Some(request.key_id),
+            ClientAction::Retrieve,
+        )
         .await?;
+
     // Serialize KeyId and send to client
     let reply = server::Response { stored_secret };
     channel.send(reply).await?;

--- a/dams-key-server/src/database/user.rs
+++ b/dams-key-server/src/database/user.rs
@@ -95,12 +95,12 @@ impl Database {
     pub async fn get_user_secret(
         &self,
         user_id: &UserId,
-        key_id: KeyId,
+        key_id: &KeyId,
     ) -> Result<StoredSecret, DamsServerError> {
         // Get user collection
         let collection = self.inner.collection::<User>(constants::USERS);
         // Match on UserId and KeyId, update "retrieved" field to true
-        let key_id_bson = mongodb::bson::to_bson(&key_id)?;
+        let key_id_bson = mongodb::bson::to_bson(key_id)?;
         let filter = doc! { USER_ID: user_id, "secrets.key_id": key_id_bson };
         let update = doc! { "$set": { "secrets.$.retrieved": true } };
         let user = collection
@@ -112,7 +112,7 @@ impl Database {
         let stored_secret = user
             .secrets
             .into_iter()
-            .find(|x| x.key_id == key_id)
+            .find(|x| x.key_id == *key_id)
             .ok_or(DamsServerError::KeyNotFound)?;
 
         Ok(stored_secret)

--- a/dams-key-server/src/error.rs
+++ b/dams-key-server/src/error.rs
@@ -19,6 +19,8 @@ pub enum DamsServerError {
     StorageKeyAlreadySet,
     #[error("Storage key is not set for this user")]
     StorageKeyNotSet,
+    #[error("Key ID does not match any stored arbitrary key")]
+    KeyNotFound,
 
     // Wrapped errors
     #[error(transparent)]

--- a/dams-key-server/src/server.rs
+++ b/dams-key-server/src/server.rs
@@ -63,6 +63,7 @@ impl DamsRpc for DamsKeyServer {
     type AuthenticateStream = dams::types::MessageStream;
     type CreateStorageKeyStream = dams::types::MessageStream;
     type GenerateStream = dams::types::MessageStream;
+    type RetrieveStream = dams::types::MessageStream;
     type RetrieveStorageKeyStream = dams::types::MessageStream;
 
     async fn register(
@@ -97,6 +98,15 @@ impl DamsRpc for DamsKeyServer {
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::GenerateStream>, Status> {
         Ok(command::generate::Generate
+            .run(request, self.context())
+            .await?)
+    }
+
+    async fn retrieve(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+    ) -> Result<Response<Self::RetrieveStream>, Status> {
+        Ok(command::retrieve::Retrieve
             .run(request, self.context())
             .await?)
     }

--- a/dams-tests/tests/main.rs
+++ b/dams-tests/tests/main.rs
@@ -1,13 +1,12 @@
 pub(crate) mod common;
 
 use crate::{
-    Operation::{Authenticate, Register},
+    Operation::{Authenticate, Generate, GenerateAndRetrieve, Register},
     Party::{Client, Server},
 };
 use common::{get_logs, LogType, Party};
 use dams_key_server::database::Database;
 
-use crate::Operation::{Generate, Retrieve};
 use dams::{config::client::Config, user::AccountName};
 use dams_client::{client::Password, DamsClient, DamsClientError};
 use std::{fs::OpenOptions, str::FromStr};
@@ -214,7 +213,7 @@ async fn tests() -> Vec<Test> {
                     },
                 ),
                 (
-                    Retrieve(
+                    GenerateAndRetrieve(
                         AccountName::from_str("retrieve").unwrap(),
                         Password::from_str("retrievePassword").unwrap(),
                     ),
@@ -258,7 +257,7 @@ impl Test {
                         .map(|_| ())
                         .map_err(|e| e.into())
                 }
-                Retrieve(account_name, password) => {
+                GenerateAndRetrieve(account_name, password) => {
                     let dams_client =
                         DamsClient::authenticated_client(account_name, password, config).await?;
                     let (key_id, _) = dams_client.generate_and_store().await?;
@@ -331,7 +330,7 @@ enum Operation {
     Register(AccountName, Password),
     Authenticate(AccountName, Password),
     Generate(AccountName, Password),
-    Retrieve(AccountName, Password),
+    GenerateAndRetrieve(AccountName, Password),
 }
 
 #[derive(Debug)]

--- a/dams-tests/tests/main.rs
+++ b/dams-tests/tests/main.rs
@@ -7,7 +7,7 @@ use crate::{
 use common::{get_logs, LogType, Party};
 use dams_key_server::database::Database;
 
-use dams::{config::client::Config, user::AccountName};
+use dams::{config::client::Config, user::AccountName, RetrieveContext};
 use dams_client::{client::Password, DamsClient, DamsClientError};
 use std::{fs::OpenOptions, str::FromStr};
 use thiserror::Error;
@@ -262,7 +262,7 @@ impl Test {
                         DamsClient::authenticated_client(account_name, password, config).await?;
                     let (key_id, _) = dams_client.generate_and_store().await?;
                     dams_client
-                        .retrieve(&key_id, None)
+                        .retrieve(&key_id, RetrieveContext::Null)
                         .await
                         .map(|_| ())
                         .map_err(|e| e.into())

--- a/dams/proto/dams_rpc.proto
+++ b/dams/proto/dams_rpc.proto
@@ -6,6 +6,7 @@ service DamsRpc {
   rpc Authenticate (stream Message) returns (stream Message);
   rpc CreateStorageKey (stream Message) returns (stream Message);
   rpc Generate (stream Message) returns (stream Message);
+  rpc Retrieve (stream Message) returns (stream Message);
   rpc RetrieveStorageKey (stream Message) returns (stream Message);
 }
 

--- a/dams/src/crypto.rs
+++ b/dams/src/crypto.rs
@@ -193,8 +193,9 @@ impl Encrypted<Secret> {
     /// retrieve a secret from the server.
     ///
     /// This must be run by the client.
-    pub fn decrypt_secret(self, storage_key: StorageKey) -> Result<Secret, CryptoError> {
-        self.decrypt(&storage_key.0)
+    pub fn decrypt_secret(self, storage_key: StorageKey) -> Result<Secret, DamsError> {
+        let decrypted = self.decrypt(&storage_key.0)?;
+        Ok(decrypted)
     }
 }
 

--- a/dams/src/lib.rs
+++ b/dams/src/lib.rs
@@ -46,6 +46,14 @@ pub enum ClientAction {
     RetrieveStorageKey,
 }
 
+/// Options for the asset owner's intended use of a secret
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum RetrieveContext {
+    Null,
+    LocalOnly,
+    Export,
+}
+
 /// Logs used to verify that an operation completed in the integration tests.
 #[derive(Debug)]
 pub enum TestLogs {

--- a/dams/src/lib.rs
+++ b/dams/src/lib.rs
@@ -42,6 +42,7 @@ pub enum ClientAction {
     Authenticate,
     CreateStorageKey,
     Generate,
+    Retrieve,
     RetrieveStorageKey,
 }
 

--- a/dams/src/types.rs
+++ b/dams/src/types.rs
@@ -2,6 +2,7 @@ pub mod authenticate;
 pub mod create_storage_key;
 pub mod generate;
 pub mod register;
+pub mod retrieve;
 pub mod retrieve_storage_key;
 
 use tokio_stream::wrappers::ReceiverStream;

--- a/dams/src/types/retrieve.rs
+++ b/dams/src/types/retrieve.rs
@@ -1,10 +1,6 @@
 pub mod client {
-    use crate::{
-        impl_message_conversion,
-        user::UserId,
-    };
+    use crate::{crypto::KeyId, impl_message_conversion, user::UserId};
     use serde::{Deserialize, Serialize};
-    use crate::crypto::KeyId;
 
     #[derive(Debug, Deserialize, Serialize)]
     /// pass user ID and key ID to server
@@ -17,9 +13,8 @@ pub mod client {
 }
 
 pub mod server {
-    use crate::impl_message_conversion;
+    use crate::{impl_message_conversion, user::StoredSecret};
     use serde::{Deserialize, Serialize};
-    use crate::user::StoredSecret;
 
     #[derive(Debug, Deserialize, Serialize)]
     /// return new requested key and key ID

--- a/dams/src/types/retrieve.rs
+++ b/dams/src/types/retrieve.rs
@@ -1,5 +1,5 @@
 pub mod client {
-    use crate::{crypto::KeyId, impl_message_conversion, user::UserId};
+    use crate::{crypto::KeyId, impl_message_conversion, user::UserId, RetrieveContext};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
@@ -7,6 +7,7 @@ pub mod client {
     pub struct Request {
         pub user_id: UserId,
         pub key_id: KeyId,
+        pub context: RetrieveContext,
     }
 
     impl_message_conversion!(Request);

--- a/dams/src/types/retrieve.rs
+++ b/dams/src/types/retrieve.rs
@@ -1,0 +1,31 @@
+pub mod client {
+    use crate::{
+        impl_message_conversion,
+        user::UserId,
+    };
+    use serde::{Deserialize, Serialize};
+    use crate::crypto::KeyId;
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// pass user ID and key ID to server
+    pub struct Request {
+        pub user_id: UserId,
+        pub key_id: KeyId,
+    }
+
+    impl_message_conversion!(Request);
+}
+
+pub mod server {
+    use crate::impl_message_conversion;
+    use serde::{Deserialize, Serialize};
+    use crate::user::StoredSecret;
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// return new requested key and key ID
+    pub struct Response {
+        pub stored_secret: StoredSecret,
+    }
+
+    impl_message_conversion!(Response);
+}

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -89,8 +89,8 @@ impl AccountName {
 /// Wrapper around an [`Encrypted<Secret>`] and its [`KeyId`]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct StoredSecret {
-    secret: Encrypted<Secret>,
-    key_id: KeyId,
+    pub secret: Encrypted<Secret>,
+    pub key_id: KeyId,
 }
 
 impl StoredSecret {

--- a/dams/src/user.rs
+++ b/dams/src/user.rs
@@ -91,11 +91,16 @@ impl AccountName {
 pub struct StoredSecret {
     pub secret: Encrypted<Secret>,
     pub key_id: KeyId,
+    pub retrieved: bool,
 }
 
 impl StoredSecret {
     pub fn new(secret: Encrypted<Secret>, key_id: KeyId) -> Self {
-        Self { secret, key_id }
+        Self {
+            secret,
+            key_id,
+            retrieved: false,
+        }
     }
 }
 


### PR DESCRIPTION
Closes #73 

Aside from regular review I have a few questions:
- @indomitableSwan There is a section in the spec that says to "update the database record to indicate that the secret has been retrieved by the client". Besides logging, was there something else you wanted to happen here?
- Logging
    - I'm having issues logging things that only have one helper function call in the server (i.e. retrieve and retrieve_storage_key) because I can't get the UserId/AccountName out of the result and then call `.log()` on the same result.
    - Is it reasonable/possible to only call `.log` on results that contain an `impl LogIdentifier` and make all the "last" helper functions for each endpoint return a UserId/AccountName in its result so that we can just pull it from there instead of passing it in?
- Testing
    - There's a dummy test in there that just makes sure no errors happen when retrieving, but how can I test that we got the right secret back? I have thoughts, but they might be easier to discuss on call.
    - Right now, I have to generate the secret in the same block as retrieving it so that I have access to the `KeyId` to pass to retrieve. Is there a way we can return things from the execute function to be available to future operations, so that I can separate the generate and retrieve operations?