### PR TITLE
Don't call local_storage_bytes in None case #320

### DIFF
--- a/lock-keeper-client-cli/src/storage.rs
+++ b/lock-keeper-client-cli/src/storage.rs
@@ -212,14 +212,14 @@ pub struct Entry {
 impl Display for Entry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let key_id_hex = hex::encode(self.key_id.as_bytes());
-        let bytes = local_storage_bytes(&self.data).map_err(|e| {
-            // Avoid error inception
-            let _ = writeln!(f, "{e}");
-            std::fmt::Error
-        })?;
         let data_hex = match &self.data {
             DataType::None => "None".to_string(),
             DataType::ArbitraryKey(_) => {
+                let bytes = local_storage_bytes(&self.data).map_err(|e| {
+                    // Avoid error inception
+                    let _ = writeln!(f, "{e}");
+                    std::fmt::Error
+                })?;
                 format!("Arbitrary Key - {}", hex::encode(&bytes))
             }
         };


### PR DESCRIPTION
Closes #320 

This was on me! I had the conversion to bytes outside of the match so it was trying to convert blank key material into bytes.

Also addresses part of #317 to move the audit event log check in the e2e tests to the end.