### PR TITLE
Add decryption validation for encrypted signing keys

### DIFF
--- a/lock-keeper-key-server/src/server/opaque_storage.rs
+++ b/lock-keeper-key-server/src/server/opaque_storage.rs
@@ -22,7 +22,7 @@ pub fn create_or_retrieve_server_key_opaque(
         Err(_) => {
             let server_setup = ServerSetup::<OpaqueCipherSuite>::new(rng);
             std::fs::create_dir_all(
-                &service
+                service
                     .opaque_server_key
                     .parent()
                     .ok_or(LockKeeperServerError::InvalidOpaqueDirectory)?,


### PR DESCRIPTION
Closes #241.
Closes #239.

This PR adds validation of the associated data for signing keys encrypted under a storage key. Encryption under a storage key means they are generated client-side, either in a generate flow or in an import flow.

It also adds "some bad-behavior checks" as requested in #239, by testing decryption with a bunch of incorrect associated data.

See also: boltlabs-inc/key-mgmt-spec#144, which fixes the spec to work for either generated or imported keys.