### PR TITLE
Add .dockerignore file #303

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.idea/


### PR DESCRIPTION
Closes #303 

This just adds the target folder and the IntelliJ-generated folder to an ignore file so the Docker restarts don't take as long.  It brings my restart time down to about 20 seconds. I'd like if folks ran this and made sure their tests still run correctly with this addition. If there are other files that would be useful to add to this, I can do that too.