### PR TITLE
Refactor database types into submodules

### DIFF
--- a/lkic/src/state.rs
+++ b/lkic/src/state.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use crate::storage::Storage;
-use lock_keeper::{config::client::Config, types::user::AccountName};
+use lock_keeper::{config::client::Config, types::database::user::AccountName};
 use lock_keeper_client::client::Password;
 
 /// In-memory state for a running application

--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -18,8 +18,8 @@ use lock_keeper::{
     crypto::{KeyId, Secret},
     types::{
         audit_event::{AuditEvent, AuditEventOptions, EventType},
+        database::user::AccountName,
         operations::{retrieve::RetrieveContext, ClientAction},
-        user::AccountName,
     },
 };
 use rand::{rngs::StdRng, SeedableRng};
@@ -171,10 +171,10 @@ impl LockKeeperClient {
     /// and each asset fiduciary (if relevant), and any other relevant
     /// details.
     ///
-    /// The [`lock_keeper::types::user::UserId`] must match the asset owner
-    /// authenticated in the [`crate::LockKeeperClient`], and if specified,
-    /// the [`KeyId`] must correspond to a key owned by the
-    /// [`lock_keeper::types::user::UserId`].
+    /// The [`lock_keeper::types::database::user::UserId`] must match the asset
+    /// owner authenticated in the [`crate::LockKeeperClient`], and if
+    /// specified, the [`KeyId`] must correspond to a key owned by the
+    /// [`lock_keeper::types::database::user::UserId`].
     ///
     /// Output: if successful, returns a [`String`] representation of the logs.
     pub async fn retrieve_audit_event_log(

--- a/lock-keeper-client/src/api/authenticate.rs
+++ b/lock-keeper-client/src/api/authenticate.rs
@@ -6,8 +6,8 @@ use lock_keeper::{
     crypto::OpaqueSessionKey,
     infrastructure::channel::ClientChannel,
     types::{
+        database::user::{AccountName, UserId},
         operations::authenticate::{client, server},
-        user::{AccountName, UserId},
     },
 };
 use opaque_ke::{

--- a/lock-keeper-client/src/api/create_storage_key.rs
+++ b/lock-keeper-client/src/api/create_storage_key.rs
@@ -3,8 +3,8 @@ use lock_keeper::{
     crypto::OpaqueExportKey,
     infrastructure::channel::ClientChannel,
     types::{
+        database::user::{AccountName, UserId},
         operations::create_storage_key::{client, server},
-        user::{AccountName, UserId},
     },
 };
 use rand::{CryptoRng, RngCore};

--- a/lock-keeper-client/src/api/generate.rs
+++ b/lock-keeper-client/src/api/generate.rs
@@ -3,8 +3,8 @@ use lock_keeper::{
     crypto::{KeyId, Secret, StorageKey},
     infrastructure::channel::ClientChannel,
     types::{
+        database::user::UserId,
         operations::generate::{client, server},
-        user::UserId,
     },
 };
 use rand::rngs::StdRng;

--- a/lock-keeper-client/src/api/register.rs
+++ b/lock-keeper-client/src/api/register.rs
@@ -7,8 +7,8 @@ use lock_keeper::{
     crypto::OpaqueExportKey,
     infrastructure::channel::ClientChannel,
     types::{
+        database::user::AccountName,
         operations::register::{client, server},
-        user::AccountName,
     },
 };
 use opaque_ke::{

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -12,11 +12,11 @@ use lock_keeper::{
     infrastructure::channel::ClientChannel,
     rpc::lock_keeper_rpc_client::LockKeeperRpcClient,
     types::{
+        database::user::{AccountName, UserId},
         operations::{
             retrieve_storage_key::{client, server},
             ClientAction,
         },
-        user::{AccountName, UserId},
     },
 };
 use rand::{rngs::StdRng, SeedableRng};

--- a/lock-keeper-key-server/src/database.rs
+++ b/lock-keeper-key-server/src/database.rs
@@ -7,7 +7,7 @@ use crate::constants;
 use lock_keeper::{
     config::server::DatabaseSpec,
     constants::{ACCOUNT_NAME, USER_ID},
-    types::user::User,
+    types::database::user::User,
 };
 use mongodb::{
     bson::doc,
@@ -18,6 +18,7 @@ use mongodb::{
 use crate::error::LockKeeperServerError;
 
 pub(crate) mod audit_event;
+pub(crate) mod secrets;
 pub(crate) mod user;
 
 #[derive(Clone, Debug)]

--- a/lock-keeper-key-server/src/database/audit_event.rs
+++ b/lock-keeper-key-server/src/database/audit_event.rs
@@ -9,8 +9,8 @@ use lock_keeper::{
     crypto::KeyId,
     types::{
         audit_event::{AuditEvent, AuditEventOptions, EventStatus, EventType},
+        database::user::AccountName,
         operations::ClientAction,
-        user::AccountName,
     },
 };
 use mongodb::bson::{doc, Document};
@@ -79,7 +79,7 @@ mod test {
     use crate::database::test::{server_registration, setup_db};
 
     use bson::DateTime;
-    use lock_keeper::types::user::UserId;
+    use lock_keeper::types::database::user::UserId;
     use rand::{seq::SliceRandom, CryptoRng, RngCore};
     use std::str::FromStr;
     use strum::IntoEnumIterator;

--- a/lock-keeper-key-server/src/database/secrets.rs
+++ b/lock-keeper-key-server/src/database/secrets.rs
@@ -1,0 +1,64 @@
+//! Module for operations on secrets in the database.
+
+use crate::{constants, LockKeeperServerError};
+use lock_keeper::{
+    constants::USER_ID,
+    crypto::{Encrypted, KeyId, Secret},
+    types::database::{
+        secrets::StoredSecret,
+        user::{User, UserId},
+    },
+};
+use mongodb::bson::doc;
+
+use super::Database;
+
+pub const SECRETS: &str = "secrets";
+
+impl Database {
+    /// Add a [`StoredSecret`] to a [`User`]'s list of arbitrary secrets
+    pub async fn add_user_secret(
+        &self,
+        user_id: &UserId,
+        secret: Encrypted<Secret>,
+        key_id: KeyId,
+    ) -> Result<(), LockKeeperServerError> {
+        let collection = self.inner.collection::<User>(constants::USERS);
+        let stored_secret = StoredSecret::new(secret, key_id);
+        let stored_secret_bson = mongodb::bson::to_bson(&stored_secret)?;
+        let filter = doc! { USER_ID: user_id };
+        let update = doc! { "$push": { SECRETS: stored_secret_bson } };
+        let _ = collection
+            .find_one_and_update(filter, update, None)
+            .await?
+            .ok_or(LockKeeperServerError::InvalidAccount)?;
+        Ok(())
+    }
+
+    /// Get a [`User`]'s [`StoredSecret`] based on its [`KeyId`]
+    pub async fn get_user_secret(
+        &self,
+        user_id: &UserId,
+        key_id: &KeyId,
+    ) -> Result<StoredSecret, LockKeeperServerError> {
+        // Get user collection
+        let collection = self.inner.collection::<User>(constants::USERS);
+        // Match on UserId and KeyId, update "retrieved" field to true
+        let key_id_bson = mongodb::bson::to_bson(key_id)?;
+        let filter = doc! { USER_ID: user_id, "secrets.key_id": key_id_bson };
+        let update = doc! { "$set": { "secrets.$.retrieved": true } };
+        let user = collection
+            .find_one_and_update(filter, update, None)
+            .await?
+            .ok_or(LockKeeperServerError::InvalidAccount)?;
+
+        // Filter found user to return stored secret
+        let stored_secret = user
+            .secrets
+            .into_iter()
+            .find(|x| x.key_id == *key_id)
+            .ok_or(LockKeeperServerError::KeyNotFound)?;
+
+        Ok(stored_secret)
+    }
+}

--- a/lock-keeper-key-server/src/operations/authenticate.rs
+++ b/lock-keeper-key-server/src/operations/authenticate.rs
@@ -8,8 +8,8 @@ use lock_keeper::{
     config::opaque::OpaqueCipherSuite,
     infrastructure::channel::ServerChannel,
     types::{
+        database::user::UserId,
         operations::authenticate::{client, server},
-        user::UserId,
     },
 };
 use opaque_ke::{ServerLogin, ServerLoginStartParameters, ServerLoginStartResult};

--- a/lock-keeper-key-server/src/operations/create_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/create_storage_key.rs
@@ -7,8 +7,8 @@ use async_trait::async_trait;
 use lock_keeper::{
     infrastructure::channel::ServerChannel,
     types::{
+        database::user::UserId,
         operations::create_storage_key::{client, server},
-        user::UserId,
     },
 };
 

--- a/lock-keeper-key-server/src/operations/register.rs
+++ b/lock-keeper-key-server/src/operations/register.rs
@@ -9,8 +9,8 @@ use lock_keeper::{
     config::opaque::OpaqueCipherSuite,
     infrastructure::channel::ServerChannel,
     types::{
+        database::user::{AccountName, UserId},
         operations::register::{client, server},
-        user::{AccountName, UserId},
     },
 };
 use opaque_ke::ServerRegistration;

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -13,7 +13,7 @@ use lock_keeper::{
     constants::{ACCOUNT_NAME, ACTION},
     crypto::KeyId,
     rpc::{lock_keeper_rpc_server::LockKeeperRpc, HealthCheck},
-    types::{operations::ClientAction, user::AccountName, Message, MessageStream},
+    types::{database::user::AccountName, operations::ClientAction, Message, MessageStream},
 };
 
 use rand::{rngs::StdRng, SeedableRng};
@@ -46,7 +46,10 @@ impl LockKeeperKeyServer {
         })
     }
 
-    pub fn context(&self, request: &Request<tonic::Streaming<Message>>) -> Result<Context, Status> {
+    pub fn context(
+        &self,
+        request: &Request<tonic::Streaming<Message>>,
+    ) -> Result<Context, LockKeeperServerError> {
         // Parse AccountName from metadata
         let account_name_str = Self::str_from_metadata(
             request,

--- a/lock-keeper-tests/src/end_to_end.rs
+++ b/lock-keeper-tests/src/end_to_end.rs
@@ -3,8 +3,8 @@ use lock_keeper::{
     crypto::KeyId,
     types::{
         audit_event::{AuditEventOptions, EventStatus, EventType},
+        database::user::AccountName,
         operations::{retrieve::RetrieveContext, ClientAction},
-        user::AccountName,
     },
 };
 use lock_keeper_client::{

--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -13,7 +13,7 @@ use sha3::{Digest, Sha3_256};
 use std::{array::IntoIter, convert::TryFrom};
 use tracing::error;
 
-use crate::types::user::UserId;
+use crate::types::database::user::UserId;
 
 mod arbitrary_secret;
 mod generic;

--- a/lock-keeper/src/crypto/arbitrary_secret.rs
+++ b/lock-keeper/src/crypto/arbitrary_secret.rs
@@ -1,4 +1,4 @@
-use crate::{types::user::UserId, LockKeeperError};
+use crate::{types::database::user::UserId, LockKeeperError};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -1,4 +1,4 @@
-use crate::{types::user::UserId, LockKeeperError};
+use crate::{types::database::user::UserId, LockKeeperError};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;

--- a/lock-keeper/src/types.rs
+++ b/lock-keeper/src/types.rs
@@ -1,8 +1,8 @@
 //! Type definitions that are shared between crates but have little to no logic.
 
 pub mod audit_event;
+pub mod database;
 pub mod operations;
-pub mod user;
 
 pub use crate::rpc::Message;
 

--- a/lock-keeper/src/types/audit_event.rs
+++ b/lock-keeper/src/types/audit_event.rs
@@ -2,7 +2,7 @@
 //!
 //! Includes possible events to log and statuses of those events
 
-use crate::types::{operations::ClientAction, user::AccountName};
+use crate::types::{database::user::AccountName, operations::ClientAction};
 
 use crate::crypto::KeyId;
 use bson::DateTime;

--- a/lock-keeper/src/types/database.rs
+++ b/lock-keeper/src/types/database.rs
@@ -1,0 +1,4 @@
+//! Models for data stored in the database
+
+pub mod secrets;
+pub mod user;

--- a/lock-keeper/src/types/database/secrets.rs
+++ b/lock-keeper/src/types/database/secrets.rs
@@ -1,0 +1,23 @@
+//! Database models for secrets
+
+use crate::crypto::{Encrypted, KeyId, Secret};
+
+use serde::{Deserialize, Serialize};
+
+/// Wrapper around an [`Encrypted<Secret>`] and its [`KeyId`]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct StoredSecret {
+    pub secret: Encrypted<Secret>,
+    pub key_id: KeyId,
+    pub retrieved: bool,
+}
+
+impl StoredSecret {
+    pub fn new(secret: Encrypted<Secret>, key_id: KeyId) -> Self {
+        Self {
+            secret,
+            key_id,
+            retrieved: false,
+        }
+    }
+}

--- a/lock-keeper/src/types/database/user.rs
+++ b/lock-keeper/src/types/database/user.rs
@@ -1,11 +1,8 @@
-//! Models for the first pass of MongoDB integration.
-//!
-//! Includes structs for the various models found in the first round of Mongo
-//! integration. This module will likely be split by model into sub-modules.
+//! Database models for users and user-related fields
 
 use crate::{
     config::opaque::OpaqueCipherSuite,
-    crypto::{CryptoError, Encrypted, KeyId, Secret, StorageKey},
+    crypto::{CryptoError, Encrypted, StorageKey},
     LockKeeperError,
 };
 
@@ -15,6 +12,8 @@ use rand::{CryptoRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr, vec::IntoIter};
 use uuid::Uuid;
+
+use super::secrets::StoredSecret;
 
 /// Unique ID for a user.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -95,24 +94,6 @@ impl FromStr for AccountName {
 impl AccountName {
     pub fn as_bytes(&self) -> &[u8] {
         self.0.as_bytes()
-    }
-}
-
-/// Wrapper around an [`Encrypted<Secret>`] and its [`KeyId`]
-#[derive(Debug, Deserialize, Serialize)]
-pub struct StoredSecret {
-    pub secret: Encrypted<Secret>,
-    pub key_id: KeyId,
-    pub retrieved: bool,
-}
-
-impl StoredSecret {
-    pub fn new(secret: Encrypted<Secret>, key_id: KeyId) -> Self {
-        Self {
-            secret,
-            key_id,
-            retrieved: false,
-        }
     }
 }
 

--- a/lock-keeper/src/types/operations/authenticate.rs
+++ b/lock-keeper/src/types/operations/authenticate.rs
@@ -1,6 +1,7 @@
 pub mod client {
     use crate::{
-        config::opaque::OpaqueCipherSuite, impl_message_conversion, types::user::AccountName,
+        config::opaque::OpaqueCipherSuite, impl_message_conversion,
+        types::database::user::AccountName,
     };
     use opaque_ke::{CredentialFinalization, CredentialRequest};
     use serde::{Deserialize, Serialize};
@@ -23,7 +24,9 @@ pub mod client {
 }
 
 pub mod server {
-    use crate::{config::opaque::OpaqueCipherSuite, impl_message_conversion, types::user::UserId};
+    use crate::{
+        config::opaque::OpaqueCipherSuite, impl_message_conversion, types::database::user::UserId,
+    };
     use opaque_ke::CredentialResponse;
     use serde::{Deserialize, Serialize};
 

--- a/lock-keeper/src/types/operations/create_storage_key.rs
+++ b/lock-keeper/src/types/operations/create_storage_key.rs
@@ -2,7 +2,7 @@ pub mod client {
     use crate::{
         crypto::{Encrypted, StorageKey},
         impl_message_conversion,
-        types::user::{AccountName, UserId},
+        types::database::user::{AccountName, UserId},
     };
     use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ pub mod client {
 }
 
 pub mod server {
-    use crate::{impl_message_conversion, types::user::UserId};
+    use crate::{impl_message_conversion, types::database::user::UserId};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]

--- a/lock-keeper/src/types/operations/generate.rs
+++ b/lock-keeper/src/types/operations/generate.rs
@@ -2,7 +2,7 @@ pub mod client {
     use crate::{
         crypto::{Encrypted, Secret},
         impl_message_conversion,
-        types::user::UserId,
+        types::database::user::UserId,
     };
     use serde::{Deserialize, Serialize};
 

--- a/lock-keeper/src/types/operations/register.rs
+++ b/lock-keeper/src/types/operations/register.rs
@@ -1,6 +1,7 @@
 pub mod client {
     use crate::{
-        config::opaque::OpaqueCipherSuite, impl_message_conversion, types::user::AccountName,
+        config::opaque::OpaqueCipherSuite, impl_message_conversion,
+        types::database::user::AccountName,
     };
     use opaque_ke::{RegistrationRequest, RegistrationUpload};
     use serde::{Deserialize, Serialize};

--- a/lock-keeper/src/types/operations/retrieve.rs
+++ b/lock-keeper/src/types/operations/retrieve.rs
@@ -8,7 +8,7 @@ pub enum RetrieveContext {
 }
 
 pub mod client {
-    use crate::{crypto::KeyId, impl_message_conversion, types::user::UserId};
+    use crate::{crypto::KeyId, impl_message_conversion, types::database::user::UserId};
     use serde::{Deserialize, Serialize};
 
     use super::RetrieveContext;
@@ -25,7 +25,7 @@ pub mod client {
 }
 
 pub mod server {
-    use crate::{impl_message_conversion, types::user::StoredSecret};
+    use crate::{impl_message_conversion, types::database::secrets::StoredSecret};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]

--- a/lock-keeper/src/types/operations/retrieve_storage_key.rs
+++ b/lock-keeper/src/types/operations/retrieve_storage_key.rs
@@ -1,5 +1,5 @@
 pub mod client {
-    use crate::{impl_message_conversion, types::user::UserId};
+    use crate::{impl_message_conversion, types::database::user::UserId};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This PR creates a new types module for database types and moves the secret functionality out of the `user` module into its own `secrets` module.

Moved from: https://github.com/boltlabs-inc/key-mgmt/pull/283