### PR TITLE
Added cargo make tasks for CI #265

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,20 +47,11 @@ jobs:
         with:
           version: '3.x'
 
-      - name: Format check
-        run: cargo +nightly fmt --all -- --check
+      - name: Install cargo-make
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug cargo-make
 
-      - name: Clippy lint
-        run: cargo clippy --all-features --all-targets --verbose --workspace -- -Dwarnings
-
-      - name: Build
-        run: cargo build --all-features --all-targets --verbose --workspace
-
-      - name: Run all unit + library tests (not doc, integration, benchmark, or example tests)
-        run: cargo test --all-features --lib --bins --workspace
-
-      - name: Run all doctests
-        run: cargo test --all-features --doc --verbose --workspace -- --ignored
-
-      - name: Build documentation
-        run: RUSTDOCFLAGS="-Dwarnings" cargo doc --all-features --no-deps --verbose --workspace
+      - name: Run Tests
+        run: cargo make ci

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,7 +1,7 @@
 [config]
 default_to_workspace = false
 
-# Server tasks
+# -- Server Tasks --
 
 # Shorthand task to start server in the background.
 [tasks.start]
@@ -43,16 +43,55 @@ command = "cargo"
 args = ["run", "--bin", "key-server-cli", "./dev/local/Server.toml"]
 dependencies = ["certs"]
 
-# Run the interactive client.
-[tasks.lkic]
-command = "cargo"
-args = ["run", "--bin", "lkic"]
+# -- Testing Tasks --
 
 # Run end-to-end tests against a server that can be accessed via localhost.
 # Servers running in Docker satisfy this requirement.
 [tasks.e2e]
 command = "cargo"
 args = ["run", "--bin", "lock-keeper-tests", "./dev/local/Client.toml"]
+
+# -- CI Tasks --
+[tasks.ci]
+dependencies = ["ci-format", "ci-clippy", "ci-build", "ci-tests", "ci-doc-tests", "ci-docs", "ci-database-tests"]
+
+[tasks.ci-format]
+toolchain = "nightly"
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.ci-clippy]
+command = "cargo"
+args = ["clippy", "--all-features", "--all-targets", "--workspace", "--", "-Dwarnings"]
+
+[tasks.ci-build]
+command = "cargo"
+args = ["build", "--all-features", "--all-targets", "--workspace"]
+
+[tasks.ci-tests]
+command = "cargo"
+args = ["test", "--all-features", "--lib", "--bins", "--workspace"]
+
+[tasks.ci-doc-tests]
+command = "cargo"
+args = ["test", "--all-features", "--doc", "--workspace"]
+
+[tasks.ci-docs]
+command = "cargo"
+env = { "RUSTDOCFLAGS" = "-Dwarnings" }
+args = ["doc", "--all-features", "--no-deps", "--workspace"]
+
+# TODO: Remove with #268
+[tasks.ci-database-tests]
+command = "cargo"
+args = ["test", "--all-features", "--lib", "--bins", "--workspace", "--", "--ignored"]
+
+# -- Utility Tasks --
+
+# Run the interactive client.
+[tasks.lkic]
+command = "cargo"
+args = ["run", "--bin", "lkic"]
 
 # Generate certificates in the dev directory at the root of this repo.
 [tasks.certs]

--- a/lock-keeper-tests/src/main.rs
+++ b/lock-keeper-tests/src/main.rs
@@ -31,7 +31,7 @@ async fn wait_for_server(config: &Config) {
             Err(_) => {
                 println!("Server connection failed. Retrying in {:?}", RETRY_DELAY);
                 if i == 0 {
-                    println!("Did you remember to run `cargo make run-server`?")
+                    println!("Did you remember to run `cargo make start`?")
                 }
                 std::thread::sleep(RETRY_DELAY);
             }


### PR DESCRIPTION
This PR adds some new tasks to `Makefile.toml` for use in CI. CI now calls `cargo make ci` to run all checks. This also allows developers to run `cargo make ci` locally before pushing to Github so that they can feel confident that their commits will pass CI checks.

`cargo make ci` currently requires MongoDB to be running on your local machine due the the database unit tests.

Closes #265 