### PR TITLE
Split e2e tests into modules #270

### DIFF
--- a/lock-keeper-tests/src/end_to_end/operations.rs
+++ b/lock-keeper-tests/src/end_to_end/operations.rs
@@ -1,0 +1,53 @@
+use lock_keeper::types::{audit_event::EventStatus, operations::ClientAction};
+use lock_keeper_client::client::Password;
+
+pub mod authenticate;
+pub mod export;
+pub mod generate;
+pub mod import;
+pub mod register;
+pub mod remote_generate;
+pub mod retrieve;
+
+/// Set of operations that can be executed by the test harness
+#[allow(unused)]
+#[derive(Debug)]
+pub enum Operation {
+    Authenticate(Option<Password>),
+    Export,
+    ExportSigningKey,
+    Generate,
+    ImportSigningKey,
+    Register,
+    RemoteGenerate,
+    Retrieve,
+    SetFakeKeyId,
+}
+
+impl Operation {
+    pub fn to_final_client_action(&self, status: &EventStatus) -> Option<ClientAction> {
+        match self {
+            Self::Authenticate(_) => {
+                if status == &EventStatus::Failed {
+                    None
+                } else {
+                    Some(ClientAction::Authenticate)
+                }
+            }
+            Self::Export => Some(ClientAction::Export),
+            Self::ExportSigningKey => Some(ClientAction::ExportSigningKey),
+            Self::Generate => Some(ClientAction::Generate),
+            Self::ImportSigningKey => Some(ClientAction::ImportSigningKey),
+            Self::Register => {
+                if status == &EventStatus::Successful {
+                    Some(ClientAction::CreateStorageKey)
+                } else {
+                    Some(ClientAction::Register)
+                }
+            }
+            Self::RemoteGenerate => Some(ClientAction::RemoteGenerate),
+            Self::Retrieve => Some(ClientAction::Retrieve),
+            Self::SetFakeKeyId => None,
+        }
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/operations/authenticate.rs
+++ b/lock-keeper-tests/src/end_to_end/operations/authenticate.rs
@@ -1,0 +1,16 @@
+use lock_keeper_client::{client::Password, LockKeeperClient};
+
+use crate::end_to_end::Test;
+
+impl Test {
+    pub async fn authenticate(&self, password: &Option<Password>) -> anyhow::Result<()> {
+        let password = match password {
+            Some(pwd) => pwd,
+            None => &self.password,
+        };
+        let _ = LockKeeperClient::authenticated_client(&self.account_name, password, &self.config)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/operations/export.rs
+++ b/lock-keeper-tests/src/end_to_end/operations/export.rs
@@ -1,0 +1,60 @@
+use lock_keeper::crypto::KeyId;
+use lock_keeper_client::{api::LocalStorage, LockKeeperClient};
+
+use crate::end_to_end::{Test, KEY_ID, KEY_MATERIAL};
+
+impl Test {
+    pub async fn export(&self) -> anyhow::Result<()> {
+        // Authenticate
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &self.account_name,
+            &self.password,
+            &self.config,
+        )
+        .await?;
+
+        // Get KeyId from state and run export
+        let key_id_json = self.state.get(KEY_ID)?;
+        let key_id: KeyId = serde_json::from_value(key_id_json.clone())?;
+        match lock_keeper_client.export_key(&key_id).await {
+            Ok(res) => {
+                // Compare generated key and exported key material
+                let original_local_storage_json = self.state.get(KEY_MATERIAL)?.clone();
+                let original_local_storage_bytes: Vec<u8> =
+                    serde_json::from_value::<LocalStorage>(original_local_storage_json.clone())?
+                        .secret
+                        .into();
+                let res_json = serde_json::to_value(res.clone())?;
+                if original_local_storage_bytes != res {
+                    anyhow::bail!(
+                        "expected: {}; got: {}",
+                        original_local_storage_json,
+                        res_json
+                    );
+                } else {
+                    Ok(())
+                }
+            }
+            Err(e) => Err(anyhow::Error::from(e)),
+        }
+    }
+
+    pub async fn export_signing_key(&self) -> anyhow::Result<()> {
+        // Authenticate
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &self.account_name,
+            &self.password,
+            &self.config,
+        )
+        .await?;
+
+        // Get KeyId from state and run export
+        let key_id_json = self.state.get(KEY_ID)?;
+        let key_id: KeyId = serde_json::from_value(key_id_json.clone())?;
+        lock_keeper_client
+            .export_signing_key(&key_id)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.into())
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/operations/generate.rs
+++ b/lock-keeper-tests/src/end_to_end/operations/generate.rs
@@ -1,0 +1,21 @@
+use lock_keeper_client::LockKeeperClient;
+
+use crate::end_to_end::{Test, KEY_ID, KEY_MATERIAL};
+
+impl Test {
+    pub async fn generate(&mut self) -> anyhow::Result<()> {
+        // Authenticate and run generate
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &self.account_name,
+            &self.password,
+            &self.config,
+        )
+        .await?;
+        let (key_id, local_storage) = lock_keeper_client.generate_and_store().await?;
+        // Store generated key ID and local storage object to state
+        self.state.set(KEY_ID, key_id)?;
+        self.state.set(KEY_MATERIAL, local_storage)?;
+
+        Ok(())
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/operations/import.rs
+++ b/lock-keeper-tests/src/end_to_end/operations/import.rs
@@ -1,0 +1,22 @@
+use lock_keeper_client::LockKeeperClient;
+use rand::Rng;
+
+use crate::end_to_end::{Test, KEY_ID};
+
+impl Test {
+    pub async fn import_signing_key(&mut self) -> anyhow::Result<()> {
+        // Authenticate and run generate
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &self.account_name,
+            &self.password,
+            &self.config,
+        )
+        .await?;
+        let random_bytes = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+        let key_id = lock_keeper_client.import_signing_key(random_bytes).await?;
+        // Store generated key ID to state
+        self.state.set(KEY_ID, key_id)?;
+
+        Ok(())
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/operations/register.rs
+++ b/lock-keeper-tests/src/end_to_end/operations/register.rs
@@ -1,0 +1,11 @@
+use lock_keeper_client::LockKeeperClient;
+
+use crate::end_to_end::Test;
+
+impl Test {
+    pub async fn register(&self) -> anyhow::Result<()> {
+        LockKeeperClient::register(&self.account_name, &self.password, &self.config).await?;
+
+        Ok(())
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/operations/remote_generate.rs
+++ b/lock-keeper-tests/src/end_to_end/operations/remote_generate.rs
@@ -1,0 +1,20 @@
+use lock_keeper_client::LockKeeperClient;
+
+use crate::end_to_end::{Test, KEY_ID};
+
+impl Test {
+    pub async fn remote_generate(&mut self) -> anyhow::Result<()> {
+        // Authenticate and run remote generate
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &self.account_name,
+            &self.password,
+            &self.config,
+        )
+        .await?;
+        let key_id = lock_keeper_client.remote_generate().await?;
+        // Store generated key ID
+        self.state.set(KEY_ID, key_id)?;
+
+        Ok(())
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/operations/retrieve.rs
+++ b/lock-keeper-tests/src/end_to_end/operations/retrieve.rs
@@ -1,0 +1,53 @@
+use lock_keeper::{crypto::KeyId, types::operations::retrieve::RetrieveContext};
+use lock_keeper_client::{api::RetrieveResult, LockKeeperClient};
+
+use crate::end_to_end::{Test, KEY_ID, KEY_MATERIAL};
+
+impl Test {
+    pub async fn retrieve(&self) -> anyhow::Result<()> {
+        // Authenticate
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &self.account_name,
+            &self.password,
+            &self.config,
+        )
+        .await?;
+        // Get KeyId from state and run retrieve
+        let key_id_json = self.state.get(KEY_ID)?;
+        let key_id: KeyId = serde_json::from_value(key_id_json.clone())?;
+
+        // Ensure result matches what was stored in generate
+        match lock_keeper_client
+            .retrieve(&key_id, RetrieveContext::LocalOnly)
+            .await
+        {
+            Ok(res) => {
+                let original_local_storage_json = self.state.get(KEY_MATERIAL)?.clone();
+                match res {
+                    RetrieveResult::None => anyhow::bail!("No key with key_id {:?}", key_id),
+                    RetrieveResult::ArbitraryKey(local_storage) => {
+                        let new_local_storage_json = serde_json::to_value(local_storage)?;
+                        if original_local_storage_json != new_local_storage_json {
+                            anyhow::bail!(
+                                "expected: {}; got: {}",
+                                original_local_storage_json,
+                                new_local_storage_json
+                            );
+                        }
+                    }
+                    RetrieveResult::SigningKey(signing_key) => {
+                        let new_local_storage_json = serde_json::to_value(signing_key)?;
+                        anyhow::bail!(
+                            "expected: {}; got: {}",
+                            original_local_storage_json,
+                            new_local_storage_json
+                        );
+                    }
+                }
+            }
+            Err(e) => anyhow::bail!(e),
+        }
+
+        Ok(())
+    }
+}

--- a/lock-keeper-tests/src/end_to_end/test_cases.rs
+++ b/lock-keeper-tests/src/end_to_end/test_cases.rs
@@ -1,0 +1,312 @@
+use std::str::FromStr;
+
+use lock_keeper_client::{client::Password, LockKeeperClientError};
+
+use crate::{
+    config::Config,
+    end_to_end::{Operation, Outcome},
+};
+
+use super::Test;
+
+/// Get a list of tests to execute.
+/// Assumption: none of these will cause a fatal error to the long-running
+/// processes (server).
+pub async fn tests(config: &Config) -> Vec<Test> {
+    use Operation::*;
+
+    vec![
+        Test::new(
+            "Register the same user twice user",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Register,
+                    Outcome {
+                        expected_error: Some(LockKeeperClientError::AccountAlreadyRegistered),
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Register and open multiple sessions as a client to the server",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Authenticate(None),
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Authenticate(None),
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Register and authenticate with wrong password fails as a client to the server",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Authenticate(Some(Password::from_str("wrongPassword").unwrap())),
+                    Outcome {
+                        expected_error: Some(LockKeeperClientError::InvalidLogin),
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Authenticate with unregistered user fails",
+            vec![(
+                Authenticate(None),
+                Outcome {
+                    expected_error: Some(LockKeeperClientError::InvalidAccount),
+                },
+            )],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Generate a secret",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Generate,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Retrieve a secret",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Generate,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Retrieve,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Retrieving a non-existent secret fails",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    SetFakeKeyId,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Retrieve,
+                    Outcome {
+                        expected_error: Some(LockKeeperClientError::InvalidAccount),
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Export a secret",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Generate,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Export,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Exporting a non-existent secret fails",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    SetFakeKeyId,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Export,
+                    Outcome {
+                        expected_error: Some(LockKeeperClientError::InvalidAccount),
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Remote generate a secret",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    RemoteGenerate,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Import a signing key",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    ImportSigningKey,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Export a signing key",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    ImportSigningKey,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    ExportSigningKey,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Exporting a secret using 'export_signing_key' fails",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    Generate,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    ExportSigningKey,
+                    Outcome {
+                        expected_error: Some(LockKeeperClientError::InvalidAccount),
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+        Test::new(
+            "Exporting a non-existent signing key fails",
+            vec![
+                (
+                    Register,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    SetFakeKeyId,
+                    Outcome {
+                        expected_error: None,
+                    },
+                ),
+                (
+                    ExportSigningKey,
+                    Outcome {
+                        expected_error: Some(LockKeeperClientError::InvalidAccount),
+                    },
+                ),
+            ],
+            config.client_config.clone(),
+        ),
+    ]
+}


### PR DESCRIPTION
This PR splits the end-to-end tests into separate modules for each operation. I also added a module for the test cases and removed the custom error type.

Closes #270 