### PR TITLE
258 import signing keys

### DIFF
--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -8,6 +8,7 @@
 mod authenticate;
 mod create_storage_key;
 mod generate;
+mod import_signing_key;
 mod register;
 mod remote_generate;
 mod retrieve;
@@ -143,6 +144,21 @@ impl LockKeeperClient {
         )
         .await?;
         self.handle_generate(&mut client_channel).await
+    }
+
+    /// Import signing key material to the key server
+    pub async fn import_signing_key(
+        &self,
+        key_material: Vec<u8>,
+    ) -> Result<KeyId, LockKeeperClientError> {
+        let mut client_channel = Self::create_channel(
+            &mut self.tonic_client(),
+            ClientAction::ImportSigningKey,
+            self.account_name(),
+        )
+        .await?;
+        self.handle_import_signing_key(&mut client_channel, key_material)
+            .await
     }
 
     /// Retrieve an arbitrary secret from the key server by [`KeyId`]

--- a/lock-keeper-client/src/api/import_signing_key.rs
+++ b/lock-keeper-client/src/api/import_signing_key.rs
@@ -11,9 +11,7 @@ impl LockKeeperClient {
         channel: &mut ClientChannel,
         key_material: Vec<u8>,
     ) -> Result<KeyId, LockKeeperClientError> {
-        let key_material = Import {
-            material: key_material,
-        };
+        let key_material = Import { key_material };
         // Send UserId and key material to server
         let request = client::Request {
             user_id: self.user_id().clone(),

--- a/lock-keeper-client/src/api/import_signing_key.rs
+++ b/lock-keeper-client/src/api/import_signing_key.rs
@@ -1,0 +1,29 @@
+use crate::{LockKeeperClient, LockKeeperClientError};
+use lock_keeper::{
+    crypto::{Import, KeyId},
+    infrastructure::channel::ClientChannel,
+    types::operations::import_signing_key::{client, server},
+};
+
+impl LockKeeperClient {
+    pub(crate) async fn handle_import_signing_key(
+        &self,
+        channel: &mut ClientChannel,
+        key_material: Vec<u8>,
+    ) -> Result<KeyId, LockKeeperClientError> {
+        let key_material = Import {
+            material: key_material,
+        };
+        // Send UserId and key material to server
+        let request = client::Request {
+            user_id: self.user_id().clone(),
+            key_material,
+        };
+        channel.send(request).await?;
+
+        // Get KeyId for imported key from server
+        let server_response: server::Response = channel.receive().await?;
+
+        Ok(server_response.key_id)
+    }
+}

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -188,6 +188,7 @@ impl LockKeeperClient {
             ClientAction::CreateStorageKey => client.create_storage_key(stream).await,
             ClientAction::Export => client.retrieve(stream).await,
             ClientAction::Generate => client.generate(stream).await,
+            ClientAction::ImportSigningKey => client.import_signing_key(stream).await,
             ClientAction::Register => client.register(stream).await,
             ClientAction::RemoteGenerate => client.remote_generate(stream).await,
             ClientAction::Retrieve => client.retrieve(stream).await,

--- a/lock-keeper-key-server/src/database/secrets.rs
+++ b/lock-keeper-key-server/src/database/secrets.rs
@@ -36,6 +36,27 @@ impl Database {
         Ok(())
     }
 
+    /// Add a [`StoredSigningKeyPair`] to a [`User`]'s list of arbitrary
+    /// secrets
+    pub async fn add_server_imported_signing_key(
+        &self,
+        user_id: &UserId,
+        secret: SigningKeyPair,
+        key_id: KeyId,
+    ) -> Result<(), LockKeeperServerError> {
+        let collection = self.inner.collection::<User>(constants::USERS);
+        let stored_secret = StoredSigningKeyPair::new(secret, key_id);
+        let stored_secret_bson = mongodb::bson::to_bson(&stored_secret)?;
+        let filter = doc! { USER_ID: user_id };
+        let update =
+            doc! { "$push":  { "secrets.server_created_signing_keys": stored_secret_bson } };
+        let _ = collection
+            .find_one_and_update(filter, update, None)
+            .await?
+            .ok_or(LockKeeperServerError::InvalidAccount)?;
+        Ok(())
+    }
+
     /// Get a [`User`]'s [`StoredEncryptedSecret`] based on its [`KeyId`]
     pub async fn get_user_secret(
         &self,

--- a/lock-keeper-key-server/src/operations.rs
+++ b/lock-keeper-key-server/src/operations.rs
@@ -1,6 +1,7 @@
 mod authenticate;
 mod create_storage_key;
 mod generate;
+mod import_signing_key;
 mod register;
 mod remote_generate;
 mod retrieve;
@@ -10,6 +11,7 @@ mod retrieve_storage_key;
 pub use authenticate::Authenticate;
 pub use create_storage_key::CreateStorageKey;
 pub use generate::Generate;
+pub use import_signing_key::ImportSigningKey;
 pub use register::Register;
 pub use remote_generate::RemoteGenerate;
 pub use retrieve::Retrieve;

--- a/lock-keeper-key-server/src/operations/import_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/import_signing_key.rs
@@ -1,0 +1,49 @@
+use crate::{
+    server::{Context, Operation},
+    LockKeeperServerError,
+};
+
+use async_trait::async_trait;
+use lock_keeper::{
+    crypto::KeyId,
+    infrastructure::channel::ServerChannel,
+    types::operations::import_signing_key::{client, server},
+};
+
+#[derive(Debug)]
+pub struct ImportSigningKey;
+
+#[async_trait]
+impl Operation for ImportSigningKey {
+    async fn operation(
+        self,
+        channel: &mut ServerChannel,
+        context: &mut Context,
+    ) -> Result<(), LockKeeperServerError> {
+        // Receive UserId and key material from client
+        let request: client::Request = channel.receive().await?;
+
+        // Generate new KeyId
+        let key_id = {
+            let mut rng = context.rng.lock().await;
+            KeyId::generate(&mut *rng, &request.user_id)?
+        };
+        context.key_id = Some(key_id.clone());
+
+        // Make signing key out of bytes
+        let signing_key = request
+            .key_material
+            .into_signing_key(&request.user_id, &key_id)?;
+
+        // Check validity of ciphertext and store in DB
+        context
+            .db
+            .add_server_imported_signing_key(&request.user_id, signing_key, key_id.clone())
+            .await?;
+
+        // Serialize KeyId and send to client
+        let reply = server::Response { key_id };
+        channel.send(reply).await?;
+        Ok(())
+    }
+}

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -110,6 +110,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     type AuthenticateStream = MessageStream;
     type CreateStorageKeyStream = MessageStream;
     type GenerateStream = MessageStream;
+    type ImportSigningKeyStream = MessageStream;
     type RemoteGenerateStream = MessageStream;
     type RetrieveStream = MessageStream;
     type RetrieveAuditEventsStream = MessageStream;
@@ -155,6 +156,16 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     ) -> Result<Response<Self::GenerateStream>, Status> {
         let context = self.context(&request)?;
         Ok(operations::Generate
+            .handle_request(context, request)
+            .await?)
+    }
+
+    async fn import_signing_key(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+    ) -> Result<Response<Self::ImportSigningKeyStream>, Status> {
+        let context = self.context(&request)?;
+        Ok(operations::ImportSigningKey
             .handle_request(context, request)
             .await?)
     }

--- a/lock-keeper/proto/lock_keeper_rpc.proto
+++ b/lock-keeper/proto/lock_keeper_rpc.proto
@@ -8,6 +8,7 @@ service LockKeeperRpc {
   rpc CreateStorageKey (stream Message) returns (stream Message);
   rpc Generate (stream Message) returns (stream Message);
   rpc RemoteGenerate (stream Message) returns (stream Message);
+  rpc ImportSigningKey (stream Message) returns (stream Message);
   rpc Retrieve (stream Message) returns (stream Message);
   rpc RetrieveAuditEvents (stream Message) returns (stream Message);
   rpc RetrieveStorageKey (stream Message) returns (stream Message);

--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -22,7 +22,7 @@ mod signing_key;
 pub use arbitrary_secret::Secret;
 use generic::{AssociatedData, EncryptionKey};
 pub use generic::{CryptoError, Encrypted};
-pub use signing_key::{PlaceholderEncryptedSigningKeyPair, SigningKeyPair};
+pub use signing_key::{Import, PlaceholderEncryptedSigningKeyPair, SigningKeyPair};
 
 /// A session key is produced as shared output for client and server from
 /// OPAQUE.

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -169,7 +169,7 @@ impl Import {
         self,
         user_id: &UserId,
         key_id: &KeyId,
-    ) -> Result<SigningKeyPair, CryptoError> {
+    ) -> Result<SigningKeyPair, LockKeeperError> {
         let context = AssociatedData::new()
             .with_bytes(user_id.clone())
             .with_bytes(key_id.clone())

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -11,7 +11,7 @@ use super::{generic::AssociatedData, CryptoError, Encrypted, KeyId, StorageKey};
 ///
 /// This can be generated locally by the client or remotely by the server.
 #[allow(unused)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SigningKeyPair {
     context: AssociatedData,
 }

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -147,13 +147,13 @@ impl SigningKeyPair {
 /// Raw material for an imported signing key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Import {
-    pub material: Vec<u8>,
+    pub key_material: Vec<u8>,
 }
 
 impl From<&[u8]> for Import {
     fn from(bytes: &[u8]) -> Self {
         Self {
-            material: bytes.into(),
+            key_material: bytes.into(),
         }
     }
 }

--- a/lock-keeper/src/types/database/secrets.rs
+++ b/lock-keeper/src/types/database/secrets.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct StoredSecrets {
     pub arbitrary_secrets: Vec<StoredEncryptedSecret>,
     pub signing_keys: Vec<StoredEncryptedSigningKeyPair>,
-    pub server_generated_signing_keys: Vec<StoredSigningKeyPair>,
+    pub server_created_signing_keys: Vec<StoredSigningKeyPair>,
 }
 
 /// Wrapper around an [`Encrypted<Secret>`] and its [`KeyId`]

--- a/lock-keeper/src/types/database/secrets.rs
+++ b/lock-keeper/src/types/database/secrets.rs
@@ -29,7 +29,10 @@ impl StoredEncryptedSecret {
     }
 }
 
-/// Wrapper around an [`Encrypted<SigningKeyPair>`] and its [`KeyId`]
+/// Wrapper around an [`Encrypted<SigningKeyPair>`] and its [`KeyId`].
+///
+/// This is used to hold signing key pairs encrypted by the client before being
+/// sent by the server.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct StoredEncryptedSigningKeyPair {
     pub signing_key: Encrypted<SigningKeyPair>,
@@ -48,8 +51,10 @@ impl StoredEncryptedSigningKeyPair {
 }
 
 /// Wrapper around an [`SigningKeyPair`] and its [`KeyId`]
+///
+/// This is used to hold signing key pairs sent by the client in the clear and
+/// encrypted by the server.
 #[derive(Debug, Deserialize, Serialize)]
-#[allow(unused)]
 pub struct StoredSigningKeyPair {
     pub signing_key: PlaceholderEncryptedSigningKeyPair,
     pub key_id: KeyId,

--- a/lock-keeper/src/types/operations.rs
+++ b/lock-keeper/src/types/operations.rs
@@ -3,6 +3,7 @@
 pub mod authenticate;
 pub mod create_storage_key;
 pub mod generate;
+pub mod import_signing_key;
 pub mod register;
 pub mod remote_generate;
 pub mod retrieve;
@@ -21,6 +22,7 @@ pub enum ClientAction {
     CreateStorageKey,
     Export,
     Generate,
+    ImportSigningKey,
     Register,
     RemoteGenerate,
     Retrieve,

--- a/lock-keeper/src/types/operations/import_signing_key.rs
+++ b/lock-keeper/src/types/operations/import_signing_key.rs
@@ -1,0 +1,26 @@
+pub mod client {
+    use crate::{crypto::Import, impl_message_conversion, types::database::user::UserId};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// send user ID and material to import
+    pub struct Request {
+        pub user_id: UserId,
+        pub key_material: Import,
+    }
+
+    impl_message_conversion!(Request);
+}
+
+pub mod server {
+    use crate::{crypto::KeyId, impl_message_conversion};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Deserialize, Serialize)]
+    /// return new requested key ID
+    pub struct Response {
+        pub key_id: KeyId,
+    }
+
+    impl_message_conversion!(Response);
+}


### PR DESCRIPTION
Closes #258 

Making this to reconcile differences with remote generation branch. I like the new types module structure there, so I'll port that over. 

Things that will probably be helpful for remote generation:
- the Import type - this can maybe be a more general wrapper around bytes that can be turned into a signing key?
- the different stored secret types
- the struct that holds a user's different secrets (@picklenerd I went with a struct after all because there were more than just the 2 types of keys)

Update:
The export branch is branched off this one, so this should be merged first. There is a question in the export PR (#287) about import behavior.