### PR TITLE
232 improve logging

### DIFF
--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -115,10 +115,11 @@ pub fn retrieve_public_key_by_id(
     todo!()
 }
 
-/// Retrieve the audit log from the key server for a specified asset owner;
-/// optionally, filter for logs associated with the specified [`KeyId`].
+/// Retrieve the log of audit events from the key server for a specified asset
+/// owner; optionally, filter for audit events associated with the specified
+/// [`KeyId`].
 ///
-/// The audit log includes context
+/// The log of audit events includes context
 /// about any action requested and/or taken on the digital asset key, including
 /// which action was requested and by whom, the date, details about approval or
 /// rejection from each key server, the policy engine, and each asset fiduciary
@@ -130,7 +131,7 @@ pub fn retrieve_public_key_by_id(
 ///
 /// Output: if successful, returns a [`String`] representation of the logs.
 #[allow(unused)]
-pub fn retrieve_audit_log(
+pub fn retrieve_audit_event_log(
     user_id: UserId,
     key_id: Option<&KeyId>,
 ) -> Result<String, LockKeeperClientError> {

--- a/lock-keeper-client/src/api/arbitrary_secrets.rs
+++ b/lock-keeper-client/src/api/arbitrary_secrets.rs
@@ -28,9 +28,12 @@ impl LockKeeperClient {
     /// to the user specified by `user_id`
     async fn retrieve_storage_key(&self) -> Result<StorageKey, LockKeeperClientError> {
         // Create channel to send messages to server
-        let mut channel =
-            Self::create_channel(&mut self.tonic_client(), ClientAction::RetrieveStorageKey)
-                .await?;
+        let mut channel = Self::create_channel(
+            &mut self.tonic_client(),
+            ClientAction::RetrieveStorageKey,
+            self.account_name(),
+        )
+        .await?;
 
         // Send UserId to server
         let request = client::Request {
@@ -50,8 +53,12 @@ impl LockKeeperClient {
 
     /// Generate and store an arbitrary secret at the key server
     pub async fn generate_and_store(&self) -> Result<(KeyId, LocalStorage), LockKeeperClientError> {
-        let mut client_channel =
-            Self::create_channel(&mut self.tonic_client(), ClientAction::Generate).await?;
+        let mut client_channel = Self::create_channel(
+            &mut self.tonic_client(),
+            ClientAction::Generate,
+            self.account_name(),
+        )
+        .await?;
         self.handle_generate(&mut client_channel).await
     }
 
@@ -61,8 +68,12 @@ impl LockKeeperClient {
         key_id: &KeyId,
         context: RetrieveContext,
     ) -> Result<RetrieveResult, LockKeeperClientError> {
-        let mut client_channel =
-            Self::create_channel(&mut self.tonic_client(), ClientAction::Retrieve).await?;
+        let mut client_channel = Self::create_channel(
+            &mut self.tonic_client(),
+            ClientAction::Retrieve,
+            self.account_name(),
+        )
+        .await?;
         self.handle_retrieve(&mut client_channel, key_id, context)
             .await
     }

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -227,8 +227,7 @@ impl LockKeeperClient {
         let (tx, rx) = mpsc::channel(2);
         let mut stream = Request::new(ReceiverStream::new(rx));
 
-        let account_name_val = MetadataValue::try_from(account_name.to_string())
-            .map_err(|_| LockKeeperClientError::InvalidAccount)?;
+        let account_name_val = MetadataValue::try_from(account_name.to_string())?;
         let _ = stream
             .metadata_mut()
             .insert("account_name", account_name_val);

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -9,6 +9,7 @@ use lock_keeper::{
     channel::ClientChannel,
     config::client::Config,
     crypto::{OpaqueExportKey, OpaqueSessionKey},
+    defaults::client::ACCOUNT_NAME,
     rpc::lock_keeper_rpc_client::LockKeeperRpcClient,
     user::{AccountName, UserId},
     ClientAction,
@@ -228,9 +229,7 @@ impl LockKeeperClient {
         let mut stream = Request::new(ReceiverStream::new(rx));
 
         let account_name_val = MetadataValue::try_from(account_name.to_string())?;
-        let _ = stream
-            .metadata_mut()
-            .insert("account_name", account_name_val);
+        let _ = stream.metadata_mut().insert(ACCOUNT_NAME, account_name_val);
 
         // Server returns its own channel that is uses to send responses
         let server_response = match action {

--- a/lock-keeper-client/src/error.rs
+++ b/lock-keeper-client/src/error.rs
@@ -24,6 +24,8 @@ pub enum LockKeeperClientError {
     #[error("OPAQUE protocol error: {}", .0)]
     OpaqueProtocol(opaque_ke::errors::ProtocolError),
     #[error(transparent)]
+    TonicMetadata(#[from] tonic::metadata::errors::InvalidMetadataValue),
+    #[error(transparent)]
     TonicStatus(Status),
     #[error(transparent)]
     TonicTransport(#[from] tonic::transport::Error),

--- a/lock-keeper-key-server/src/constants.rs
+++ b/lock-keeper-key-server/src/constants.rs
@@ -2,5 +2,5 @@
 
 /* DB TABLE NAMES */
 /// Name of MongoDB users table.
-pub(crate) const LOGS: &str = "logs";
+pub(crate) const AUDIT_EVENTS: &str = "audit_events";
 pub(crate) const USERS: &str = "users";

--- a/lock-keeper-key-server/src/database.rs
+++ b/lock-keeper-key-server/src/database.rs
@@ -4,7 +4,11 @@
 //! they have stored in the key server.
 
 use crate::constants;
-use lock_keeper::{config::server::DatabaseSpec, user::User};
+use lock_keeper::{
+    config::server::DatabaseSpec,
+    defaults::server::{ACCOUNT_NAME, USER_ID},
+    user::User,
+};
 use mongodb::{
     bson::doc,
     options::{ClientOptions, IndexOptions},
@@ -34,14 +38,14 @@ impl Database {
         // Enforce that the user ID is unique
         let enforce_uniqueness = IndexOptions::builder().unique(true).build();
         let user_id_index = IndexModel::builder()
-            .keys(doc! {"user_id": 1})
+            .keys(doc! {USER_ID: 1})
             .options(enforce_uniqueness)
             .build();
 
         // Enforce that the account name is unique
         let enforce_uniqueness = IndexOptions::builder().unique(true).build();
         let account_name_index = IndexModel::builder()
-            .keys(doc! {"account_name": 1})
+            .keys(doc! {ACCOUNT_NAME: 1})
             .options(enforce_uniqueness)
             .build();
 

--- a/lock-keeper-key-server/src/database.rs
+++ b/lock-keeper-key-server/src/database.rs
@@ -13,7 +13,7 @@ use mongodb::{
 
 use crate::error::LockKeeperServerError;
 
-pub(crate) mod log;
+pub(crate) mod audit_event;
 pub(crate) mod user;
 
 #[derive(Clone, Debug)]

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -3,20 +3,13 @@
 //! Functions in this module are used to perform CRUD operations
 //! on the [`AuditEvent`] model in the MongoDB database.
 
-use crate::{
-    constants,
-    server::{Context, OperationResult},
-    LockKeeperServerError,
-};
-use async_trait::async_trait;
+use crate::{constants, LockKeeperServerError};
 use lock_keeper::{
     audit_event::{AuditEvent, Outcome},
-    channel::ServerChannel,
     crypto::KeyId,
     user::AccountName,
     ClientAction,
 };
-use std::{thread, time::Duration};
 
 use super::Database;
 
@@ -33,51 +26,5 @@ impl Database {
         let new_event = AuditEvent::new(actor.clone(), secret_id, action, outcome);
         let _ = collection.insert_one(new_event, None).await?;
         Ok(())
-    }
-}
-
-#[async_trait]
-pub trait AuditEventExt {
-    async fn log_audit_event(
-        self,
-        channel: &mut ServerChannel,
-        context: &Context,
-        action: ClientAction,
-    ) -> Result<(), LockKeeperServerError>;
-}
-
-#[async_trait]
-impl AuditEventExt for Result<OperationResult, LockKeeperServerError> {
-    async fn log_audit_event(
-        self,
-        channel: &mut ServerChannel,
-        context: &Context,
-        action: ClientAction,
-    ) -> Result<(), LockKeeperServerError> {
-        match self {
-            Ok(op_result) => Ok(context
-                .db
-                .create_audit_event(
-                    &context.account_name,
-                    op_result.0,
-                    action,
-                    Outcome::Successful,
-                )
-                .await?),
-            Err(e) => {
-                tracing::error!("{}", e);
-                if let Err(e) = channel.send_error(e).await {
-                    tracing::error!("{}", e);
-                }
-                // Log action
-                context
-                    .db
-                    .create_audit_event(&context.account_name, None, action, Outcome::Failed)
-                    .await?;
-                // Give the client a moment to receive the error before dropping the channel
-                thread::sleep(Duration::from_millis(100));
-                Ok(())
-            }
-        }
     }
 }

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -18,12 +18,12 @@ impl Database {
     pub async fn create_audit_event(
         &self,
         actor: &AccountName,
-        secret_id: Option<KeyId>,
-        action: ClientAction,
+        secret_id: &Option<KeyId>,
+        action: &ClientAction,
         outcome: Outcome,
     ) -> Result<(), LockKeeperServerError> {
         let collection = self.inner.collection::<AuditEvent>(constants::AUDIT_EVENTS);
-        let new_event = AuditEvent::new(actor.clone(), secret_id, action, outcome);
+        let new_event = AuditEvent::new(actor.clone(), secret_id.clone(), action.clone(), outcome);
         let _ = collection.insert_one(new_event, None).await?;
         Ok(())
     }

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -5,7 +5,7 @@
 
 use crate::{constants, LockKeeperServerError};
 use lock_keeper::{
-    audit_event::{AuditEvent, Outcome},
+    audit_event::{AuditEvent, EventStatus},
     crypto::KeyId,
     user::AccountName,
     ClientAction,
@@ -20,10 +20,10 @@ impl Database {
         actor: &AccountName,
         secret_id: &Option<KeyId>,
         action: &ClientAction,
-        outcome: Outcome,
+        status: EventStatus,
     ) -> Result<(), LockKeeperServerError> {
         let collection = self.inner.collection::<AuditEvent>(constants::AUDIT_EVENTS);
-        let new_event = AuditEvent::new(actor.clone(), secret_id.clone(), action.clone(), outcome);
+        let new_event = AuditEvent::new(actor.clone(), secret_id.clone(), action.clone(), status);
         let _ = collection.insert_one(new_event, None).await?;
         Ok(())
     }

--- a/lock-keeper-key-server/src/database/log.rs
+++ b/lock-keeper-key-server/src/database/log.rs
@@ -3,14 +3,17 @@
 //! Functions in this module are used to perform CRUD operations
 //! on the [`LogEntry`] model in the MongoDB database.
 
-use crate::{constants, LockKeeperServerError};
+use crate::{constants, server::Context, LockKeeperServerError};
 use async_trait::async_trait;
 use lock_keeper::{
     audit_log::{LogEntry, Outcome},
+    channel::ServerChannel,
     crypto::KeyId,
-    user::LogIdentifier,
+    user::AccountName,
     ClientAction,
 };
+use std::{thread, time::Duration};
+use tonic::Status;
 
 use super::Database;
 
@@ -18,13 +21,13 @@ impl Database {
     /// Create a new [`LogEntry`] for the given actor, action, and outcome
     pub async fn create_log_entry(
         &self,
-        actor: impl Into<LogIdentifier> + std::marker::Send,
+        actor: &AccountName,
         secret_id: Option<KeyId>,
         action: ClientAction,
         outcome: Outcome,
     ) -> Result<(), LockKeeperServerError> {
         let collection = self.inner.collection::<LogEntry>(constants::LOGS);
-        let new_log = LogEntry::new(actor.into(), secret_id, action, outcome);
+        let new_log = LogEntry::new(actor.clone(), secret_id, action, outcome);
         let _ = collection.insert_one(new_log, None).await?;
         Ok(())
     }
@@ -34,29 +37,49 @@ impl Database {
 pub trait AuditLogExt {
     async fn audit_log(
         self,
-        db: &Database,
-        actor: impl Into<LogIdentifier> + std::marker::Send + 'async_trait,
+        channel: &mut ServerChannel,
+        context: &Context,
         secret_id: Option<KeyId>,
         action: ClientAction,
-    ) -> Self;
+    ) -> Result<(), LockKeeperServerError>;
 }
 
 #[async_trait]
 impl<T: std::marker::Send> AuditLogExt for Result<T, LockKeeperServerError> {
     async fn audit_log(
         self,
-        db: &Database,
-        actor: impl Into<LogIdentifier> + std::marker::Send + 'async_trait,
+        channel: &mut ServerChannel,
+        context: &Context,
         secret_id: Option<KeyId>,
         action: ClientAction,
-    ) -> Self {
+    ) -> Result<(), LockKeeperServerError> {
         if self.is_err() {
-            db.create_log_entry(actor, secret_id, action, Outcome::Failed)
+            // Send error to client
+            let e = self
+                .err()
+                .ok_or_else(|| Status::internal("Unable to unwrap error"))?;
+            tracing::error!("{}", e);
+            if let Err(e) = channel.send_error(e).await {
+                tracing::error!("{}", e);
+            }
+            // Log action
+            context
+                .db
+                .create_log_entry(&context.account_name, secret_id, action, Outcome::Failed)
                 .await?;
+            // Give the client a moment to receive the error before dropping the channel
+            thread::sleep(Duration::from_millis(100));
+            Ok(())
         } else {
-            db.create_log_entry(actor, secret_id, action, Outcome::Successful)
-                .await?;
+            Ok(context
+                .db
+                .create_log_entry(
+                    &context.account_name,
+                    secret_id,
+                    action,
+                    Outcome::Successful,
+                )
+                .await?)
         }
-        self
     }
 }

--- a/lock-keeper-key-server/src/database/user.rs
+++ b/lock-keeper-key-server/src/database/user.rs
@@ -7,6 +7,7 @@ use crate::{constants, LockKeeperServerError};
 use lock_keeper::{
     config::opaque::OpaqueCipherSuite,
     crypto::{Encrypted, KeyId, Secret, StorageKey},
+    defaults::server::{ACCOUNT_NAME, USER_ID},
     user::{AccountName, StoredSecret, User, UserId},
 };
 use mongodb::bson::{doc, oid::ObjectId};
@@ -14,10 +15,8 @@ use opaque_ke::ServerRegistration;
 
 use super::Database;
 
-pub const ACCOUNT_NAME: &str = "account_name";
 pub const STORAGE_KEY: &str = "storage_key";
 pub const SECRETS: &str = "secrets";
-pub const USER_ID: &str = "user_id";
 
 impl Database {
     /// Create a new [`User`] with their authentication information and insert

--- a/lock-keeper-key-server/src/operations/authenticate.rs
+++ b/lock-keeper-key-server/src/operations/authenticate.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::LockKeeperServerError,
-    server::{Context, Operation, OperationResult},
+    server::{Context, Operation},
 };
 
 use async_trait::async_trait;
@@ -27,7 +27,7 @@ impl Operation for Authenticate {
         self,
         channel: &mut ServerChannel,
         context: &mut Context,
-    ) -> Result<OperationResult, LockKeeperServerError> {
+    ) -> Result<(), LockKeeperServerError> {
         let AuthenticateStartResult {
             login_start_result,
             user_id,
@@ -35,7 +35,7 @@ impl Operation for Authenticate {
         authenticate_finish(channel, login_start_result).await?;
         send_user_id(channel, user_id).await?;
 
-        Ok(OperationResult(None))
+        Ok(())
     }
 }
 

--- a/lock-keeper-key-server/src/operations/authenticate.rs
+++ b/lock-keeper-key-server/src/operations/authenticate.rs
@@ -26,7 +26,7 @@ impl Operation for Authenticate {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: &Context,
+        context: &mut Context,
     ) -> Result<OperationResult, LockKeeperServerError> {
         let AuthenticateStartResult {
             login_start_result,

--- a/lock-keeper-key-server/src/operations/authenticate.rs
+++ b/lock-keeper-key-server/src/operations/authenticate.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::LockKeeperServerError,
-    server::{Context, Operation},
+    server::{Context, Operation, OperationResult},
 };
 
 use async_trait::async_trait;
@@ -27,7 +27,7 @@ impl Operation for Authenticate {
         self,
         channel: &mut ServerChannel,
         context: &Context,
-    ) -> Result<(), LockKeeperServerError> {
+    ) -> Result<OperationResult, LockKeeperServerError> {
         let AuthenticateStartResult {
             login_start_result,
             user_id,
@@ -35,7 +35,7 @@ impl Operation for Authenticate {
         authenticate_finish(channel, login_start_result).await?;
         send_user_id(channel, user_id).await?;
 
-        Ok(())
+        Ok(OperationResult(None))
     }
 }
 

--- a/lock-keeper-key-server/src/operations/create_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/create_storage_key.rs
@@ -18,10 +18,10 @@ impl Operation for CreateStorageKey {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: Context,
+        context: &Context,
     ) -> Result<(), LockKeeperServerError> {
-        let user_id = send_user_id(channel, &context).await?;
-        store_storage_key(user_id, channel, &context).await?;
+        let user_id = send_user_id(channel, context).await?;
+        store_storage_key(user_id, channel, context).await?;
         Ok(())
     }
 }

--- a/lock-keeper-key-server/src/operations/create_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/create_storage_key.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::LockKeeperServerError,
-    server::{Context, Operation, OperationResult},
+    server::{Context, Operation},
 };
 
 use async_trait::async_trait;
@@ -19,10 +19,10 @@ impl Operation for CreateStorageKey {
         self,
         channel: &mut ServerChannel,
         context: &mut Context,
-    ) -> Result<OperationResult, LockKeeperServerError> {
+    ) -> Result<(), LockKeeperServerError> {
         let user_id = send_user_id(channel, context).await?;
         store_storage_key(user_id, channel, context).await?;
-        Ok(OperationResult(None))
+        Ok(())
     }
 }
 

--- a/lock-keeper-key-server/src/operations/create_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/create_storage_key.rs
@@ -18,7 +18,7 @@ impl Operation for CreateStorageKey {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: &Context,
+        context: &mut Context,
     ) -> Result<OperationResult, LockKeeperServerError> {
         let user_id = send_user_id(channel, context).await?;
         store_storage_key(user_id, channel, context).await?;

--- a/lock-keeper-key-server/src/operations/create_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/create_storage_key.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::LockKeeperServerError,
-    server::{Context, Operation},
+    server::{Context, Operation, OperationResult},
 };
 
 use async_trait::async_trait;
@@ -19,10 +19,10 @@ impl Operation for CreateStorageKey {
         self,
         channel: &mut ServerChannel,
         context: &Context,
-    ) -> Result<(), LockKeeperServerError> {
+    ) -> Result<OperationResult, LockKeeperServerError> {
         let user_id = send_user_id(channel, context).await?;
         store_storage_key(user_id, channel, context).await?;
-        Ok(())
+        Ok(OperationResult(None))
     }
 }
 

--- a/lock-keeper-key-server/src/operations/generate.rs
+++ b/lock-keeper-key-server/src/operations/generate.rs
@@ -70,7 +70,5 @@ async fn store_key(
     let reply = server::Store { success: true };
     channel.send(reply).await?;
 
-    // TODO #67 (implementation): Log that a new key was generated and stored
-
     Ok(())
 }

--- a/lock-keeper-key-server/src/operations/generate.rs
+++ b/lock-keeper-key-server/src/operations/generate.rs
@@ -1,5 +1,5 @@
 use crate::{
-    server::{Context, Operation},
+    server::{Context, Operation, OperationResult},
     LockKeeperServerError,
 };
 
@@ -19,13 +19,13 @@ impl Operation for Generate {
         self,
         channel: &mut ServerChannel,
         context: &Context,
-    ) -> Result<(), LockKeeperServerError> {
+    ) -> Result<OperationResult, LockKeeperServerError> {
         // Generate step: receive UserId and reply with new KeyId
         let key_id = generate_key(channel, context).await?;
 
         // Store step: receive ciphertext from client and store in DB
         store_key(channel, context, &key_id).await?;
-        Ok(())
+        Ok(OperationResult(Some(key_id)))
     }
 }
 

--- a/lock-keeper-key-server/src/operations/generate.rs
+++ b/lock-keeper-key-server/src/operations/generate.rs
@@ -1,5 +1,5 @@
 use crate::{
-    server::{Context, Operation, OperationResult},
+    server::{Context, Operation},
     LockKeeperServerError,
 };
 
@@ -19,14 +19,14 @@ impl Operation for Generate {
         self,
         channel: &mut ServerChannel,
         context: &mut Context,
-    ) -> Result<OperationResult, LockKeeperServerError> {
+    ) -> Result<(), LockKeeperServerError> {
         // Generate step: receive UserId and reply with new KeyId
         let key_id = generate_key(channel, context).await?;
         context.key_id = Some(key_id.clone());
 
         // Store step: receive ciphertext from client and store in DB
         store_key(channel, context, &key_id).await?;
-        Ok(OperationResult(Some(key_id)))
+        Ok(())
     }
 }
 

--- a/lock-keeper-key-server/src/operations/generate.rs
+++ b/lock-keeper-key-server/src/operations/generate.rs
@@ -18,10 +18,11 @@ impl Operation for Generate {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: &Context,
+        context: &mut Context,
     ) -> Result<OperationResult, LockKeeperServerError> {
         // Generate step: receive UserId and reply with new KeyId
         let key_id = generate_key(channel, context).await?;
+        context.key_id = Some(key_id.clone());
 
         // Store step: receive ciphertext from client and store in DB
         store_key(channel, context, &key_id).await?;

--- a/lock-keeper-key-server/src/operations/generate.rs
+++ b/lock-keeper-key-server/src/operations/generate.rs
@@ -1,5 +1,4 @@
 use crate::{
-    database::log::AuditLogExt,
     server::{Context, Operation},
     LockKeeperServerError,
 };
@@ -9,8 +8,6 @@ use lock_keeper::{
     channel::ServerChannel,
     crypto::KeyId,
     types::generate::{client, server},
-    user::UserId,
-    ClientAction,
 };
 
 #[derive(Debug)]
@@ -21,16 +18,13 @@ impl Operation for Generate {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: Context,
+        context: &Context,
     ) -> Result<(), LockKeeperServerError> {
         // Generate step: receive UserId and reply with new KeyId
-        let (key_id, user_id) = generate_key(channel, &context).await?;
+        let key_id = generate_key(channel, context).await?;
 
         // Store step: receive ciphertext from client and store in DB
-        store_key(channel, &context, &key_id)
-            .await
-            .audit_log(&context.db, &user_id, Some(key_id), ClientAction::Generate)
-            .await?;
+        store_key(channel, context, &key_id).await?;
         Ok(())
     }
 }
@@ -38,7 +32,7 @@ impl Operation for Generate {
 async fn generate_key(
     channel: &mut ServerChannel,
     context: &Context,
-) -> Result<(KeyId, UserId), LockKeeperServerError> {
+) -> Result<KeyId, LockKeeperServerError> {
     // Receive UserId from client
     let generate_message: client::Generate = channel.receive().await?;
     // Generate new KeyId
@@ -51,7 +45,7 @@ async fn generate_key(
         key_id: key_id.clone(),
     };
     channel.send(reply).await?;
-    Ok((key_id, generate_message.user_id))
+    Ok(key_id)
 }
 
 async fn store_key(

--- a/lock-keeper-key-server/src/operations/register.rs
+++ b/lock-keeper-key-server/src/operations/register.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::LockKeeperServerError,
-    server::{Context, Operation},
+    server::{Context, Operation, OperationResult},
 };
 use std::ops::DerefMut;
 
@@ -23,11 +23,11 @@ impl Operation for Register {
         self,
         channel: &mut ServerChannel,
         context: &Context,
-    ) -> Result<(), LockKeeperServerError> {
+    ) -> Result<OperationResult, LockKeeperServerError> {
         let account_name = register_start(channel, context).await?;
         register_finish(&account_name, channel, context).await?;
 
-        Ok(())
+        Ok(OperationResult(None))
     }
 }
 

--- a/lock-keeper-key-server/src/operations/register.rs
+++ b/lock-keeper-key-server/src/operations/register.rs
@@ -1,5 +1,4 @@
 use crate::{
-    database::log::AuditLogExt,
     error::LockKeeperServerError,
     server::{Context, Operation},
 };
@@ -12,7 +11,6 @@ use lock_keeper::{
     opaque_storage::create_or_retrieve_server_key_opaque,
     types::register::{client, server},
     user::{AccountName, UserId},
-    ClientAction,
 };
 use opaque_ke::ServerRegistration;
 
@@ -24,13 +22,10 @@ impl Operation for Register {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: Context,
+        context: &Context,
     ) -> Result<(), LockKeeperServerError> {
-        let account_name = register_start(channel, &context).await?;
-        register_finish(&account_name, channel, &context)
-            .await
-            .audit_log(&context.db, &account_name, None, ClientAction::Register)
-            .await?;
+        let account_name = register_start(channel, context).await?;
+        register_finish(&account_name, channel, context).await?;
 
         Ok(())
     }

--- a/lock-keeper-key-server/src/operations/register.rs
+++ b/lock-keeper-key-server/src/operations/register.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::LockKeeperServerError,
-    server::{Context, Operation, OperationResult},
+    server::{Context, Operation},
 };
 use std::ops::DerefMut;
 
@@ -23,11 +23,11 @@ impl Operation for Register {
         self,
         channel: &mut ServerChannel,
         context: &mut Context,
-    ) -> Result<OperationResult, LockKeeperServerError> {
+    ) -> Result<(), LockKeeperServerError> {
         let account_name = register_start(channel, context).await?;
         register_finish(&account_name, channel, context).await?;
 
-        Ok(OperationResult(None))
+        Ok(())
     }
 }
 

--- a/lock-keeper-key-server/src/operations/register.rs
+++ b/lock-keeper-key-server/src/operations/register.rs
@@ -22,7 +22,7 @@ impl Operation for Register {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: &Context,
+        context: &mut Context,
     ) -> Result<OperationResult, LockKeeperServerError> {
         let account_name = register_start(channel, context).await?;
         register_finish(&account_name, channel, context).await?;

--- a/lock-keeper-key-server/src/operations/retrieve.rs
+++ b/lock-keeper-key-server/src/operations/retrieve.rs
@@ -17,10 +17,11 @@ impl Operation for Retrieve {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: &Context,
+        context: &mut Context,
     ) -> Result<OperationResult, LockKeeperServerError> {
         // Receive UserId from client
         let request: client::Request = channel.receive().await?;
+        context.key_id = Some(request.key_id.clone());
 
         // Find secret based on key_id
         let stored_secret = context

--- a/lock-keeper-key-server/src/operations/retrieve.rs
+++ b/lock-keeper-key-server/src/operations/retrieve.rs
@@ -22,7 +22,6 @@ impl Operation for Retrieve {
         // Receive UserId from client
         let request: client::Request = channel.receive().await?;
 
-        // TODO #232: move this log so that we log the entire operation
         // Find secret based on key_id
         let stored_secret = context
             .db

--- a/lock-keeper-key-server/src/operations/retrieve.rs
+++ b/lock-keeper-key-server/src/operations/retrieve.rs
@@ -1,5 +1,5 @@
 use crate::{
-    server::{Context, Operation, OperationResult},
+    server::{Context, Operation},
     LockKeeperServerError,
 };
 
@@ -18,7 +18,7 @@ impl Operation for Retrieve {
         self,
         channel: &mut ServerChannel,
         context: &mut Context,
-    ) -> Result<OperationResult, LockKeeperServerError> {
+    ) -> Result<(), LockKeeperServerError> {
         // Receive UserId from client
         let request: client::Request = channel.receive().await?;
         context.key_id = Some(request.key_id.clone());
@@ -32,6 +32,6 @@ impl Operation for Retrieve {
         // Serialize KeyId and send to client
         let reply = server::Response { stored_secret };
         channel.send(reply).await?;
-        Ok(OperationResult(Some(request.key_id)))
+        Ok(())
     }
 }

--- a/lock-keeper-key-server/src/operations/retrieve.rs
+++ b/lock-keeper-key-server/src/operations/retrieve.rs
@@ -1,5 +1,4 @@
 use crate::{
-    database::log::AuditLogExt,
     server::{Context, Operation},
     LockKeeperServerError,
 };
@@ -8,7 +7,6 @@ use async_trait::async_trait;
 use lock_keeper::{
     channel::ServerChannel,
     types::retrieve::{client, server},
-    ClientAction,
 };
 
 #[derive(Debug)]
@@ -19,7 +17,7 @@ impl Operation for Retrieve {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: Context,
+        context: &Context,
     ) -> Result<(), LockKeeperServerError> {
         // Receive UserId from client
         let request: client::Request = channel.receive().await?;
@@ -29,13 +27,6 @@ impl Operation for Retrieve {
         let stored_secret = context
             .db
             .get_user_secret(&request.user_id, &request.key_id)
-            .await
-            .audit_log(
-                &context.db,
-                &request.user_id,
-                Some(request.key_id),
-                ClientAction::Retrieve,
-            )
             .await?;
 
         // Serialize KeyId and send to client

--- a/lock-keeper-key-server/src/operations/retrieve.rs
+++ b/lock-keeper-key-server/src/operations/retrieve.rs
@@ -1,5 +1,5 @@
 use crate::{
-    server::{Context, Operation},
+    server::{Context, Operation, OperationResult},
     LockKeeperServerError,
 };
 
@@ -18,7 +18,7 @@ impl Operation for Retrieve {
         self,
         channel: &mut ServerChannel,
         context: &Context,
-    ) -> Result<(), LockKeeperServerError> {
+    ) -> Result<OperationResult, LockKeeperServerError> {
         // Receive UserId from client
         let request: client::Request = channel.receive().await?;
 
@@ -32,6 +32,6 @@ impl Operation for Retrieve {
         // Serialize KeyId and send to client
         let reply = server::Response { stored_secret };
         channel.send(reply).await?;
-        Ok(())
+        Ok(OperationResult(Some(request.key_id)))
     }
 }

--- a/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
@@ -1,5 +1,5 @@
 use crate::{
-    server::{Context, Operation},
+    server::{Context, Operation, OperationResult},
     LockKeeperServerError,
 };
 use async_trait::async_trait;
@@ -17,7 +17,7 @@ impl Operation for RetrieveStorageKey {
         self,
         channel: &mut ServerChannel,
         context: &Context,
-    ) -> Result<(), LockKeeperServerError> {
+    ) -> Result<OperationResult, LockKeeperServerError> {
         // Receive user ID and retrieve encrypted storage key for that user
         let request: client::Request = channel.receive().await?;
 
@@ -37,6 +37,6 @@ impl Operation for RetrieveStorageKey {
         };
         channel.send(reply).await?;
 
-        Ok(())
+        Ok(OperationResult(None))
     }
 }

--- a/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
@@ -1,5 +1,5 @@
 use crate::{
-    server::{Context, Operation, OperationResult},
+    server::{Context, Operation},
     LockKeeperServerError,
 };
 use async_trait::async_trait;
@@ -17,7 +17,7 @@ impl Operation for RetrieveStorageKey {
         self,
         channel: &mut ServerChannel,
         context: &mut Context,
-    ) -> Result<OperationResult, LockKeeperServerError> {
+    ) -> Result<(), LockKeeperServerError> {
         // Receive user ID and retrieve encrypted storage key for that user
         let request: client::Request = channel.receive().await?;
 
@@ -37,6 +37,6 @@ impl Operation for RetrieveStorageKey {
         };
         channel.send(reply).await?;
 
-        Ok(OperationResult(None))
+        Ok(())
     }
 }

--- a/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
@@ -16,7 +16,7 @@ impl Operation for RetrieveStorageKey {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: Context,
+        context: &Context,
     ) -> Result<(), LockKeeperServerError> {
         // Receive user ID and retrieve encrypted storage key for that user
         let request: client::Request = channel.receive().await?;

--- a/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
@@ -16,7 +16,7 @@ impl Operation for RetrieveStorageKey {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: &Context,
+        context: &mut Context,
     ) -> Result<OperationResult, LockKeeperServerError> {
         // Receive user ID and retrieve encrypted storage key for that user
         let request: client::Request = channel.receive().await?;

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -9,6 +9,7 @@ use crate::{database::Database, error::LockKeeperServerError, operations};
 
 use lock_keeper::{
     config::server::{Config, Service},
+    defaults::server::ACCOUNT_NAME,
     rpc::lock_keeper_rpc_server::LockKeeperRpc,
     types::{Message, MessageStream},
     ClientAction,
@@ -52,7 +53,7 @@ impl LockKeeperKeyServer {
     ) -> Result<Context, Status> {
         let account_name_str = request
             .metadata()
-            .get("account_name")
+            .get(ACCOUNT_NAME)
             .ok_or_else(|| Status::unauthenticated("Account name not found"))?
             .to_str()
             .map_err(|_| Status::unauthenticated("Invalid account name"))?;

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -14,11 +14,13 @@ use lock_keeper::{
     ClientAction,
 };
 
-use lock_keeper::user::AccountName;
+use lock_keeper::{crypto::KeyId, user::AccountName};
 use rand::{rngs::StdRng, SeedableRng};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
+
+pub(crate) struct OperationResult(pub(crate) Option<KeyId>);
 
 #[allow(unused)]
 #[derive(Debug)]

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -11,6 +11,7 @@ use lock_keeper::{
     config::server::{Config, Service},
     rpc::lock_keeper_rpc_server::LockKeeperRpc,
     types::{Message, MessageStream},
+    ClientAction,
 };
 
 use lock_keeper::user::AccountName;
@@ -85,7 +86,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::RegisterStream>, Status> {
         let context = self.context(&request)?;
         Ok(operations::Register
-            .handle_request(context, request)
+            .handle_request(context, request, ClientAction::Register)
             .await?)
     }
 
@@ -95,7 +96,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::AuthenticateStream>, Status> {
         let context = self.context(&request)?;
         Ok(operations::Authenticate
-            .handle_request(context, request)
+            .handle_request(context, request, ClientAction::Authenticate)
             .await?)
     }
 
@@ -105,7 +106,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::CreateStorageKeyStream>, Status> {
         let context = self.context(&request)?;
         Ok(operations::CreateStorageKey
-            .handle_request(context, request)
+            .handle_request(context, request, ClientAction::CreateStorageKey)
             .await?)
     }
 
@@ -115,7 +116,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::GenerateStream>, Status> {
         let context = self.context(&request)?;
         Ok(operations::Generate
-            .handle_request(context, request)
+            .handle_request(context, request, ClientAction::Generate)
             .await?)
     }
 
@@ -125,7 +126,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::RetrieveStream>, Status> {
         let context = self.context(&request)?;
         Ok(operations::Retrieve
-            .handle_request(context, request)
+            .handle_request(context, request, ClientAction::Retrieve)
             .await?)
     }
 
@@ -135,7 +136,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::RetrieveStorageKeyStream>, Status> {
         let context = self.context(&request)?;
         Ok(operations::RetrieveStorageKey
-            .handle_request(context, request)
+            .handle_request(context, request, ClientAction::RetrieveStorageKey)
             .await?)
     }
 }

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -3,6 +3,7 @@ mod service;
 
 pub(crate) use operation::Operation;
 pub use service::start_lock_keeper_server;
+use std::str::FromStr;
 
 use crate::{database::Database, error::LockKeeperServerError, operations};
 
@@ -12,6 +13,7 @@ use lock_keeper::{
     types::{Message, MessageStream},
 };
 
+use lock_keeper::user::AccountName;
 use rand::{rngs::StdRng, SeedableRng};
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -42,12 +44,21 @@ impl LockKeeperKeyServer {
         })
     }
 
-    pub fn context(&self) -> Context {
-        Context {
+    pub fn context(&self, request: &Request<tonic::Streaming<Message>>) -> Result<Context, Status> {
+        let account_name_str = request
+            .metadata()
+            .get("account_name")
+            .ok_or_else(|| Status::unauthenticated("Account name not found"))?
+            .to_str()
+            .map_err(|_| Status::unauthenticated("Invalid account name"))?;
+        let account_name = AccountName::from_str(account_name_str)?;
+
+        Ok(Context {
             db: self.db.clone(),
             service: self.service.clone(),
             rng: self.rng.clone(),
-        }
+            account_name,
+        })
     }
 }
 
@@ -56,6 +67,7 @@ pub struct Context {
     pub db: Arc<Database>,
     pub service: Arc<Service>,
     pub rng: Arc<Mutex<StdRng>>,
+    pub account_name: AccountName,
 }
 
 #[tonic::async_trait]
@@ -71,8 +83,9 @@ impl LockKeeperRpc for LockKeeperKeyServer {
         &self,
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::RegisterStream>, Status> {
+        let context = self.context(&request)?;
         Ok(operations::Register
-            .handle_request(self.context(), request)
+            .handle_request(context, request)
             .await?)
     }
 
@@ -80,8 +93,9 @@ impl LockKeeperRpc for LockKeeperKeyServer {
         &self,
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::AuthenticateStream>, Status> {
+        let context = self.context(&request)?;
         Ok(operations::Authenticate
-            .handle_request(self.context(), request)
+            .handle_request(context, request)
             .await?)
     }
 
@@ -89,8 +103,9 @@ impl LockKeeperRpc for LockKeeperKeyServer {
         &self,
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::CreateStorageKeyStream>, Status> {
+        let context = self.context(&request)?;
         Ok(operations::CreateStorageKey
-            .handle_request(self.context(), request)
+            .handle_request(context, request)
             .await?)
     }
 
@@ -98,8 +113,9 @@ impl LockKeeperRpc for LockKeeperKeyServer {
         &self,
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::GenerateStream>, Status> {
+        let context = self.context(&request)?;
         Ok(operations::Generate
-            .handle_request(self.context(), request)
+            .handle_request(context, request)
             .await?)
     }
 
@@ -107,8 +123,9 @@ impl LockKeeperRpc for LockKeeperKeyServer {
         &self,
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::RetrieveStream>, Status> {
+        let context = self.context(&request)?;
         Ok(operations::Retrieve
-            .handle_request(self.context(), request)
+            .handle_request(context, request)
             .await?)
     }
 
@@ -116,8 +133,9 @@ impl LockKeeperRpc for LockKeeperKeyServer {
         &self,
         request: Request<tonic::Streaming<Message>>,
     ) -> Result<Response<Self::RetrieveStorageKeyStream>, Status> {
+        let context = self.context(&request)?;
         Ok(operations::RetrieveStorageKey
-            .handle_request(self.context(), request)
+            .handle_request(context, request)
             .await?)
     }
 }

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -20,8 +20,6 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
 
-pub(crate) struct OperationResult(pub(crate) Option<KeyId>);
-
 #[allow(unused)]
 #[derive(Debug)]
 pub struct LockKeeperKeyServer {

--- a/lock-keeper-key-server/src/server/operation.rs
+++ b/lock-keeper-key-server/src/server/operation.rs
@@ -1,14 +1,15 @@
 use async_trait::async_trait;
 use lock_keeper::{
+    audit_event::Outcome,
     channel::ServerChannel,
     types::{Message, MessageStream},
     ClientAction,
 };
+use std::{thread, time::Duration};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::{
-    database::audit_event::AuditEventExt,
     server::{Context, OperationResult},
     LockKeeperServerError,
 };
@@ -38,13 +39,39 @@ pub(crate) trait Operation: Sized + Send + 'static {
         let context = context;
 
         let _ = tokio::spawn(async move {
-            let _ = self
-                .operation(&mut channel, &context)
-                .await
-                .log_audit_event(&mut channel, &context, action)
-                .await;
+            let result = self.operation(&mut channel, &context).await;
+            if let Err(e) = result {
+                Self::handle_error(&mut channel, e).await;
+                Self::audit_event(&mut channel, &context, action, Outcome::Failed).await;
+
+                // Give the client a moment to receive the error before dropping the channel
+                thread::sleep(Duration::from_millis(100));
+            } else {
+                Self::audit_event(&mut channel, &context, action, Outcome::Successful).await;
+            }
         });
 
         Ok(Response::new(ReceiverStream::new(rx)))
+    }
+    async fn handle_error(channel: &mut ServerChannel, e: LockKeeperServerError) {
+        tracing::error!("{}", e);
+        if let Err(e) = channel.send_error(e).await {
+            tracing::error!("{}", e);
+        }
+    }
+
+    async fn audit_event(
+        channel: &mut ServerChannel,
+        context: &Context,
+        action: ClientAction,
+        outcome: Outcome,
+    ) {
+        let audit_event = context
+            .db
+            .create_audit_event(&context.account_name, None, action, outcome)
+            .await;
+        if let Err(e) = audit_event {
+            let _ = Self::handle_error(channel, e);
+        };
     }
 }

--- a/lock-keeper-key-server/src/server/operation.rs
+++ b/lock-keeper-key-server/src/server/operation.rs
@@ -8,7 +8,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::{
-    database::log::AuditLogExt,
+    database::audit_event::AuditEventExt,
     server::{Context, OperationResult},
     LockKeeperServerError,
 };
@@ -41,7 +41,7 @@ pub(crate) trait Operation: Sized + Send + 'static {
             let _ = self
                 .operation(&mut channel, &context)
                 .await
-                .audit_log(&mut channel, &context, action)
+                .log_audit_event(&mut channel, &context, action)
                 .await;
         });
 

--- a/lock-keeper-key-server/src/server/operation.rs
+++ b/lock-keeper-key-server/src/server/operation.rs
@@ -3,7 +3,6 @@ use lock_keeper::{
     audit_event::Outcome,
     channel::ServerChannel,
     types::{Message, MessageStream},
-    ClientAction,
 };
 use std::{thread, time::Duration};
 use tokio_stream::wrappers::ReceiverStream;
@@ -22,7 +21,7 @@ pub(crate) trait Operation: Sized + Send + 'static {
     async fn operation(
         self,
         channel: &mut ServerChannel,
-        context: &Context,
+        context: &mut Context,
     ) -> Result<OperationResult, LockKeeperServerError>;
 
     /// Takes a request from `tonic` and spawns a new thread to process that
@@ -33,26 +32,26 @@ pub(crate) trait Operation: Sized + Send + 'static {
         self,
         context: Context,
         request: Request<Streaming<Message>>,
-        action: ClientAction,
     ) -> Result<Response<MessageStream>, Status> {
         let (mut channel, rx) = ServerChannel::create(request.into_inner());
-        let context = context;
+        let mut context = context;
 
         let _ = tokio::spawn(async move {
-            let result = self.operation(&mut channel, &context).await;
+            let result = self.operation(&mut channel, &mut context).await;
             if let Err(e) = result {
                 Self::handle_error(&mut channel, e).await;
-                Self::audit_event(&mut channel, &context, action, Outcome::Failed).await;
+                Self::audit_event(&mut channel, &context, Outcome::Failed).await;
 
                 // Give the client a moment to receive the error before dropping the channel
                 thread::sleep(Duration::from_millis(100));
             } else {
-                Self::audit_event(&mut channel, &context, action, Outcome::Successful).await;
+                Self::audit_event(&mut channel, &context, Outcome::Successful).await;
             }
         });
 
         Ok(Response::new(ReceiverStream::new(rx)))
     }
+
     async fn handle_error(channel: &mut ServerChannel, e: LockKeeperServerError) {
         tracing::error!("{}", e);
         if let Err(e) = channel.send_error(e).await {
@@ -60,15 +59,15 @@ pub(crate) trait Operation: Sized + Send + 'static {
         }
     }
 
-    async fn audit_event(
-        channel: &mut ServerChannel,
-        context: &Context,
-        action: ClientAction,
-        outcome: Outcome,
-    ) {
+    async fn audit_event(channel: &mut ServerChannel, context: &Context, outcome: Outcome) {
         let audit_event = context
             .db
-            .create_audit_event(&context.account_name, None, action, outcome)
+            .create_audit_event(
+                &context.account_name,
+                &context.key_id,
+                &context.action,
+                outcome,
+            )
             .await;
         if let Err(e) = audit_event {
             let _ = Self::handle_error(channel, e);

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -1,6 +1,6 @@
 //! Audit events, and associated fields and types
 //!
-//! Includes possible events to log and outcomes of those events
+//! Includes possible events to log and statuses of those events
 
 use crate::user::AccountName;
 
@@ -11,7 +11,8 @@ use std::fmt::{Debug, Display, Formatter};
 
 /// Options for the outcome of a given action in a [`AuditEvent`]
 #[derive(Debug, Serialize, Deserialize)]
-pub enum Outcome {
+pub enum EventStatus {
+    Started,
     Successful,
     Failed,
 }
@@ -24,7 +25,7 @@ pub struct AuditEvent {
     secret_id: Option<KeyId>,
     date: DateTime,
     action: ClientAction,
-    outcome: Outcome,
+    status: EventStatus,
 }
 
 impl AuditEvent {
@@ -32,14 +33,14 @@ impl AuditEvent {
         actor: AccountName,
         secret_id: Option<KeyId>,
         action: ClientAction,
-        outcome: Outcome,
+        status: EventStatus,
     ) -> Self {
         AuditEvent {
             actor,
             secret_id,
             date: DateTime::now(),
             action,
-            outcome,
+            status,
         }
     }
 }
@@ -49,7 +50,7 @@ impl Display for AuditEvent {
         write!(
             f,
             "AuditEvent: User <{:?}> performed action <{:?}> on {} with outcome <{:?}>",
-            self.actor, self.action, self.date, self.outcome
+            self.actor, self.action, self.date, self.status
         )
     }
 }

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -1,6 +1,6 @@
-//! Audit log entries, fields, and types
+//! Audit events, and associated fields and types
 //!
-//! Includes possible actions to log and outcomes of those actions
+//! Includes possible events to log and outcomes of those events
 
 use crate::user::AccountName;
 
@@ -9,17 +9,17 @@ use mongodb::bson::DateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
-/// Options for the outcome of a given action in a [`LogEntry`]
+/// Options for the outcome of a given action in a [`AuditEvent`]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Outcome {
     Successful,
     Failed,
 }
 
-/// A single log entry that specifies the actor, action, outcome, and
-/// any related key for a logged event
+/// A single entry that specifies the actor, action, outcome, and
+/// any related key for a logged audit event
 #[derive(Debug, Serialize, Deserialize)]
-pub struct LogEntry {
+pub struct AuditEvent {
     actor: AccountName,
     secret_id: Option<KeyId>,
     date: DateTime,
@@ -27,14 +27,14 @@ pub struct LogEntry {
     outcome: Outcome,
 }
 
-impl LogEntry {
+impl AuditEvent {
     pub fn new(
         actor: AccountName,
         secret_id: Option<KeyId>,
         action: ClientAction,
         outcome: Outcome,
     ) -> Self {
-        LogEntry {
+        AuditEvent {
             actor,
             secret_id,
             date: DateTime::now(),
@@ -44,11 +44,11 @@ impl LogEntry {
     }
 }
 
-impl Display for LogEntry {
+impl Display for AuditEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "LogEntry: User <{:?}> performed action <{:?}> on {} with outcome <{:?}>",
+            "AuditEvent: User <{:?}> performed action <{:?}> on {} with outcome <{:?}>",
             self.actor, self.action, self.date, self.outcome
         )
     }

--- a/lock-keeper/src/audit_log.rs
+++ b/lock-keeper/src/audit_log.rs
@@ -2,7 +2,7 @@
 //!
 //! Includes possible actions to log and outcomes of those actions
 
-use crate::user::LogIdentifier;
+use crate::user::AccountName;
 
 use crate::{crypto::KeyId, ClientAction};
 use mongodb::bson::DateTime;
@@ -20,7 +20,7 @@ pub enum Outcome {
 /// any related key for a logged event
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LogEntry {
-    actor: LogIdentifier,
+    actor: AccountName,
     secret_id: Option<KeyId>,
     date: DateTime,
     action: ClientAction,
@@ -29,7 +29,7 @@ pub struct LogEntry {
 
 impl LogEntry {
     pub fn new(
-        actor: LogIdentifier,
+        actor: AccountName,
         secret_id: Option<KeyId>,
         action: ClientAction,
         outcome: Outcome,

--- a/lock-keeper/src/defaults.rs
+++ b/lock-keeper/src/defaults.rs
@@ -18,6 +18,8 @@ pub(crate) mod shared {
     pub const ORGANIZATION: &str = "Bolt Labs";
     pub const APPLICATION: &str = "key-mgmt";
     pub const LOCAL_SERVER_URI: &str = "https://localhost:1113";
+    pub const ACCOUNT_NAME: &str = "account_name";
+    pub const USER_ID: &str = "user_id";
 
     pub const fn max_pending_connection_retries() -> usize {
         4

--- a/lock-keeper/src/lib.rs
+++ b/lock-keeper/src/lib.rs
@@ -13,7 +13,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-pub mod audit_log;
+pub mod audit_event;
 pub mod blockchain;
 pub mod channel;
 pub mod config;

--- a/lock-keeper/src/lib.rs
+++ b/lock-keeper/src/lib.rs
@@ -36,7 +36,7 @@ pub mod rpc {
 }
 
 /// Options for actions the Lock Keeper client can take.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ClientAction {
     Register,
     Authenticate,

--- a/lock-keeper/src/user.rs
+++ b/lock-keeper/src/user.rs
@@ -134,20 +134,3 @@ impl User {
         (self.server_registration, self.user_id)
     }
 }
-
-/// Abstraction to wrap around [`UserId`] and [`AccountName`] as user
-/// identifiers for log entries.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct LogIdentifier(String);
-
-impl From<&UserId> for LogIdentifier {
-    fn from(user_id: &UserId) -> Self {
-        Self(user_id.clone().0)
-    }
-}
-
-impl From<&AccountName> for LogIdentifier {
-    fn from(account_name: &AccountName) -> Self {
-        Self(account_name.clone().0)
-    }
-}


### PR DESCRIPTION
Closes #232 

My tonic changes are based on [this post](https://dev.to/anshulgoyal15/a-beginners-guide-to-grpc-with-rust-3c7o). Linking here in case it's useful in the future for handling sessions/other authentication related things on the server.

Main changes:
- Add the account name to every request's metadata
- Remove `LogIdentifier` and use account name for all logs
- Pull KeyId from operation results
- Change "audit log" language to "audit event"
- Remove log extension trait + function
- Log beginning and end of each operation

Questions:
- I'd like to make a constant for the string "account_name". Where in the dams crate can I put that (or do we have enough constants that I can make a constants module there)?
- ~I don't like the way I'm handling KeyIds here because we can only log them in the successful case here, but putting KeyIds in the request metadata doesn't seem appropriate. Thoughts on how to get the KeyId in the error case?~ 
    It's now in the server context as per @picklenerd's suggestion!