### PR TITLE
add import methods for secret types

### DIFF
--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -268,6 +268,41 @@ impl KeyId {
     }
 }
 
+/// The set of types that can be imported into the system, either to the key
+/// server only or as a local import with remote backup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Importable {
+    ArbitrarySecret,
+    SigningKey,
+}
+
+/// Raw material for imported key types.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Import {
+    material: Vec<u8>,
+    key_type: Importable,
+}
+
+impl Import {
+    /// Wrap key material as an import.
+    pub fn new(material: &[u8], key_type: Importable) -> Self {
+        Self {
+            material: material.into(),
+            key_type,
+        }
+    }
+
+    /// Retrieve the key type.
+    pub fn key_type(&self) -> Importable {
+        self.key_type
+    }
+
+    /// Extract the key material.
+    pub fn into_material(self) -> Vec<u8> {
+        self.material
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;

--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -268,41 +268,6 @@ impl KeyId {
     }
 }
 
-/// The set of types that can be imported into the system, either to the key
-/// server only or as a local import with remote backup.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Importable {
-    ArbitrarySecret,
-    SigningKey,
-}
-
-/// Raw material for imported key types.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Import {
-    material: Vec<u8>,
-    key_type: Importable,
-}
-
-impl Import {
-    /// Wrap key material as an import.
-    pub fn new(material: &[u8], key_type: Importable) -> Self {
-        Self {
-            material: material.into(),
-            key_type,
-        }
-    }
-
-    /// Retrieve the key type.
-    pub fn key_type(&self) -> Importable {
-        self.key_type
-    }
-
-    /// Extract the key material.
-    pub fn into_material(self) -> Vec<u8> {
-        self.material
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;

--- a/lock-keeper/src/crypto/generic.rs
+++ b/lock-keeper/src/crypto/generic.rs
@@ -262,6 +262,11 @@ impl Secret {
         }
     }
 
+    /// Retrieve the context for this secret.
+    ///
+    /// This is currently only used in testing, but it is fine to make it
+    /// publicly accessible if necessary.
+    #[cfg(test)]
     pub(super) fn context(&self) -> &AssociatedData {
         &self.context
     }

--- a/lock-keeper/src/crypto/generic.rs
+++ b/lock-keeper/src/crypto/generic.rs
@@ -252,6 +252,19 @@ impl Secret {
             context,
         }
     }
+
+    /// Create a new secret from its constituent parts.
+    /// This is unchecked; use with care.
+    pub(super) fn from_parts(secret_material: &[u8], context: &AssociatedData) -> Self {
+        Self {
+            material: secret_material.to_vec(),
+            context: context.clone(),
+        }
+    }
+
+    pub(super) fn context(&self) -> &AssociatedData {
+        &self.context
+    }
 }
 
 impl From<Secret> for Vec<u8> {

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -54,6 +54,31 @@ impl SigningKeyPair {
         SigningKeyPair
     }
 
+    /// Create a `SigningKeyPair` from an imported key and encrypt it for
+    /// storage at a server.
+    ///
+    /// This is part of the import flow and must be run by the client.
+    pub fn import_and_encrypt(
+        _key_material: &[u8],
+        rng: &mut (impl CryptoRng + RngCore),
+        storage_key: &StorageKey,
+        user_id: &UserId,
+        key_id: &KeyId,
+    ) -> Result<(Self, Encrypted<Self>), LockKeeperError> {
+        let context = AssociatedData::new()
+            .with_bytes(user_id.clone())
+            .with_bytes(key_id.clone())
+            .with_str("imported key");
+
+        // TODO #235: use the actual key material and the context.
+        let signing_key = SigningKeyPair;
+
+        Ok((
+            signing_key.clone(),
+            Encrypted::encrypt(rng, &storage_key.0, signing_key, &context)?,
+        ))
+    }
+
     /// Create and encrypt a new signing key. This is part of the local signing
     /// key generation flow.
     ///

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -71,7 +71,7 @@ impl SigningKeyPair {
     /// storage at a server, under a key known only to the client.
     ///
     /// This is part of the local import with remote backup flow and must be run
-    /// by the client. In this flow, the key server will only recieve an
+    /// by the client. In this flow, the key server will only receive an
     /// [`Encrypted<SigningKeyPair>`], not the cleartext.
     ///
     /// This function takes the following steps:
@@ -104,7 +104,7 @@ impl SigningKeyPair {
     /// a server, under a key known only to the client.
     ///
     /// This is part of the local signing key generation flow and must be run by
-    /// the client. In this flow the key server will only recieve an
+    /// the client. In this flow the key server will only receive an
     /// [`Encrypted<SigningKeyPair>`], not the cleartext.
     ///
     /// This function takes the following steps:


### PR DESCRIPTION
Closes boltlabs-inc/key-mgmt-spec#134: adds an import-and-encrypt method for signing keys and arbitrary secrets.

I added a new item to #235 to implement this correctly for signing keys. I also added context to the (previously trivial) signing keys because I wanted to test that the context is set correctly.  This adds a bit of boilerplate code that is actually duplicated in #262.

