### PR TITLE
Run cargo audit when dependencies change #275

### DIFF
--- a/.github/workflows/audit-scheduled.yml
+++ b/.github/workflows/audit-scheduled.yml
@@ -1,0 +1,14 @@
+# Runs a daily security audit of dependencies using `cargo audit`, an issue gets created for vulnerabilities detected
+name: Scheduled security audit
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,12 +1,14 @@
-# Runs a daily security audit of dependencies using `cargo audit`, an issue gets created for vulnerabilities detected
+# Runs `cargo audit` when dependencies change
 name: Security audit
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
+  push:
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
 jobs:
-  audit:
+  security_audit:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/audit-check@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14"
 hyper-rustls = { version = "0.23", features = ["http2"] }
-mongodb = "2.3.0"
+mongodb = "2.3"
 opaque-ke = { version = "2.0.0-pre.3", features = ["argon2"] }
 prost = "0.11.0"
 rand = "0.8"


### PR DESCRIPTION
We had some discussions on Slack and it turns out that we already have `cargo audit` running daily. That action also creates issues for any vulnerabilities it finds.

This PR adds a new action that runs any time dependencies change. This action will fail if it discovers any vulnerabilities but it will allow the CI workflow to continue so that we're not blocked.

Closes #275 