### PR TITLE
Added name filtering to e2e tests

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,6 +15,10 @@ alias = "stop-server"
 [tasks.teardown]
 alias = "teardown-server"
 
+# Stops the server, recompiles it, and restarts it
+[tasks.restart]
+dependencies = ["stop", "start"]
+
 # Start a key server and monitor its output.
 [tasks.start-server]
 command = "docker"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ If you want to watch server output in real-time, you can run the server in the f
 cargo make start-server
 ```
 
+Running the test binary directly offer some extra command line options.
+
+To only run tests whose name contains certain words, use the `--filter` option
+```bash
+cargo run --bin lock-keeper-tests -- --filter generate --filter retrieve
+```
 
 ## Running the server locally
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,5 @@ services:
       - 1113:1113
     depends_on:
       - "mongodb"
+    stdin_open: true
+    tty: true 

--- a/lkic/src/main.rs
+++ b/lkic/src/main.rs
@@ -10,7 +10,7 @@ use lock_keeper::config::client::Config;
 #[tokio::main]
 pub async fn main() {
     let cli = cli::Cli::parse();
-    let config = Config::load(&cli.config).await.unwrap();
+    let config = Config::load(&cli.config).unwrap();
 
     app::run(config, cli.storage_path).await.unwrap();
 }

--- a/lock-keeper-tests/src/config.rs
+++ b/lock-keeper-tests/src/config.rs
@@ -1,0 +1,47 @@
+use lock_keeper::config::client;
+
+use crate::Cli;
+
+#[derive(Debug)]
+pub struct Config {
+    pub client_config: client::Config,
+    pub filters: TestFilters,
+}
+
+impl TryFrom<Cli> for Config {
+    type Error = anyhow::Error;
+
+    fn try_from(cli: Cli) -> Result<Self, Self::Error> {
+        let client_config = client::Config::load(&cli.client_config)?;
+        Ok(Self {
+            client_config,
+            filters: cli.filters.unwrap_or_default().into(),
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TestFilters {
+    filters: Vec<String>,
+}
+
+impl From<Vec<String>> for TestFilters {
+    fn from(filters: Vec<String>) -> Self {
+        Self { filters }
+    }
+}
+
+impl TestFilters {
+    pub fn matches(&self, text: &str) -> bool {
+        if self.filters.is_empty() {
+            return true;
+        }
+
+        for filter in &self.filters {
+            if text.to_lowercase().contains(&filter.to_lowercase()) {
+                return true;
+            }
+        }
+        false
+    }
+}

--- a/lock-keeper/src/config/client.rs
+++ b/lock-keeper/src/config/client.rs
@@ -17,8 +17,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub async fn load(config_path: impl AsRef<Path>) -> Result<Config, LockKeeperError> {
-        let config_string = tokio::fs::read_to_string(&config_path).await?;
+    pub fn load(config_path: impl AsRef<Path>) -> Result<Config, LockKeeperError> {
+        let config_string = std::fs::read_to_string(&config_path)?;
         let config = Self::from_str(&config_string)?;
         Ok(config)
     }


### PR DESCRIPTION
Adds the ability to specify filters to the e2e tests. If filters are provided, tests will only run if their name contains the text of the filter argument. See README for an example.

This PR also includes a few housekeeping items:
- `cargo make restart` task added to quickly rebuild and run server after making code changes.
- Updated docker compose to run key server with Docker's `-it` flags for easier  attach/detach behavior.
- Configs are now loaded synchronously. 

This code was pulled from https://github.com/boltlabs-inc/key-mgmt/pull/273 to make that PR smaller.

