### PR TITLE
281 export signing keys

### DIFF
--- a/lkic/src/storage.rs
+++ b/lkic/src/storage.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::anyhow;
-use lock_keeper::crypto::{KeyId, PlaceholderEncryptedSigningKeyPair};
+use lock_keeper::crypto::{Export, KeyId};
 use lock_keeper_client::api::{LocalStorage, RetrieveResult};
 use serde::{Deserialize, Serialize};
 
@@ -260,10 +260,10 @@ fn local_storage_bytes(local_storage: &LocalStorage) -> anyhow::Result<Vec<u8>> 
     Ok(bytes)
 }
 
-fn signing_key_bytes(signing_key: &PlaceholderEncryptedSigningKeyPair) -> anyhow::Result<Vec<u8>> {
+fn signing_key_bytes(signing_key: &Export) -> anyhow::Result<Vec<u8>> {
     let json = serde_json::to_value(signing_key)?;
     let key = json
-        .pointer("/context")
+        .pointer("/key_material")
         .ok_or_else(|| anyhow!("Error converting SigningKey to bytes"))?
         .clone();
     let bytes: Vec<u8> = serde_json::from_value(key)?;

--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -147,13 +147,13 @@ impl LockKeeperClient {
         // Create channel: this will internally be a `retrieve` channel
         let mut client_channel = Self::create_channel(
             &mut self.tonic_client(),
-            ClientAction::Export,
+            ClientAction::ExportSigningKey,
             self.account_name(),
         )
         .await?;
         // Get local-only secret
         let secret = self
-            .handle_retrieve(&mut client_channel, key_id, RetrieveContext::LocalOnly)
+            .handle_retrieve_signing_key(&mut client_channel, key_id, RetrieveContext::LocalOnly)
             .await?;
         // Return secret as bytes
         match secret {

--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -17,7 +17,7 @@ mod retrieve_audit_events;
 use crate::{client::Password, LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
     config::client::Config,
-    crypto::{KeyId, Secret},
+    crypto::{KeyId, PlaceholderEncryptedSigningKeyPair, Secret},
     types::{
         audit_event::{AuditEvent, AuditEventOptions, EventType},
         database::user::AccountName,
@@ -34,6 +34,7 @@ use tracing::error;
 pub enum RetrieveResult {
     None,
     ArbitraryKey(LocalStorage),
+    SigningKey(PlaceholderEncryptedSigningKeyPair),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -132,6 +133,33 @@ impl LockKeeperClient {
         match secret {
             RetrieveResult::None => Err(LockKeeperClientError::ExportFailed),
             RetrieveResult::ArbitraryKey(local_storage) => Ok(local_storage.secret.into()),
+            RetrieveResult::SigningKey(_) => Err(LockKeeperClientError::InvalidKeyRetrieved),
+        }
+    }
+
+    /// Export signing key pair material from the key servers.
+    ///
+    /// Output: If successful, returns the requested key material in byte form.
+    pub async fn export_signing_key(
+        &self,
+        key_id: &KeyId,
+    ) -> Result<Vec<u8>, LockKeeperClientError> {
+        // Create channel: this will internally be a `retrieve` channel
+        let mut client_channel = Self::create_channel(
+            &mut self.tonic_client(),
+            ClientAction::Export,
+            self.account_name(),
+        )
+        .await?;
+        // Get local-only secret
+        let secret = self
+            .handle_retrieve(&mut client_channel, key_id, RetrieveContext::LocalOnly)
+            .await?;
+        // Return secret as bytes
+        match secret {
+            RetrieveResult::None => Err(LockKeeperClientError::ExportFailed),
+            RetrieveResult::ArbitraryKey(local_storage) => Ok(local_storage.secret.into()),
+            RetrieveResult::SigningKey(_) => Err(LockKeeperClientError::InvalidKeyRetrieved),
         }
     }
 
@@ -217,6 +245,22 @@ impl LockKeeperClient {
         )
         .await?;
         self.handle_retrieve_audit_events(&mut client_channel, event_type, options)
+            .await
+    }
+
+    /// Retrieve a signing key pair from the key server by [`KeyId`]
+    pub async fn retrieve_signing_key(
+        &self,
+        key_id: &KeyId,
+        context: RetrieveContext,
+    ) -> Result<RetrieveResult, LockKeeperClientError> {
+        let mut client_channel = Self::create_channel(
+            &mut self.tonic_client(),
+            ClientAction::RetrieveSigningKey,
+            self.account_name(),
+        )
+        .await?;
+        self.handle_retrieve_signing_key(&mut client_channel, key_id, context)
             .await
     }
 }

--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -17,7 +17,7 @@ mod retrieve_audit_events;
 use crate::{client::Password, LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
     config::client::Config,
-    crypto::{KeyId, PlaceholderEncryptedSigningKeyPair, Secret},
+    crypto::{KeyId, PlaceholderEncryptedSigningKeyPair, Secret, SigningKeyPair},
     types::{
         audit_event::{AuditEvent, AuditEventOptions, EventType},
         database::user::AccountName,
@@ -158,8 +158,11 @@ impl LockKeeperClient {
         // Return secret as bytes
         match secret {
             RetrieveResult::None => Err(LockKeeperClientError::ExportFailed),
-            RetrieveResult::ArbitraryKey(local_storage) => Ok(local_storage.secret.into()),
-            RetrieveResult::SigningKey(_) => Err(LockKeeperClientError::InvalidKeyRetrieved),
+            RetrieveResult::ArbitraryKey(_) => Err(LockKeeperClientError::InvalidKeyRetrieved),
+            RetrieveResult::SigningKey(signing_key) => {
+                let signing_key: SigningKeyPair = signing_key.into();
+                Ok(signing_key.into())
+            }
         }
     }
 

--- a/lock-keeper-client/src/api/retrieve.rs
+++ b/lock-keeper-client/src/api/retrieve.rs
@@ -9,6 +9,8 @@ use lock_keeper::{
 };
 
 impl LockKeeperClient {
+    /// Handles the retrieval of arbitrary secrets
+    /// ([`lock_keeper::crypto::Secret`]) only.
     pub(crate) async fn handle_retrieve(
         &self,
         channel: &mut ClientChannel,
@@ -46,6 +48,8 @@ impl LockKeeperClient {
         }
     }
 
+    /// Handles the retrieval of signing keys
+    /// ([`lock_keeper::crypto::SigningKeyPair`]) only.
     pub(crate) async fn handle_retrieve_signing_key(
         &self,
         channel: &mut ClientChannel,
@@ -62,17 +66,15 @@ impl LockKeeperClient {
         };
         channel.send(request).await?;
 
-        // Get StoredSecret from server
+        // Get Export type back from server
         let server_response: server::ResponseSigningKey = channel.receive().await?;
 
         // Return appropriate value based on Context
         match context {
             RetrieveContext::Null => Ok(RetrieveResult::None),
-            RetrieveContext::LocalOnly => {
-                // Decrypt secret
-                let secret = server_response.stored_secret.signing_key;
-                Ok(RetrieveResult::SigningKey(secret))
-            }
+            RetrieveContext::LocalOnly => Ok(RetrieveResult::SigningKey(
+                server_response.exported_signing_key,
+            )),
         }
     }
 }

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -187,7 +187,7 @@ impl LockKeeperClient {
             ClientAction::Authenticate => client.authenticate(stream).await,
             ClientAction::CreateStorageKey => client.create_storage_key(stream).await,
             ClientAction::Export => client.retrieve(stream).await,
-            ClientAction::ExportSingingKey => client.retrieve_signing_key(stream).await,
+            ClientAction::ExportSigningKey => client.retrieve_signing_key(stream).await,
             ClientAction::Generate => client.generate(stream).await,
             ClientAction::ImportSigningKey => client.import_signing_key(stream).await,
             ClientAction::Register => client.register(stream).await,

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -187,12 +187,14 @@ impl LockKeeperClient {
             ClientAction::Authenticate => client.authenticate(stream).await,
             ClientAction::CreateStorageKey => client.create_storage_key(stream).await,
             ClientAction::Export => client.retrieve(stream).await,
+            ClientAction::ExportSingingKey => client.retrieve_signing_key(stream).await,
             ClientAction::Generate => client.generate(stream).await,
             ClientAction::ImportSigningKey => client.import_signing_key(stream).await,
             ClientAction::Register => client.register(stream).await,
             ClientAction::RemoteGenerate => client.remote_generate(stream).await,
             ClientAction::Retrieve => client.retrieve(stream).await,
             ClientAction::RetrieveAuditEvents => client.retrieve_audit_events(stream).await,
+            ClientAction::RetrieveSigningKey => client.retrieve_signing_key(stream).await,
             ClientAction::RetrieveStorageKey => client.retrieve_storage_key(stream).await,
         }?
         .into_inner();

--- a/lock-keeper-client/src/error.rs
+++ b/lock-keeper-client/src/error.rs
@@ -19,6 +19,8 @@ pub enum LockKeeperClientError {
     InvalidAccount,
     #[error("Invalid login")]
     InvalidLogin,
+    #[error("Invalid key retrieved")]
+    InvalidKeyRetrieved,
 
     // Wrapped errors
     #[error(transparent)]

--- a/lock-keeper-key-server/src/operations.rs
+++ b/lock-keeper-key-server/src/operations.rs
@@ -6,6 +6,7 @@ mod register;
 mod remote_generate;
 mod retrieve;
 mod retrieve_audit_events;
+mod retrieve_signing_key;
 mod retrieve_storage_key;
 
 pub use authenticate::Authenticate;
@@ -16,4 +17,5 @@ pub use register::Register;
 pub use remote_generate::RemoteGenerate;
 pub use retrieve::Retrieve;
 pub use retrieve_audit_events::RetrieveAuditEvents;
+pub use retrieve_signing_key::RetrieveSigningKey;
 pub use retrieve_storage_key::RetrieveStorageKey;

--- a/lock-keeper-key-server/src/operations/import_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/import_signing_key.rs
@@ -38,7 +38,7 @@ impl Operation for ImportSigningKey {
         // Check validity of ciphertext and store in DB
         context
             .db
-            .add_server_imported_signing_key(&request.user_id, signing_key, key_id.clone())
+            .add_remote_secret(&request.user_id, signing_key, key_id.clone())
             .await?;
 
         // Serialize KeyId and send to client

--- a/lock-keeper-key-server/src/operations/retrieve_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_signing_key.rs
@@ -5,6 +5,7 @@ use crate::{
 
 use async_trait::async_trait;
 use lock_keeper::{
+    crypto::{Export, SigningKeyPair},
     infrastructure::channel::ServerChannel,
     types::operations::retrieve::{client, server},
 };
@@ -29,8 +30,12 @@ impl Operation for RetrieveSigningKey {
             .get_user_signing_key(&request.user_id, &request.key_id)
             .await?;
 
-        // Serialize KeyId and send to client
-        let reply = server::ResponseSigningKey { stored_secret };
+        // Convert from signing key to Export, serialize and send
+        let signing_key_pair: SigningKeyPair = stored_secret.signing_key.into();
+        let exported_signing_key = Export::from(signing_key_pair);
+        let reply = server::ResponseSigningKey {
+            exported_signing_key,
+        };
         channel.send(reply).await?;
         Ok(())
     }

--- a/lock-keeper-key-server/src/operations/retrieve_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_signing_key.rs
@@ -1,0 +1,37 @@
+use crate::{
+    server::{Context, Operation},
+    LockKeeperServerError,
+};
+
+use async_trait::async_trait;
+use lock_keeper::{
+    infrastructure::channel::ServerChannel,
+    types::operations::retrieve::{client, server},
+};
+
+#[derive(Debug)]
+pub struct RetrieveSigningKey;
+
+#[async_trait]
+impl Operation for RetrieveSigningKey {
+    async fn operation(
+        self,
+        channel: &mut ServerChannel,
+        context: &mut Context,
+    ) -> Result<(), LockKeeperServerError> {
+        // Receive UserId from client
+        let request: client::RequestSigningKey = channel.receive().await?;
+        context.key_id = Some(request.key_id.clone());
+
+        // Find secret based on key_id
+        let stored_secret = context
+            .db
+            .get_user_signing_key(&request.user_id, &request.key_id)
+            .await?;
+
+        // Serialize KeyId and send to client
+        let reply = server::ResponseSigningKey { stored_secret };
+        channel.send(reply).await?;
+        Ok(())
+    }
+}

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -114,6 +114,7 @@ impl LockKeeperRpc for LockKeeperKeyServer {
     type RemoteGenerateStream = MessageStream;
     type RetrieveStream = MessageStream;
     type RetrieveAuditEventsStream = MessageStream;
+    type RetrieveSigningKeyStream = MessageStream;
     type RetrieveStorageKeyStream = MessageStream;
 
     async fn health(&self, _: Request<HealthCheck>) -> Result<Response<HealthCheck>, Status> {
@@ -190,6 +191,16 @@ impl LockKeeperRpc for LockKeeperKeyServer {
             .await?)
     }
 
+    async fn retrieve_audit_events(
+        &self,
+        request: Request<tonic::Streaming<Message>>,
+    ) -> Result<Response<Self::RetrieveAuditEventsStream>, Status> {
+        let context = self.context(&request)?;
+        Ok(operations::RetrieveAuditEvents
+            .handle_request(context, request)
+            .await?)
+    }
+
     async fn retrieve_storage_key(
         &self,
         request: Request<tonic::Streaming<Message>>,
@@ -200,12 +211,12 @@ impl LockKeeperRpc for LockKeeperKeyServer {
             .await?)
     }
 
-    async fn retrieve_audit_events(
+    async fn retrieve_signing_key(
         &self,
         request: Request<tonic::Streaming<Message>>,
-    ) -> Result<Response<Self::RetrieveAuditEventsStream>, Status> {
+    ) -> Result<Response<Self::RetrieveSigningKeyStream>, Status> {
         let context = self.context(&request)?;
-        Ok(operations::RetrieveAuditEvents
+        Ok(operations::RetrieveSigningKey
             .handle_request(context, request)
             .await?)
     }

--- a/lock-keeper-tests/src/end_to_end.rs
+++ b/lock-keeper-tests/src/end_to_end.rs
@@ -468,8 +468,7 @@ impl Test {
                     match lock_keeper_client.export_key(&key_id).await {
                         Ok(res) => {
                             // Compare generated key and exported key material
-                            let original_local_storage_json =
-                                self.state.get(KEY_MATERIAL)?.clone();
+                            let original_local_storage_json = self.state.get(KEY_MATERIAL)?.clone();
                             let original_local_storage_bytes: Vec<u8> =
                                 serde_json::from_value::<LocalStorage>(
                                     original_local_storage_json.clone(),
@@ -552,8 +551,7 @@ impl Test {
                         .await
                     {
                         Ok(res) => {
-                            let original_local_storage_json =
-                                self.state.get(KEY_MATERIAL)?.clone();
+                            let original_local_storage_json = self.state.get(KEY_MATERIAL)?.clone();
                             match res {
                                 RetrieveResult::None => Err(TestError::InvalidValueRetrieved(
                                     original_local_storage_json,

--- a/lock-keeper/proto/lock_keeper_rpc.proto
+++ b/lock-keeper/proto/lock_keeper_rpc.proto
@@ -11,6 +11,7 @@ service LockKeeperRpc {
   rpc ImportSigningKey (stream Message) returns (stream Message);
   rpc Retrieve (stream Message) returns (stream Message);
   rpc RetrieveAuditEvents (stream Message) returns (stream Message);
+  rpc RetrieveSigningKey (stream Message) returns (stream Message);
   rpc RetrieveStorageKey (stream Message) returns (stream Message);
 }
 

--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -22,7 +22,7 @@ mod signing_key;
 pub use arbitrary_secret::Secret;
 use generic::{AssociatedData, EncryptionKey};
 pub use generic::{CryptoError, Encrypted};
-pub use signing_key::{Import, PlaceholderEncryptedSigningKeyPair, SigningKeyPair};
+pub use signing_key::{Export, Import, PlaceholderEncryptedSigningKeyPair, SigningKeyPair};
 
 /// A session key is produced as shared output for client and server from
 /// OPAQUE.

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -36,6 +36,14 @@ impl From<SigningKeyPair> for PlaceholderEncryptedSigningKeyPair {
     }
 }
 
+impl From<PlaceholderEncryptedSigningKeyPair> for SigningKeyPair {
+    fn from(key_pair: PlaceholderEncryptedSigningKeyPair) -> Self {
+        Self {
+            context: key_pair.context,
+        }
+    }
+}
+
 #[allow(unused)]
 impl SigningKeyPair {
     /// Create a new `SigningKeyPair` with the given associated data.

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -188,6 +188,34 @@ impl Import {
     }
 }
 
+/// Raw material for an exported signing key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Export {
+    pub key_material: Vec<u8>,
+}
+
+impl From<SigningKeyPair> for Export {
+    fn from(key_pair: SigningKeyPair) -> Self {
+        Self {
+            key_material: key_pair.into(),
+        }
+    }
+}
+
+impl Export {
+    // TODO #235: Once the signing key pair has a way to hold key material,
+    // copy the key material and associated data from `Export` directly to the
+    // corresponding fields in the `SigningKeyPair`. Do not put the key material
+    // into the associated data field -- they have very different security
+    // properties!
+    pub fn into_signing_key(self) -> Result<SigningKeyPair, LockKeeperError> {
+        let associated_data = self.key_material.try_into()?;
+        Ok(SigningKeyPair {
+            context: associated_data,
+        })
+    }
+}
+
 impl From<SigningKeyPair> for Vec<u8> {
     fn from(key_pair: SigningKeyPair) -> Self {
         let domain_separator_bytes: Vec<u8> = SigningKeyPair::domain_separator().into();

--- a/lock-keeper/src/types/operations.rs
+++ b/lock-keeper/src/types/operations.rs
@@ -21,7 +21,7 @@ pub enum ClientAction {
     Authenticate,
     CreateStorageKey,
     Export,
-    ExportSingingKey,
+    ExportSigningKey,
     Generate,
     ImportSigningKey,
     Register,

--- a/lock-keeper/src/types/operations.rs
+++ b/lock-keeper/src/types/operations.rs
@@ -21,11 +21,13 @@ pub enum ClientAction {
     Authenticate,
     CreateStorageKey,
     Export,
+    ExportSingingKey,
     Generate,
     ImportSigningKey,
     Register,
     RemoteGenerate,
     Retrieve,
     RetrieveAuditEvents,
+    RetrieveSigningKey,
     RetrieveStorageKey,
 }

--- a/lock-keeper/src/types/operations/retrieve.rs
+++ b/lock-keeper/src/types/operations/retrieve.rs
@@ -39,13 +39,13 @@ pub mod server {
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
-    /// return new requested key and key ID
+    /// return requested key and key ID
     pub struct Response {
         pub stored_secret: StoredEncryptedSecret,
     }
 
     #[derive(Debug, Deserialize, Serialize)]
-    /// return new requested key and key ID
+    /// return requested signing key and key ID
     pub struct ResponseSigningKey {
         pub stored_secret: StoredSigningKeyPair,
     }

--- a/lock-keeper/src/types/operations/retrieve.rs
+++ b/lock-keeper/src/types/operations/retrieve.rs
@@ -21,11 +21,21 @@ pub mod client {
         pub context: RetrieveContext,
     }
 
-    impl_message_conversion!(Request);
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct RequestSigningKey {
+        pub user_id: UserId,
+        pub key_id: KeyId,
+        pub context: RetrieveContext,
+    }
+
+    impl_message_conversion!(Request, RequestSigningKey);
 }
 
 pub mod server {
-    use crate::{impl_message_conversion, types::database::secrets::StoredEncryptedSecret};
+    use crate::{
+        impl_message_conversion,
+        types::database::secrets::{StoredEncryptedSecret, StoredSigningKeyPair},
+    };
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
@@ -34,5 +44,11 @@ pub mod server {
         pub stored_secret: StoredEncryptedSecret,
     }
 
-    impl_message_conversion!(Response);
+    #[derive(Debug, Deserialize, Serialize)]
+    /// return new requested key and key ID
+    pub struct ResponseSigningKey {
+        pub stored_secret: StoredSigningKeyPair,
+    }
+
+    impl_message_conversion!(Response, ResponseSigningKey);
 }

--- a/lock-keeper/src/types/operations/retrieve.rs
+++ b/lock-keeper/src/types/operations/retrieve.rs
@@ -33,8 +33,7 @@ pub mod client {
 
 pub mod server {
     use crate::{
-        impl_message_conversion,
-        types::database::secrets::{StoredEncryptedSecret, StoredSigningKeyPair},
+        crypto::Export, impl_message_conversion, types::database::secrets::StoredEncryptedSecret,
     };
     use serde::{Deserialize, Serialize};
 
@@ -45,9 +44,9 @@ pub mod server {
     }
 
     #[derive(Debug, Deserialize, Serialize)]
-    /// return requested signing key and key ID
+    /// return exported signing key material
     pub struct ResponseSigningKey {
-        pub stored_secret: StoredSigningKeyPair,
+        pub exported_signing_key: Export,
     }
 
     impl_message_conversion!(Response, ResponseSigningKey);


### PR DESCRIPTION
Closes #281 

This adds the export functionality for signing keys. The previous PR (#263) only implemented it for arbitrary secrets.

Questions for @indomitableSwan: 
- This export is modeled after the arbitrary secrets export, which in turn is based on arbitrary secrets retrieve. Since we didn't talk about implementing retrieve for signing keys yet, I wasn't sure if we would want to wrap the retrieved signing key in a `LocalStorage` like we do for arbitrary keys, so I have them being returned plain for now. Is that okay?
- The import spec doesn't say to return the imported signing key to the user, so currently I don't have a way to write an export test that checks that the key material is the same. Should I be returning the key in import or is there a different way to check this?