### PR TITLE
Publish docs to Github pages #251

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,66 @@
+# Builds documentation and publishes it to GitHub Pages via the 
+# `published-documentation` branch of the `key-mgmt` repo.
+name: Publish Docs
+
+on:
+  push:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+
+      # Install stable toolchain
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          default: true
+
+      - name: Build documentation in current branch
+        run: cargo doc --all-features --no-deps --document-private-items --workspace
+
+      # https://stackoverflow.com/questions/58886293/getting-current-branch-and-commit-hash-in-github-action/61699863#61699863
+      - name: Get branch name and short SHA
+        id: vars
+        shell: bash
+        run: |
+          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: Configure git
+        run: |
+          git config --global user.email "CI"
+          git config --global user.name "CI"
+
+      - name: Switch to doc branch and publish
+        run: |
+          git fetch
+          git checkout published-documentation
+          rm -rf "docs/${{ steps.vars.outputs.branch }}"
+          mkdir -p "docs/${{ steps.vars.outputs.branch }}"
+          yes | cp -rf index.html docs/index.html
+          cp -r target/doc/* "docs/${{ steps.vars.outputs.branch }}"
+          git add .
+          git commit -m "Publishing ${{ steps.vars.outputs.sha_short }}"
+          git push

--- a/README.md
+++ b/README.md
@@ -85,3 +85,18 @@ RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features --no-deps --open
 ```
 
 You can find the API docs in the source of the [client](lock-keeper-client/src/api.rs) and [policy engine](lock-keeper-key-server/src/policy_engine.rs).
+
+## Published Documentation
+
+Documentation from the `main` and `develop` branches is automatically deployed to GitHub Pages any time code is merged. There is a very basic index page for published documentation [here](https://boltlabs-inc.github.io/key-mgmt/).
+
+### `develop` docs
+
+[lock-keeper](https://boltlabs-inc.github.io/key-mgmt/develop/lock_keeper)  
+[lock-keeper-client](https://boltlabs-inc.github.io/key-mgmt/develop/lock_keeper_client)  
+[lock-keeper-key-server](https://boltlabs-inc.github.io/key-mgmt/develop/lock_keeper_key_server)  
+
+### `main` docs
+[dams](https://boltlabs-inc.github.io/key-mgmt/main/dams)  
+[dams-client](https://boltlabs-inc.github.io/key-mgmt/main/dams_client)  
+[dams-key-server](https://boltlabs-inc.github.io/key-mgmt/main/dams_key_server) 


### PR DESCRIPTION
This PR adds a CI task to build documentation and publish it to Github Pages.

This is a little tricky to see the results of since it depends on things being merged to `develop` or `main` but I did test this using this PR branch and it works.

I manually published the current docs for `develop` and `main` which you can see here: https://boltlabs-inc.github.io/key-mgmt/

This index is ugly but the docs for each repo are directly linked in the README now so no one should ever see it.

There is a new protected branch called `published-documentation` where all of these doc files live. We shouldn't ever have to work with it directly but you might see it when browsing branches.

The GitHub Pages settings can be accessed from the settings page for this repo: https://github.com/boltlabs-inc/key-mgmt/settings/pages