### PR TITLE
Updated Cargo manifests to use 1.64 workspace definitions

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -21,6 +21,11 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           version: '3.x'
+      
+      # Ensure Rust is the latest version
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Cache
         uses: actions/cache@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,38 @@ members = [
     "lock-keeper-key-server",
     "lock-keeper-tests"
 ]
+
+[workspace.package]
+version = "0.2.0"
+
+[workspace.dependencies]
+argon2 = "0.4"
+async-trait = "0.1"
+bincode = "1"
+bson = { version = "2", features = ["uuid-1"] }
+bytes = { version = "1", features = ["serde"] }
+futures = "0.3"
+generic-array = "0.14"
+http = "0.2"
+http-body = "0.4"
+hyper = "0.14"
+hyper-rustls = { version = "0.23", features = ["http2"] }
+mongodb = "2.3.0"
+opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
+prost = "0.11.0"
+rand = "0.8"
+rustls = "0.20"
+rustls-pemfile = "1"
+serde = "1"
+serde_json = "1.0.85"
+serde_with = "1"
+structopt = "0.3"
+thiserror = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-rustls = "0.23"
+tokio-stream = "0.1"
+toml = "0.5"
+tonic =  "0.8"
+tracing = "0.1"
+tracing-futures = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/lock-keeper-client/Cargo.toml
+++ b/lock-keeper-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lock-keeper-client"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 
 
@@ -10,25 +10,28 @@ allow_explicit_certificate_trust = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-argon2 = "0.4"
-async-trait = "0.1"
-bincode = "1"
+# Git dependencies
 lock-keeper = { version = "0.2.0", path = "../lock-keeper" }
-futures = "0.3"
-http = "0.2"
-http-body = "0.4"
-hyper = "0.14"
-hyper-rustls = { version = "0.23", features = ["http2"] }
-opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
-prost = "0.11.0"
-rand = "0.8"
-serde = "1"
-serde_with = "1"
-structopt = "0.3"
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
-tonic =  "0.8"
-tracing = "0.1"
-tracing-futures = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Workspace dependencies
+argon2.workspace = true
+async-trait.workspace = true
+bincode.workspace = true
+futures.workspace = true
+http.workspace = true
+http-body.workspace = true
+hyper.workspace = true
+hyper-rustls.workspace = true
+opaque-ke.workspace = true
+prost.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+structopt.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+tonic.workspace = true
+tracing.workspace = true
+tracing-futures.workspace = true
+tracing-subscriber.workspace = true

--- a/lock-keeper-key-server/Cargo.toml
+++ b/lock-keeper-key-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lock-keeper-key-server"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 
 [[bin]]
@@ -10,29 +10,33 @@ path = "src/bin/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-argon2 = "0.4"
-async-trait = "0.1"
-bincode = "1"
+# Git dependencies
 lock-keeper = { version = "0.2.0", path = "../lock-keeper" }
-futures = "0.3"
-hyper = "0.14"
-mongodb = "2.3.0"
-opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
-prost = "0.11.0"
-rand = "0.8"
-reqwest = "0.11"
-serde = "1"
-serde_with = "1"
-structopt = "0.3"
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-tokio-rustls = "0.23"
-tokio-stream = "0.1"
-tonic = "0.8.0"
+
+# Workspace dependencies
+argon2.workspace = true
+async-trait.workspace = true
+bincode.workspace = true
+futures.workspace = true
+hyper.workspace = true
+mongodb.workspace = true
+opaque-ke.workspace = true
+prost.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_with.workspace = true
+structopt.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-rustls.workspace = true
+tokio-stream.workspace = true
+tonic.workspace = true
+tracing.workspace = true
+tracing-futures.workspace = true
+tracing-subscriber.workspace = true
+
+# Other dependencies
 tower = "0.4"
-tracing = "0.1"
-tracing-futures = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-generic-array = "0.14"
+generic-array.workspace = true

--- a/lock-keeper-tests/Cargo.toml
+++ b/lock-keeper-tests/Cargo.toml
@@ -1,25 +1,30 @@
 [package]
 name = "lock-keeper-tests"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-anyhow = "1"
+# Git dependencies
 lock-keeper = { version = "0.2.0", path = "../lock-keeper" }
 lock-keeper-key-server = { version = "0.2.0", path = "../lock-keeper-key-server" }
 lock-keeper-client = { version = "0.2.0", path = "../lock-keeper-client", features=["allow_explicit_certificate_trust"] }
-futures = "0.3"
-mongodb = "2.3.0"
-opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
-rand = "0.8"
-serde = "1"
-serde_json = "1.0.85"
-structopt = "0.3"
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-tonic = "0.8.0"
-tracing = "0.1"
-tracing-futures = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Workspace dependencies
+futures.workspace = true
+mongodb.workspace = true
+opaque-ke.workspace = true
+rand.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+structopt.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tonic.workspace = true
+tracing.workspace = true
+tracing-futures.workspace = true
+tracing-subscriber.workspace = true
+
+# Other dependencies
+anyhow = "1"

--- a/lock-keeper/Cargo.toml
+++ b/lock-keeper/Cargo.toml
@@ -1,41 +1,43 @@
 [package]
 name = "lock-keeper"
-version = "0.2.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-argon2 = "0.4"
-async-trait = "0.1"
-bincode = "1"
-bson = { version = "2", features = ["uuid-1"] }
-bytes = { version = "1", features = ["serde"] }
+# Workspace dependencies
+argon2.workspace = true
+async-trait.workspace = true
+bincode.workspace = true
+bson.workspace = true
+bytes.workspace = true
+futures.workspace = true
+generic-array.workspace = true
+http.workspace = true
+mongodb.workspace = true
+opaque-ke.workspace = true
+prost.workspace = true
+rand.workspace = true
+rustls.workspace = true
+rustls-pemfile.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-rustls.workspace = true
+tokio-stream.workspace = true
+toml.workspace = true
+tonic.workspace = true
+tracing.workspace = true
+
+# Other dependencies
 chacha20poly1305 = "0.10"
 directories = "3"
-futures = "0.3"
-generic-array = "0.14"
 hkdf = "0.12"
-http = "0.2"
 http-serde = "1"
 humantime = "2"
 humantime-serde = "1"
-mongodb = "2.3.0"
-opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
-prost = "0.11.0"
-rand = "0.8"
-rustls = "0.20"
-rustls-pemfile = "1"
-serde = { version = "1", features = ["derive"] }
-serde_with = "1"
 sha3 = "0.10"
-tracing = "0.1"
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-tokio-rustls = "0.23"
-tokio-stream = "0.1"
-toml = "0.5"
-tonic = "0.8"
 uuid = "1.1.2"
 webpki = "0.22"
 
@@ -43,4 +45,4 @@ webpki = "0.22"
 tonic-build = "0.8.0"
 
 [dev-dependencies]
-serde_json = "1"
+serde_json.workspace = true


### PR DESCRIPTION
Rust 1.64 added the ability to specify some workspace-level values that can be shared between all of the crates in a workspace.

This PR adds the version number and all shared dependencies to the workspace `Cargo.toml` so that they can be updated in a single place. 