### PR TITLE
74 retrieve logs

### DIFF
--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -43,7 +43,7 @@ impl LockKeeperClient {
     pub async fn retrieve_audit_event_log(
         &self,
         event_type: EventType,
-        options: Option<AuditEventOptions>,
+        options: AuditEventOptions,
     ) -> Result<Vec<AuditEvent>, LockKeeperClientError> {
         let mut client_channel = Self::create_channel(
             &mut self.tonic_client(),

--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -8,17 +8,53 @@
 pub(crate) mod authenticate;
 pub(crate) mod create_storage_key;
 pub(crate) mod register;
+pub(crate) mod retrieve_audit_events;
 
 pub mod arbitrary_secrets;
 
-use crate::LockKeeperClientError;
+use crate::{LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
+    audit_event::{AuditEvent, AuditEventOptions, EventType},
     blockchain::Blockchain,
     crypto::KeyId,
     keys::{KeyInfo, UsePermission, UseRestriction, UserPolicySpecification},
     transaction::{TransactionApprovalRequest, TransactionSignature},
     user::UserId,
+    ClientAction,
 };
+
+impl LockKeeperClient {
+    /// Retrieve the log of audit events from the key server for the
+    /// authenticated asset owner; optionally, filter for audit events
+    /// associated with the specified [`KeyId`].
+    ///
+    /// The log of audit events includes context
+    /// about any action requested and/or taken on the digital asset key,
+    /// including which action was requested and by whom, the date, details
+    /// about approval or rejection from each key server, the policy engine,
+    /// and each asset fiduciary (if relevant), and any other relevant
+    /// details.
+    ///
+    /// The [`UserId`] must match the asset owner authenticated in the
+    /// [`crate::LockKeeperClient`], and if specified, the [`KeyId`] must
+    /// correspond to a key owned by the [`UserId`].
+    ///
+    /// Output: if successful, returns a [`String`] representation of the logs.
+    pub async fn retrieve_audit_event_log(
+        &self,
+        event_type: EventType,
+        options: Option<AuditEventOptions>,
+    ) -> Result<Vec<AuditEvent>, LockKeeperClientError> {
+        let mut client_channel = Self::create_channel(
+            &mut self.tonic_client(),
+            ClientAction::RetrieveAuditEvents,
+            self.account_name(),
+        )
+        .await?;
+        self.handle_retrieve_audit_events(&mut client_channel, event_type, options)
+            .await
+    }
+}
 
 /// Generate a new, distributed digital asset key with the given use
 /// parameters for the [`UserId`], and compatible with the specified blockchain.
@@ -112,28 +148,5 @@ pub fn retrieve_public_key_by_id(
     user_id: UserId,
     key_id: &KeyId,
 ) -> Result<KeyInfo, LockKeeperClientError> {
-    todo!()
-}
-
-/// Retrieve the log of audit events from the key server for a specified asset
-/// owner; optionally, filter for audit events associated with the specified
-/// [`KeyId`].
-///
-/// The log of audit events includes context
-/// about any action requested and/or taken on the digital asset key, including
-/// which action was requested and by whom, the date, details about approval or
-/// rejection from each key server, the policy engine, and each asset fiduciary
-/// (if relevant), and any other relevant details.
-///
-/// The [`UserId`] must match the asset owner authenticated in the
-/// [`crate::LockKeeperClient`], and if specified, the [`KeyId`] must correspond
-/// to a key owned by the [`UserId`].
-///
-/// Output: if successful, returns a [`String`] representation of the logs.
-#[allow(unused)]
-pub fn retrieve_audit_event_log(
-    user_id: UserId,
-    key_id: Option<&KeyId>,
-) -> Result<String, LockKeeperClientError> {
     todo!()
 }

--- a/lock-keeper-client/src/api/retrieve_audit_events.rs
+++ b/lock-keeper-client/src/api/retrieve_audit_events.rs
@@ -1,0 +1,27 @@
+use crate::{api::AuditEventOptions, LockKeeperClient, LockKeeperClientError};
+use lock_keeper::{
+    audit_event::{AuditEvent, EventType},
+    channel::ClientChannel,
+    types::retrieve_audit_events::{client, server},
+};
+
+impl LockKeeperClient {
+    pub(crate) async fn handle_retrieve_audit_events(
+        &self,
+        channel: &mut ClientChannel,
+        event_type: EventType,
+        options: Option<AuditEventOptions>,
+    ) -> Result<Vec<AuditEvent>, LockKeeperClientError> {
+        // Generate step: get new KeyId from server
+        // Send UserId to server
+        let generate_message = client::Request {
+            event_type,
+            options,
+        };
+        channel.send(generate_message).await?;
+
+        let server_response: server::Response = channel.receive().await?;
+
+        Ok(server_response.summary_record)
+    }
+}

--- a/lock-keeper-client/src/api/retrieve_audit_events.rs
+++ b/lock-keeper-client/src/api/retrieve_audit_events.rs
@@ -12,14 +12,14 @@ impl LockKeeperClient {
         event_type: EventType,
         options: Option<AuditEventOptions>,
     ) -> Result<Vec<AuditEvent>, LockKeeperClientError> {
-        // Generate step: get new KeyId from server
-        // Send UserId to server
-        let generate_message = client::Request {
+        // Send audit event request and filters
+        let client_request = client::Request {
             event_type,
             options,
         };
-        channel.send(generate_message).await?;
+        channel.send(client_request).await?;
 
+        // Receive audit event log and return
         let server_response: server::Response = channel.receive().await?;
 
         Ok(server_response.summary_record)

--- a/lock-keeper-client/src/api/retrieve_audit_events.rs
+++ b/lock-keeper-client/src/api/retrieve_audit_events.rs
@@ -10,7 +10,7 @@ impl LockKeeperClient {
         &self,
         channel: &mut ClientChannel,
         event_type: EventType,
-        options: Option<AuditEventOptions>,
+        options: AuditEventOptions,
     ) -> Result<Vec<AuditEvent>, LockKeeperClientError> {
         // Send audit event request and filters
         let client_request = client::Request {

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -254,6 +254,7 @@ impl LockKeeperClient {
             ClientAction::CreateStorageKey => client.create_storage_key(stream).await,
             ClientAction::Generate => client.generate(stream).await,
             ClientAction::Retrieve => client.retrieve(stream).await,
+            ClientAction::RetrieveAuditEvents => client.retrieve_audit_events(stream).await,
             ClientAction::RetrieveStorageKey => client.retrieve_storage_key(stream).await,
         }?
         .into_inner();

--- a/lock-keeper-key-server/Cargo.toml
+++ b/lock-keeper-key-server/Cargo.toml
@@ -37,6 +37,7 @@ tracing-futures.workspace = true
 tracing-subscriber.workspace = true
 
 # Other dependencies
+strum = { version = "0.24.1", features = ["derive"] }
 tower = "0.4"
 
 [dev-dependencies]

--- a/lock-keeper-key-server/Cargo.toml
+++ b/lock-keeper-key-server/Cargo.toml
@@ -18,6 +18,7 @@ argon2.workspace = true
 async-trait.workspace = true
 bincode.workspace = true
 clap.workspace = true
+bson.workspace = true
 futures.workspace = true
 hyper.workspace = true
 mongodb.workspace = true

--- a/lock-keeper-key-server/src/database.rs
+++ b/lock-keeper-key-server/src/database.rs
@@ -58,3 +58,69 @@ impl Database {
         Ok(Self { inner: db })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{database::Database, LockKeeperServerError};
+    use lock_keeper::config::{opaque::OpaqueCipherSuite, server::DatabaseSpec};
+    use mongodb::{options::ClientOptions, Client};
+    use opaque_ke::{
+        ClientRegistration, ClientRegistrationFinishParameters, ServerRegistration, ServerSetup,
+    };
+    use rand::{CryptoRng, RngCore};
+
+    /// Locally simulates OPAQUE registration to get a valid
+    /// `ServerRegistration` for remaining tests.
+    pub(crate) fn server_registration(
+        rng: &mut (impl CryptoRng + RngCore),
+    ) -> ServerRegistration<OpaqueCipherSuite> {
+        let server_setup = ServerSetup::<OpaqueCipherSuite>::new(rng);
+        let client_reg_start_result =
+            ClientRegistration::<OpaqueCipherSuite>::start(rng, b"password").unwrap();
+        let server_reg_start_result = ServerRegistration::<OpaqueCipherSuite>::start(
+            &server_setup,
+            client_reg_start_result.message,
+            b"email@email.com",
+        )
+        .unwrap();
+        let client_reg_finish_result = client_reg_start_result
+            .state
+            .finish(
+                rng,
+                b"password",
+                server_reg_start_result.message,
+                ClientRegistrationFinishParameters::default(),
+            )
+            .unwrap();
+        ServerRegistration::<OpaqueCipherSuite>::finish(client_reg_finish_result.message)
+    }
+
+    pub(crate) async fn setup_db(db_name: &str) -> Result<Database, LockKeeperServerError> {
+        let mongodb_uri = "mongodb://localhost:27017";
+        let db_spec = DatabaseSpec {
+            mongodb_uri: mongodb_uri.to_string(),
+            db_name: db_name.to_string(),
+        };
+
+        // Clean up previous runs and make fresh connection
+        drop_db(mongodb_uri, db_name).await?;
+        let db = Database::connect(&db_spec).await?;
+        Ok(db)
+    }
+
+    // Delete the entire db to avoid leftover issues from previous runs.
+    pub(crate) async fn drop_db(
+        mongodb_uri: &str,
+        db_name: &str,
+    ) -> Result<(), LockKeeperServerError> {
+        // Parse a connection string into an options struct
+        let client_options = ClientOptions::parse(mongodb_uri).await?;
+        // Get a handle to the deployment
+        let client = Client::with_options(client_options)?;
+        // Get a handle to the database
+        let db = client.database(db_name);
+        db.drop(None).await?;
+
+        Ok(())
+    }
+}

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -4,14 +4,21 @@
 //! on the [`AuditEvent`] model in the MongoDB database.
 
 use crate::{constants, LockKeeperServerError};
+use futures::TryStreamExt;
 use lock_keeper::{
-    audit_event::{AuditEvent, EventStatus},
+    audit_event::{AuditEvent, AuditEventOptions, EventStatus, EventType},
     crypto::KeyId,
     user::AccountName,
     ClientAction,
 };
+use mongodb::bson::{doc, Document};
 
 use super::Database;
+
+const ACTION: &str = "action";
+const ACTOR: &str = "actor";
+const DATE: &str = "date";
+const SECRET_ID: &str = "secret_id";
 
 impl Database {
     /// Create a new [`AuditEvent`] for the given actor, action, and outcome
@@ -27,4 +34,36 @@ impl Database {
         let _ = collection.insert_one(new_event, None).await?;
         Ok(())
     }
+
+    /// Find [`AuditEvent`]s that correspond to the event type and provided filters
+    pub async fn find_audit_events(
+        &self,
+        account_name: &AccountName,
+        event_type: EventType,
+        options: Option<AuditEventOptions>,
+    ) -> Result<Vec<AuditEvent>, LockKeeperServerError> {
+        let actions = event_type.into_client_actions();
+        let mut query = doc! { ACTOR: account_name.to_string(), ACTION: {"$in": mongodb::bson::to_bson(&actions)?} };
+        if let Some(options) = options {
+            query = construct_query_with_options(options, query)?;
+        }
+        let collection = self.inner.collection::<AuditEvent>(constants::AUDIT_EVENTS);
+        let events = collection.find(query, None).await?;
+        let events_vec: Vec<AuditEvent> = events.try_collect().await?;
+        Ok(events_vec)
+    }
+}
+
+fn construct_query_with_options(options: AuditEventOptions, mut query: Document) -> Result<Document, LockKeeperServerError> {
+    if let Some(key_ids) = options.key_ids {
+        let _ = query.insert(SECRET_ID, doc! {"$in": mongodb::bson::to_bson(&key_ids)?});
+    }
+    if let Some(after_date) = options.after_date {
+        let _ = query.insert(DATE, doc! {"$gte": mongodb::bson::to_bson(&after_date)?});
+    }
+    if let Some(before_date) = options.before_date {
+        let _ = query.insert(DATE, doc! {"$lte": mongodb::bson::to_bson(&before_date)?});
+    }
+
+    Ok(query)
 }

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -30,7 +30,7 @@ impl Database {
         status: EventStatus,
     ) -> Result<(), LockKeeperServerError> {
         let collection = self.inner.collection::<AuditEvent>(constants::AUDIT_EVENTS);
-        let new_event = AuditEvent::new(actor.clone(), secret_id.clone(), action.clone(), status);
+        let new_event = AuditEvent::new(actor.clone(), secret_id.clone(), *action, status);
         let _ = collection.insert_one(new_event, None).await?;
         Ok(())
     }
@@ -135,7 +135,8 @@ mod test {
     }
 
     fn compare_key_ids(audit_events: Vec<AuditEvent>, expected_key_ids: Vec<KeyId>) {
-        let actual_key_ids: Vec<KeyId> = audit_events.iter().map(|a| a.key_id().unwrap()).collect();
+        let actual_key_ids: Vec<&KeyId> =
+            audit_events.iter().map(|a| a.key_id().unwrap()).collect();
         assert!(actual_key_ids
             .iter()
             .all(|item| expected_key_ids.contains(item)));

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -54,7 +54,10 @@ impl Database {
     }
 }
 
-fn construct_query_with_options(options: AuditEventOptions, mut query: Document) -> Result<Document, LockKeeperServerError> {
+fn construct_query_with_options(
+    options: AuditEventOptions,
+    mut query: Document,
+) -> Result<Document, LockKeeperServerError> {
     if let Some(key_ids) = options.key_ids {
         let _ = query.insert(SECRET_ID, doc! {"$in": mongodb::bson::to_bson(&key_ids)?});
     }

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -35,7 +35,8 @@ impl Database {
         Ok(())
     }
 
-    /// Find [`AuditEvent`]s that correspond to the event type and provided filters
+    /// Find [`AuditEvent`]s that correspond to the event type and provided
+    /// filters
     pub async fn find_audit_events(
         &self,
         account_name: &AccountName,
@@ -69,4 +70,195 @@ fn construct_query_with_options(
     }
 
     Ok(query)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        database::{
+            test::{server_registration, setup_db},
+            Database,
+        },
+        LockKeeperServerError,
+    };
+    use bson::DateTime;
+    use lock_keeper::{
+        audit_event::{AuditEvent, AuditEventOptions, EventStatus, EventType},
+        crypto::KeyId,
+        user::{AccountName, UserId},
+        ClientAction,
+    };
+    use rand::{seq::SliceRandom, CryptoRng, RngCore};
+    use std::str::FromStr;
+    use strum::IntoEnumIterator;
+
+    const NUM_LOGS: u32 = 10;
+
+    async fn create_user(
+        account_name: &str,
+        rng: &mut (impl CryptoRng + RngCore),
+        db: &Database,
+    ) -> Result<(UserId, AccountName), LockKeeperServerError> {
+        let user_id = UserId::new(rng)?;
+        let account_name = AccountName::from_str(account_name)?;
+
+        let server_registration = server_registration(rng);
+        let _ = db
+            .create_user(&user_id, &account_name, &server_registration)
+            .await?;
+        Ok((user_id, account_name))
+    }
+
+    async fn create_random_audit_events(
+        account_name: &AccountName,
+        user_id: &UserId,
+        rng: &mut (impl CryptoRng + RngCore),
+        db: &Database,
+    ) -> Result<Vec<KeyId>, LockKeeperServerError> {
+        let action_list = ClientAction::iter().collect::<Vec<_>>();
+        let mut key_ids = Vec::new();
+        for _ in 0..NUM_LOGS {
+            let key_id = KeyId::generate(rng, user_id)?;
+            let key_id_copy = key_id.clone();
+            let action = action_list.choose(rng).unwrap();
+            db.create_audit_event(account_name, &Some(key_id), action, EventStatus::Started)
+                .await?;
+            key_ids.push(key_id_copy);
+        }
+        Ok(key_ids)
+    }
+
+    fn compare_actions(audit_events: Vec<AuditEvent>, event_type: EventType) {
+        let actual_actions: Vec<ClientAction> = audit_events.iter().map(|a| a.action()).collect();
+        let expected_actions = event_type.into_client_actions();
+        assert!(actual_actions
+            .iter()
+            .all(|item| expected_actions.contains(item)));
+    }
+
+    fn compare_key_ids(audit_events: Vec<AuditEvent>, expected_key_ids: Vec<KeyId>) {
+        let actual_key_ids: Vec<KeyId> = audit_events.iter().map(|a| a.key_id().unwrap()).collect();
+        assert!(actual_key_ids
+            .iter()
+            .all(|item| expected_key_ids.contains(item)));
+    }
+
+    fn check_after_date(audit_events: Vec<AuditEvent>, after_date: DateTime) {
+        let actual_dates: Vec<DateTime> = audit_events.iter().map(|a| a.date()).collect();
+        assert!(actual_dates.iter().all(|item| after_date < *item));
+    }
+
+    #[tokio::test]
+    async fn event_type_filter_works() -> Result<(), LockKeeperServerError> {
+        // Setup db for this test
+        let db = setup_db("event_type_filter_works").await?;
+        // RNG for this test
+        let mut rng = rand::thread_rng();
+
+        // Add a user
+        let (user_id, account_name) = create_user("event_type_test", &mut rng, &db).await?;
+        // Create random audit events
+        let _ = create_random_audit_events(&account_name, &user_id, &mut rng, &db).await?;
+        // Retrieve all 3 types of audit events
+        let key_only_audit = db
+            .find_audit_events(&account_name, EventType::KeyOnly, None)
+            .await?;
+        let system_only_audit = db
+            .find_audit_events(&account_name, EventType::SystemOnly, None)
+            .await?;
+        let all_audit = db
+            .find_audit_events(&account_name, EventType::All, None)
+            .await?;
+
+        // Make sure each type has the correct actions
+        compare_actions(key_only_audit, EventType::KeyOnly);
+        compare_actions(system_only_audit, EventType::SystemOnly);
+        compare_actions(all_audit, EventType::All);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn key_id_filter_works() -> Result<(), LockKeeperServerError> {
+        // Setup db for this test
+        let db = setup_db("key_id_filter_works").await?;
+        // RNG for this test
+        let mut rng = rand::thread_rng();
+
+        // Add a user
+        let (user_id, account_name) = create_user("key_id_filter_test", &mut rng, &db).await?;
+        // Create random audit events
+        let key_ids = create_random_audit_events(&account_name, &user_id, &mut rng, &db).await?;
+        // Retrieve audits for just one key
+        let options = AuditEventOptions {
+            key_ids: Some(key_ids[0..5].to_vec()),
+            after_date: None,
+            before_date: None,
+        };
+        let key_audit = db
+            .find_audit_events(&account_name, EventType::All, Some(options))
+            .await?;
+
+        // Make sure only the first 5 key IDs are included
+        compare_key_ids(key_audit, key_ids[0..5].to_vec());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn after_date_filter_works() -> Result<(), LockKeeperServerError> {
+        // Use timestamp as comparison date
+        let after_date = DateTime::now();
+        // Setup db for this test
+        let db = setup_db("after_date_filter_works").await?;
+        // RNG for this test
+        let mut rng = rand::thread_rng();
+
+        // Add a user
+        let (user_id, account_name) = create_user("after_date_filter_test", &mut rng, &db).await?;
+        // Create random audit events
+        let _ = create_random_audit_events(&account_name, &user_id, &mut rng, &db).await?;
+        // Retrieve after the comparison date
+        let options = AuditEventOptions {
+            key_ids: None,
+            after_date: Some(after_date),
+            before_date: None,
+        };
+        let after_date_audit = db
+            .find_audit_events(&account_name, EventType::All, Some(options))
+            .await?;
+        // There should only be one log after "now": the one for RetrieveAuditEvents
+        // starting
+        check_after_date(after_date_audit, after_date);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn before_date_filter_works() -> Result<(), LockKeeperServerError> {
+        // Use timestamp as comparison date
+        let before_date = DateTime::now();
+        // Setup db for this test
+        let db = setup_db("before_date_filter_works").await?;
+        // RNG for this test
+        let mut rng = rand::thread_rng();
+
+        // Add a user
+        let (user_id, account_name) = create_user("before_date_filter_test", &mut rng, &db).await?;
+        // Create random audit events
+        let _ = create_random_audit_events(&account_name, &user_id, &mut rng, &db).await?;
+        // Retrieve before the comparison date
+        let options = AuditEventOptions {
+            key_ids: None,
+            after_date: None,
+            before_date: Some(before_date),
+        };
+        let before_date_audit = db
+            .find_audit_events(&account_name, EventType::All, Some(options))
+            .await?;
+        // There shouldn't be any audit events before the comparison date
+        assert_eq!(0, before_date_audit.len());
+
+        Ok(())
+    }
 }

--- a/lock-keeper-key-server/src/operations.rs
+++ b/lock-keeper-key-server/src/operations.rs
@@ -3,6 +3,7 @@ mod create_storage_key;
 mod generate;
 mod register;
 mod retrieve;
+mod retrieve_audit_events;
 mod retrieve_storage_key;
 
 pub use authenticate::Authenticate;
@@ -10,4 +11,5 @@ pub use create_storage_key::CreateStorageKey;
 pub use generate::Generate;
 pub use register::Register;
 pub use retrieve::Retrieve;
+pub use retrieve_audit_events::RetrieveAuditEvents;
 pub use retrieve_storage_key::RetrieveStorageKey;

--- a/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
@@ -3,7 +3,6 @@ use crate::{
     LockKeeperServerError,
 };
 use async_trait::async_trait;
-use tonic::Status;
 use lock_keeper::{
     channel::ServerChannel,
     types::retrieve_audit_events::{client, server},
@@ -19,7 +18,7 @@ impl Operation for RetrieveAuditEvents {
         channel: &mut ServerChannel,
         context: &mut Context,
     ) -> Result<(), LockKeeperServerError> {
-        // Receive user ID and options for audit events to return
+        // Receive event type and options for audit events to return
         let request: client::Request = channel.receive().await?;
 
         let audit_events = context

--- a/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
@@ -1,0 +1,38 @@
+use crate::{
+    server::{Context, Operation},
+    LockKeeperServerError,
+};
+use async_trait::async_trait;
+use tonic::Status;
+use lock_keeper::{
+    channel::ServerChannel,
+    types::retrieve_audit_events::{client, server},
+};
+
+#[derive(Debug)]
+pub struct RetrieveAuditEvents;
+
+#[async_trait]
+impl Operation for RetrieveAuditEvents {
+    async fn operation(
+        self,
+        channel: &mut ServerChannel,
+        context: &mut Context,
+    ) -> Result<(), LockKeeperServerError> {
+        // Receive user ID and options for audit events to return
+        let request: client::Request = channel.receive().await?;
+
+        let audit_events = context
+            .db
+            .find_audit_events(&context.account_name, request.event_type, request.options)
+            .await?;
+
+        let reply = server::Response {
+            summary_record: audit_events,
+        };
+
+        channel.send(reply).await?;
+
+        Ok(())
+    }
+}

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -88,6 +88,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     type CreateStorageKeyStream = MessageStream;
     type GenerateStream = MessageStream;
     type RetrieveStream = MessageStream;
+    type RetrieveAuditEventsStream = MessageStream;
     type RetrieveStorageKeyStream = MessageStream;
 
     async fn health(&self, _: Request<HealthCheck>) -> Result<Response<HealthCheck>, Status> {
@@ -150,6 +151,16 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::RetrieveStorageKeyStream>, Status> {
         let context = self.context(&request, ClientAction::RetrieveStorageKey)?;
         Ok(operations::RetrieveStorageKey
+            .handle_request(context, request)
+            .await?)
+    }
+
+    async fn retrieve_audit_events(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+    ) -> Result<Response<Self::RetrieveAuditEventsStream>, Status> {
+        let context = self.context(&request, ClientAction::RetrieveAuditEvents)?;
+        Ok(operations::RetrieveAuditEvents
             .handle_request(context, request)
             .await?)
     }

--- a/lock-keeper-tests/src/end_to_end.rs
+++ b/lock-keeper-tests/src/end_to_end.rs
@@ -315,20 +315,28 @@ impl Test {
             };
 
             // Check whether the process errors matched the expectation.
-            if let Err(e) = outcome {
-                self.check_audit_events(config, EventStatus::Failed, op)
-                    .await?;
-                match &expected_outcome.expected_error {
-                    Some(expected) => {
-                        let expected_string = expected.to_string();
-                        let error_string = e.to_string();
-                        if expected_string != error_string {
-                            return Err(
-                                TestError::IncorrectError(expected_string, error_string).into()
-                            );
+            match outcome {
+                Ok(_) => {
+                    self.check_audit_events(config, EventStatus::Successful, op)
+                        .await?
+                }
+                Err(e) => {
+                    self.check_audit_events(config, EventStatus::Failed, op)
+                        .await?;
+                    match &expected_outcome.expected_error {
+                        Some(expected) => {
+                            let expected_string = expected.to_string();
+                            let error_string = e.to_string();
+                            if expected_string != error_string {
+                                return Err(TestError::IncorrectError(
+                                    expected_string,
+                                    error_string,
+                                )
+                                .into());
+                            }
                         }
+                        None => return Err(TestError::UnexpectedError.into()),
                     }
-                    None => return Err(TestError::UnexpectedError.into()),
                 }
             }
         }

--- a/lock-keeper-tests/src/end_to_end.rs
+++ b/lock-keeper-tests/src/end_to_end.rs
@@ -1,6 +1,12 @@
 use Operation::{Authenticate, Generate, Register, Retrieve};
 
-use lock_keeper::{config::client::Config, crypto::KeyId, user::AccountName, RetrieveContext};
+use lock_keeper::{
+    audit_event::{EventStatus, EventType},
+    config::client::Config,
+    crypto::KeyId,
+    user::AccountName,
+    ClientAction, RetrieveContext,
+};
 use lock_keeper_client::{
     api::arbitrary_secrets::RetrieveResult, client::Password, LockKeeperClient,
     LockKeeperClientError,
@@ -310,6 +316,8 @@ impl Test {
 
             // Check whether the process errors matched the expectation.
             if let Err(e) = outcome {
+                self.check_audit_events(config, EventStatus::Failed, op)
+                    .await?;
                 match &expected_outcome.expected_error {
                     Some(expected) => {
                         let expected_string = expected.to_string();
@@ -327,6 +335,43 @@ impl Test {
 
         Ok(())
     }
+
+    async fn check_audit_events(
+        &self,
+        config: &Config,
+        expected_status: EventStatus,
+        operation: &Operation,
+    ) -> Result<(), anyhow::Error> {
+        // Map operation to ClientAction (None case is for expected Auth failures)
+        let expected_action = match operation.to_final_client_action(&expected_status) {
+            Some(action) => action,
+            None => return Ok(()),
+        };
+        // Authenticate to LockKeeperClient
+        let lock_keeper_client =
+            LockKeeperClient::authenticated_client(&self.account_name, &self.password, config)
+                .await?;
+
+        // Get audit event log
+        let audit_event_log = lock_keeper_client
+            .retrieve_audit_event_log(EventType::All, None)
+            .await?;
+        // Get the fourth last event, the last 3 are for retrieving audit logs and
+        // authenticating
+        let fourth_last = audit_event_log
+            .len()
+            .checked_sub(4)
+            .map(|i| &audit_event_log[i])
+            .ok_or_else(|| {
+                TestError::InvalidAuditEventLog(
+                    "No last element found in audit event log".to_string(),
+                )
+            })?;
+        // Check that expected status and action match
+        assert_eq!(expected_status, fourth_last.status());
+        assert_eq!(expected_action, fourth_last.action());
+        Ok(())
+    }
 }
 
 #[derive(Debug, Error)]
@@ -338,6 +383,8 @@ enum TestError {
 
     #[error("An error occurred while working with test state: {0:?}")]
     TestStateError(String),
+    #[error("An error occurred while reading the audit log: {0:?}")]
+    InvalidAuditEventLog(String),
     #[error(
         "The wrong value was retrieved from the key server:
     expected: {0:?}
@@ -354,6 +401,29 @@ enum Operation {
     Authenticate(Option<Password>),
     Generate,
     Retrieve,
+}
+
+impl Operation {
+    fn to_final_client_action(&self, status: &EventStatus) -> Option<ClientAction> {
+        match self {
+            Self::Authenticate(_) => {
+                if status == &EventStatus::Failed {
+                    None
+                } else {
+                    Some(ClientAction::Authenticate)
+                }
+            }
+            Self::Generate => Some(ClientAction::Generate),
+            Self::Register => {
+                if status == &EventStatus::Successful {
+                    Some(ClientAction::CreateStorageKey)
+                } else {
+                    Some(ClientAction::Register)
+                }
+            }
+            Self::Retrieve => Some(ClientAction::Retrieve),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/lock-keeper-tests/src/end_to_end.rs
+++ b/lock-keeper-tests/src/end_to_end.rs
@@ -1,7 +1,7 @@
 use Operation::{Authenticate, Generate, Register, Retrieve};
 
 use lock_keeper::{
-    audit_event::{EventStatus, EventType},
+    audit_event::{AuditEventOptions, EventStatus, EventType},
     config::client::Config,
     crypto::KeyId,
     user::AccountName,
@@ -354,7 +354,7 @@ impl Test {
 
         // Get audit event log
         let audit_event_log = lock_keeper_client
-            .retrieve_audit_event_log(EventType::All, None)
+            .retrieve_audit_event_log(EventType::All, AuditEventOptions::default())
             .await?;
         // Get the fourth last event, the last 3 are for retrieving audit logs and
         // authenticating

--- a/lock-keeper/Cargo.toml
+++ b/lock-keeper/Cargo.toml
@@ -22,6 +22,7 @@ rand.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true
@@ -44,6 +45,3 @@ webpki = "0.22"
 
 [build-dependencies]
 tonic-build = "0.8.0"
-
-[dev-dependencies]
-serde_json.workspace = true

--- a/lock-keeper/Cargo.toml
+++ b/lock-keeper/Cargo.toml
@@ -38,6 +38,7 @@ http-serde = "1"
 humantime = "2"
 humantime-serde = "1"
 sha3 = "0.10"
+strum = { version = "0.24.1", features = ["derive"] }
 uuid = "1.1.2"
 webpki = "0.22"
 

--- a/lock-keeper/proto/lock_keeper_rpc.proto
+++ b/lock-keeper/proto/lock_keeper_rpc.proto
@@ -8,6 +8,7 @@ service LockKeeperRpc {
   rpc CreateStorageKey (stream Message) returns (stream Message);
   rpc Generate (stream Message) returns (stream Message);
   rpc Retrieve (stream Message) returns (stream Message);
+  rpc RetrieveAuditEvents (stream Message) returns (stream Message);
   rpc RetrieveStorageKey (stream Message) returns (stream Message);
 }
 

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -83,7 +83,7 @@ impl EventType {
     }
 }
 
-/// Options for filtering [`AuditEvent`]s by
+/// Optional parameters to filter [`AuditEvent`]s by
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AuditEventOptions {
     pub key_ids: Option<Vec<KeyId>>,

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -11,7 +11,7 @@ use std::fmt::{Debug, Display, Formatter};
 use strum::IntoEnumIterator;
 
 /// Options for the outcome of a given action in a [`AuditEvent`]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EventStatus {
     Started,
     Successful,
@@ -48,11 +48,11 @@ impl AuditEvent {
 
 impl AuditEvent {
     pub fn action(&self) -> ClientAction {
-        self.action.clone()
+        self.action
     }
 
-    pub fn key_id(&self) -> Option<KeyId> {
-        self.secret_id.clone()
+    pub fn key_id(&self) -> Option<&KeyId> {
+        self.secret_id.as_ref()
     }
 
     pub fn date(&self) -> DateTime {
@@ -60,7 +60,7 @@ impl AuditEvent {
     }
 
     pub fn status(&self) -> EventStatus {
-        self.status.clone()
+        self.status
     }
 }
 

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -11,7 +11,7 @@ use std::fmt::{Debug, Display, Formatter};
 use strum::IntoEnumIterator;
 
 /// Options for the outcome of a given action in a [`AuditEvent`]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EventStatus {
     Started,
     Successful,
@@ -57,6 +57,10 @@ impl AuditEvent {
 
     pub fn date(&self) -> DateTime {
         self.date
+    }
+
+    pub fn status(&self) -> EventStatus {
+        self.status.clone()
     }
 }
 

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -5,7 +5,7 @@
 use crate::user::AccountName;
 
 use crate::{crypto::KeyId, ClientAction};
-use mongodb::bson::DateTime;
+use bson::DateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use strum::IntoEnumIterator;
@@ -70,6 +70,7 @@ impl EventType {
             ClientAction::Authenticate,
             ClientAction::CreateStorageKey,
             ClientAction::Register,
+            ClientAction::RetrieveAuditEvents,
             ClientAction::RetrieveStorageKey,
         ];
         match self {
@@ -80,4 +81,12 @@ impl EventType {
                 .collect::<Vec<_>>(),
         }
     }
+}
+
+/// Options for filtering [`AuditEvent`]s by
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuditEventOptions {
+    pub key_ids: Option<Vec<KeyId>>,
+    pub after_date: Option<DateTime>,
+    pub before_date: Option<DateTime>,
 }

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -102,7 +102,7 @@ impl EventType {
 }
 
 /// Optional parameters to filter [`AuditEvent`]s by
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AuditEventOptions {
     pub key_ids: Option<Vec<KeyId>>,
     pub after_date: Option<DateTime>,

--- a/lock-keeper/src/audit_event.rs
+++ b/lock-keeper/src/audit_event.rs
@@ -46,6 +46,20 @@ impl AuditEvent {
     }
 }
 
+impl AuditEvent {
+    pub fn action(&self) -> ClientAction {
+        self.action.clone()
+    }
+
+    pub fn key_id(&self) -> Option<KeyId> {
+        self.secret_id.clone()
+    }
+
+    pub fn date(&self) -> DateTime {
+        self.date
+    }
+}
+
 impl Display for AuditEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/lock-keeper/src/error.rs
+++ b/lock-keeper/src/error.rs
@@ -36,6 +36,8 @@ pub enum LockKeeperError {
     OpaqueProtocol(opaque_ke::errors::ProtocolError),
     #[error(transparent)]
     Rustls(#[from] rustls::Error),
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
     #[error("tokio Sender error: {}", .0)]
     TokioSender(String),
     #[error(transparent)]
@@ -75,6 +77,7 @@ impl From<LockKeeperError> for Status {
             | LockKeeperError::InvalidUri(_)
             | LockKeeperError::OpaqueProtocol(_)
             | LockKeeperError::Rustls(_)
+            | LockKeeperError::SerdeJson(_)
             | LockKeeperError::TokioSender(_)
             | LockKeeperError::Toml(_)
             | LockKeeperError::TonicStatus(_)

--- a/lock-keeper/src/lib.rs
+++ b/lock-keeper/src/lib.rs
@@ -85,7 +85,7 @@ macro_rules! impl_message_conversion {
                 type Error = $crate::LockKeeperError;
 
                 fn try_from(value: $crate::types::Message) -> Result<Self, Self::Error> {
-                    Ok(bincode::deserialize(&value.content)?)
+                    Ok(serde_json::from_slice(&value.content)?)
                 }
             }
 
@@ -93,7 +93,7 @@ macro_rules! impl_message_conversion {
                 type Error = $crate::LockKeeperError;
 
                 fn try_from(value: $message_type) -> Result<Self, Self::Error> {
-                    let content = bincode::serialize(&value)?;
+                    let content = serde_json::to_vec(&value)?;
 
                     Ok($crate::types::Message { content })
                 }

--- a/lock-keeper/src/lib.rs
+++ b/lock-keeper/src/lib.rs
@@ -37,13 +37,14 @@ pub mod rpc {
 }
 
 /// Options for actions the Lock Keeper client can take.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, EnumIter)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, EnumIter)]
 pub enum ClientAction {
     Register,
     Authenticate,
     CreateStorageKey,
     Generate,
     Retrieve,
+    RetrieveAuditEvents,
     RetrieveStorageKey,
 }
 

--- a/lock-keeper/src/lib.rs
+++ b/lock-keeper/src/lib.rs
@@ -37,7 +37,7 @@ pub mod rpc {
 }
 
 /// Options for actions the Lock Keeper client can take.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, EnumIter)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, EnumIter)]
 pub enum ClientAction {
     Register,
     Authenticate,

--- a/lock-keeper/src/lib.rs
+++ b/lock-keeper/src/lib.rs
@@ -12,6 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use strum::EnumIter;
 
 pub mod audit_event;
 pub mod blockchain;
@@ -36,7 +37,7 @@ pub mod rpc {
 }
 
 /// Options for actions the Lock Keeper client can take.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum ClientAction {
     Register,
     Authenticate,

--- a/lock-keeper/src/types.rs
+++ b/lock-keeper/src/types.rs
@@ -3,6 +3,7 @@ pub mod create_storage_key;
 pub mod generate;
 pub mod register;
 pub mod retrieve;
+pub mod retrieve_audit_events;
 pub mod retrieve_storage_key;
 
 use tokio_stream::wrappers::ReceiverStream;

--- a/lock-keeper/src/types/retrieve_audit_events.rs
+++ b/lock-keeper/src/types/retrieve_audit_events.rs
@@ -1,16 +1,16 @@
 pub mod client {
-    use crate::{audit_event::EventType, crypto::KeyId, impl_message_conversion, user::UserId};
-    use mongodb::bson::DateTime;
+    use crate::{
+        audit_event::{AuditEventOptions, EventType},
+        impl_message_conversion,
+    };
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
     /// Query specific set of audit event logs
     pub struct Request {
-        pub user_id: UserId,
+        // TODO spec#132: decide whether user ID needs to be added back in to request
         pub event_type: EventType,
-        pub key_ids: Option<Vec<KeyId>>,
-        pub after_date: Option<DateTime>,
-        pub before_date: Option<DateTime>,
+        pub options: Option<AuditEventOptions>,
     }
 
     impl_message_conversion!(Request);

--- a/lock-keeper/src/types/retrieve_audit_events.rs
+++ b/lock-keeper/src/types/retrieve_audit_events.rs
@@ -10,7 +10,7 @@ pub mod client {
     pub struct Request {
         // TODO spec#132: decide whether user ID needs to be added back in to request
         pub event_type: EventType,
-        pub options: Option<AuditEventOptions>,
+        pub options: AuditEventOptions,
     }
 
     impl_message_conversion!(Request);

--- a/lock-keeper/src/types/retrieve_audit_events.rs
+++ b/lock-keeper/src/types/retrieve_audit_events.rs
@@ -1,0 +1,30 @@
+pub mod client {
+    use crate::{audit_event::EventType, crypto::KeyId, impl_message_conversion, user::UserId};
+    use mongodb::bson::DateTime;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// Query specific set of audit event logs
+    pub struct Request {
+        pub user_id: UserId,
+        pub event_type: EventType,
+        pub key_ids: Option<Vec<KeyId>>,
+        pub after_date: Option<DateTime>,
+        pub before_date: Option<DateTime>,
+    }
+
+    impl_message_conversion!(Request);
+}
+
+pub mod server {
+    use crate::{audit_event::AuditEvent, impl_message_conversion};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// Return vector of audit events
+    pub struct Response {
+        pub summary_record: Vec<AuditEvent>,
+    }
+
+    impl_message_conversion!(Response);
+}


### PR DESCRIPTION
Closes #74 

This PR implements the audit event retrieval flow, and also changes the serialization library from `bincode` to `serde_json`.

Question: The spec says that we need to pass the UserId in the request, but the audit events are now stored and looked up by AccountName, and that is passed in the request metadata. Should the UserId be passed in the message anyway? Is there any validation we'd want to add with the UserId (e.g. making sure the AccountName in the metadata matches that of the UserId)?