### PR TITLE
Add docker cleanup to teardown task #285

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -17,7 +17,7 @@ alias = "teardown-server"
 
 # Stops the server, recompiles it, and restarts it
 [tasks.restart]
-dependencies = ["stop", "start"]
+dependencies = ["teardown", "start"]
 
 # Start a key server and monitor its output.
 [tasks.start-server]
@@ -39,7 +39,7 @@ args = ["compose", "stop"]
 # Destroy the docker containers for a server.
 [tasks.teardown-server]
 command = "docker"
-args = ["compose", "down"]
+args = ["compose", "down", "--rmi", "local", "--volumes", "--remove-orphans"]
 
 # Start a server running on your local machine without Docker.
 [tasks.start-server-local]
@@ -81,8 +81,8 @@ command = "cargo"
 args = ["test", "--all-features", "--doc", "--workspace"]
 
 [tasks.ci-docs]
-command = "cargo"
 env = { "RUSTDOCFLAGS" = "-Dwarnings" }
+command = "cargo"
 args = ["doc", "--all-features", "--no-deps", "--workspace"]
 
 # TODO: Remove with #268

--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ cargo make lkic
 
 If you get a `no space left on device` error from Docker, try running:
 ```bash
-docker system prune
+docker image prune -a
+docker volume prune
+```
+
+If this doesn't help, you can do a full system prune. This will delete your cache and your next build will take a long time.
+```bash
+docker system prune -a --volumes
 ```
 
 ## Build documentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: always
     ports:
       - 27017:27017
+    stdin_open: true
+    tty: true 
 
   key_server:
     build: .

--- a/lock-keeper-key-server/src/bin/main.rs
+++ b/lock-keeper-key-server/src/bin/main.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use clap::Parser;
 use lock_keeper::config::server::Config;
 use lock_keeper_key_server::server::start_lock_keeper_server;
-use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
 pub struct Cli {
@@ -12,8 +11,7 @@ pub struct Cli {
 
 #[tokio::main]
 pub async fn main() {
-    let filter = EnvFilter::try_new("info,sqlx::query=warn").unwrap();
-    tracing_subscriber::fmt().with_env_filter(filter).init();
+    tracing_subscriber::fmt().init();
     let cli = Cli::parse();
 
     let config = Config::load(&cli.config).await.unwrap();

--- a/lock-keeper-key-server/src/server/service.rs
+++ b/lock-keeper-key-server/src/server/service.rs
@@ -17,6 +17,7 @@ use tracing::{error, info};
 
 /// Starts a full Lock Keeper server stack based on the given config.
 pub async fn start_lock_keeper_server(config: Config) -> Result<(), LockKeeperServerError> {
+    tracing::info!("Starting Lock Keeper key server");
     let db = Database::connect(&config.database).await?;
     // Collect the futures for the result of running each specified server
     let mut server_futures: FuturesUnordered<_> = config
@@ -24,6 +25,8 @@ pub async fn start_lock_keeper_server(config: Config) -> Result<(), LockKeeperSe
         .iter()
         .map(|service| start_service(service, &config, &db))
         .collect();
+
+    tracing::info!("Lock Keeper key server started");
 
     // Wait for the server to finish
     tokio::select! {


### PR DESCRIPTION
This PR adds some extra cleanup steps to the `teardown` task so that Docker is less likely to run out of space.

It also updates the `restart` task to call `teardown` instead of `stop`. This makes it take a little bit longer to run but prevents the scenario where you can only run `cargo make restart` 2-3 times before you run out of space and have to do a `docker system prune`.

Closes #285