### PR TITLE
216 test refactor

### DIFF
--- a/dams-tests/Cargo.toml
+++ b/dams-tests/Cargo.toml
@@ -13,6 +13,7 @@ dams-client = { version = "0.1.0", path = "../dams-client", features=["allow_exp
 futures = "0.3"
 mongodb = "2.3.0"
 rand = "0.8"
+serde_json = "1.0.85"
 structopt = "0.3"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }

--- a/dams-tests/Cargo.toml
+++ b/dams-tests/Cargo.toml
@@ -13,6 +13,7 @@ dams-client = { version = "0.1.0", path = "../dams-client", features=["allow_exp
 futures = "0.3"
 mongodb = "2.3.0"
 rand = "0.8"
+serde = "1"
 serde_json = "1.0.85"
 structopt = "0.3"
 thiserror = "1"

--- a/dams-tests/tests/end_to_end.rs
+++ b/dams-tests/tests/end_to_end.rs
@@ -77,7 +77,7 @@ pub async fn end_to_end_tests() {
 async fn tests() -> Vec<Test> {
     vec![
         Test::new(
-            "Register the same user twice user".to_string(),
+            "Register the same user twice user",
             vec![
                 (
                     Register,
@@ -96,7 +96,7 @@ async fn tests() -> Vec<Test> {
             ],
         ),
         Test::new(
-            "Register and open multiple sessions as a client to the server".to_string(),
+            "Register and open multiple sessions as a client to the server",
             vec![
                 (
                     Register,
@@ -122,8 +122,7 @@ async fn tests() -> Vec<Test> {
             ],
         ),
         Test::new(
-            "Register and authenticate with wrong password fails as a client to the server"
-                .to_string(),
+            "Register and authenticate with wrong password fails as a client to the server",
             vec![
                 (
                     Register,
@@ -142,7 +141,7 @@ async fn tests() -> Vec<Test> {
             ],
         ),
         Test::new(
-            "Authenticate with unregistered user fails".to_string(),
+            "Authenticate with unregistered user fails",
             vec![(
                 Authenticate(None),
                 Outcome {
@@ -152,7 +151,7 @@ async fn tests() -> Vec<Test> {
             )],
         ),
         Test::new(
-            "Generate a secret".to_string(),
+            "Generate a secret",
             vec![
                 (
                     Register,
@@ -171,7 +170,7 @@ async fn tests() -> Vec<Test> {
             ],
         ),
         Test::new(
-            "Retrieve a secret".to_string(),
+            "Retrieve a secret",
             vec![
                 (
                     Register,
@@ -251,13 +250,13 @@ impl Test {
             .collect()
     }
 
-    fn new(name: String, operations: Vec<(Operation, Outcome)>) -> Self {
+    fn new(name: impl Into<String>, operations: Vec<(Operation, Outcome)>) -> Self {
         let tag = Self::generate_tag();
         let account_name = AccountName::from_str(format!("{}-{}", USER, tag).as_str()).unwrap();
         let password = Password::from_str(format!("{}-{}", PASSWORD, tag).as_str()).unwrap();
 
         Self {
-            name,
+            name: name.into(),
             account_name,
             password,
             operations,


### PR DESCRIPTION
Closes #216 

There is more work to do to make this structure a bit more flexible (especially to test incorrect behavior on purpose) but this first pass at keeping state in the `Test` object should let us make more meaningful generate and retrieve tests.