### PR TITLE
Test to verify correct storage key is stored #208

### DIFF
--- a/dams-client/src/client.rs
+++ b/dams-client/src/client.rs
@@ -65,7 +65,7 @@ pub struct DamsClient {
 /// Connection type used by `DamsRpcClient`.
 /// This would normally be `tonic::transport:Channel` but TLS makes it more
 /// complicated.
-type DamsRpcClientInner = hyper::Client<
+pub type DamsRpcClientInner = hyper::Client<
     HttpsConnector<HttpConnector>,
     UnsyncBoxBody<tonic::codegen::Bytes, tonic::Status>,
 >;
@@ -128,7 +128,10 @@ impl DamsClient {
         Self::authenticate(client, account_name, password, config).await
     }
 
-    async fn authenticate(
+    /// Authenticate to the DAMS key server if you already have an RPC client.
+    /// `DamsClient::authenticated_client` is the standard method for
+    /// authentication.
+    pub async fn authenticate(
         mut client: DamsRpcClient<DamsRpcClientInner>,
         account_name: &AccountName,
         password: &Password,
@@ -204,7 +207,7 @@ impl DamsClient {
 
     /// Helper to create the appropriate [`ClientChannel`] to send to tonic
     /// handler functions based on the client's action.
-    pub(crate) async fn create_channel(
+    pub async fn create_channel(
         client: &mut DamsRpcClient<DamsRpcClientInner>,
         action: ClientAction,
     ) -> Result<ClientChannel, DamsClientError> {

--- a/dams-tests/Cargo.toml
+++ b/dams-tests/Cargo.toml
@@ -11,7 +11,10 @@ dams = { version = "0.1.0", path = "../dams" }
 dams-key-server = { version = "0.1.0", path = "../dams-key-server" }
 dams-client = { version = "0.1.0", path = "../dams-client", features=["allow_explicit_certificate_trust"] }
 futures = "0.3"
+hyper = "0.14"
+hyper-rustls = { version = "0.23", features = ["http2"] }
 mongodb = "2.3.0"
+opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
 rand = "0.8"
 serde = "1"
 serde_json = "1.0.85"

--- a/dams-tests/tests/register.rs
+++ b/dams-tests/tests/register.rs
@@ -1,0 +1,117 @@
+use std::str::FromStr;
+
+use anyhow::Result;
+use dams::{
+    channel::ClientChannel, config::opaque::OpaqueCipherSuite, crypto::OpaqueExportKey,
+    user::AccountName, ClientAction,
+};
+use dams_client::{client::Password, DamsClient};
+use opaque_ke::ClientRegistration;
+use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
+
+mod common;
+
+#[tokio::test]
+pub async fn test_storage_key_stored_correctly() -> Result<()> {
+    use dams::types::create_storage_key::{client, server};
+
+    let context = common::setup().await;
+
+    let account_name = AccountName::from_str("testUser")?;
+    let password = Password::from_str("testPassword")?;
+    let config = context.client_config.clone();
+    let mut rng = StdRng::from_entropy();
+    let mut rpc_client = common::create_rpc_client(&config)?;
+
+    // Register
+    let register_channel =
+        DamsClient::create_channel(&mut rpc_client, ClientAction::Register).await?;
+    let export_key =
+        handle_registration(register_channel, &mut rng, &account_name, &password).await?;
+
+    // Authenticate
+    let _ = DamsClient::authenticate(rpc_client.clone(), &account_name, &password, &config).await?;
+
+    // Manually run through storage key creation so we can keep a copy of the
+    // storage key to check later
+    let mut create_sk_channel =
+        DamsClient::create_channel(&mut rpc_client, ClientAction::CreateStorageKey).await?;
+
+    // Request user id
+    let request = client::RequestUserId {
+        account_name: account_name.clone(),
+    };
+    create_sk_channel.send(request).await?;
+    let user_id = create_sk_channel
+        .receive::<server::SendUserId>()
+        .await?
+        .user_id;
+
+    // Create storage key
+    let storage_key = export_key.create_and_encrypt_storage_key(&mut rng, &user_id)?;
+
+    // Send storage key back to server
+    let response = client::SendStorageKey {
+        user_id,
+        storage_key: storage_key.clone(),
+    };
+    create_sk_channel.send(response).await?;
+    let result: server::CreateStorageKeyResult = create_sk_channel.receive().await?;
+    assert!(result.success);
+
+    // Get user from database
+    let user = context.database.find_user(&account_name).await?.unwrap();
+
+    assert!(user.storage_key.is_some());
+    let stored_storage_key = user.storage_key.unwrap();
+
+    // Compare generated storage key to database value
+    assert_eq!(storage_key, stored_storage_key);
+
+    context.teardown().await;
+
+    Ok(())
+}
+
+/// Reimplements this private function from [`DamsClient`].
+/// This should not be part of the public interface for [`DamsClient`].
+async fn handle_registration<T: CryptoRng + RngCore>(
+    mut channel: ClientChannel,
+    rng: &mut T,
+    account_name: &AccountName,
+    password: &Password,
+) -> Result<OpaqueExportKey> {
+    use dams::types::register::{client, server};
+
+    let client_start_result =
+        ClientRegistration::<OpaqueCipherSuite>::start(rng, password.as_bytes()).unwrap();
+
+    let response = client::RegisterStart {
+        registration_request: client_start_result.message.clone(),
+        account_name: account_name.clone(),
+    };
+
+    channel.send(response).await?;
+
+    let server_start_result: server::RegisterStart = channel.receive().await?;
+
+    let client_finish_registration_result = client_start_result
+        .state
+        .finish(
+            rng,
+            password.as_bytes(),
+            server_start_result.registration_response,
+            Default::default(),
+        )
+        .unwrap();
+
+    let response = client::RegisterFinish {
+        registration_upload: client_finish_registration_result.message,
+    };
+    channel.send(response).await?;
+
+    let result: server::RegisterFinish = channel.receive().await?;
+    assert!(result.success);
+
+    Ok(client_finish_registration_result.export_key.into())
+}


### PR DESCRIPTION
This PR checks a generated storage key against the storage key stored in the database after registration.

This test has to insert itself into the normal registration flow so that it can keep a copy of the storage key it generates and sends to the server. In order to avoid a bunch of duplicate logic, I made the `DamsClient::authenticate` method public. This method is not abusable or easy to misuse so I think it's safe to be public. I added a note that the caller should prefer `DamsClient::authenticate_client`.

Unfortunately I couldn't do the same thing with `handle_registration` since it can be used to create a broken user who doesn't have a storage key. I messed around with feature flags but ultimately I just copied the handler code to into the test module. 

Having written this test, I'm wondering if this sort of test case is even useful. I think the same error conditions can be tested through normal generate and retrieve tests that depend on the storage key being correct.

Closes #208