### PR TITLE
Newtype definitions for API return types WIP

### DIFF
--- a/lock-keeper-client-cli/src/cli_command/import.rs
+++ b/lock-keeper-client-cli/src/cli_command/import.rs
@@ -1,6 +1,7 @@
 use crate::{cli_command::CliCommand, state::State};
 use anyhow::Error;
 use async_trait::async_trait;
+use lock_keeper::crypto::Import as LkImport;
 use lock_keeper_client::LockKeeperClient;
 use rand::Rng;
 
@@ -24,8 +25,9 @@ impl CliCommand for Import {
         .into_inner();
 
         let random_bytes = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+        let import = LkImport::new(random_bytes)?;
         let key_id = lock_keeper_client
-            .import_signing_key(random_bytes)
+            .import_signing_key(import)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to import signing key. Error: {:?}", e))?
             .into_inner();

--- a/lock-keeper-client/src/api/import.rs
+++ b/lock-keeper-client/src/api/import.rs
@@ -9,9 +9,8 @@ impl LockKeeperClient {
     pub(crate) async fn handle_import_signing_key(
         &self,
         mut channel: ClientChannel,
-        key_material: Vec<u8>,
+        key_material: Import,
     ) -> Result<LockKeeperResponse<KeyId>, LockKeeperClientError> {
-        let key_material = Import { key_material };
         // Send UserId and key material to server
         let request = client::Request {
             user_id: self.user_id().clone(),

--- a/lock-keeper-tests/src/test_suites/database/secret.rs
+++ b/lock-keeper-tests/src/test_suites/database/secret.rs
@@ -100,9 +100,8 @@ async fn add_arbitrary_secret(
 
 async fn import_signing_key(db: &Database, rng: &mut StdRng, user_id: &UserId) -> Result<KeyId> {
     let key_id = KeyId::generate(rng, user_id)?;
-    let import = Import {
-        key_material: rand::thread_rng().gen::<[u8; 32]>().to_vec(),
-    };
+    let random_bytes = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+    let import = Import::new(random_bytes)?;
     let signing_key = import.into_signing_key(user_id, &key_id)?;
 
     db.add_remote_secret(user_id, signing_key.clone(), key_id.clone())

--- a/lock-keeper-tests/src/test_suites/end_to_end/operations.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/operations.rs
@@ -1,6 +1,6 @@
 use crate::test_suites::end_to_end::test_cases::TestState;
 use lock_keeper::{
-    crypto::{Export, KeyId, Secret, Signable, Signature},
+    crypto::{Export, Import, KeyId, Secret, Signable, Signature},
     types::{
         audit_event::{AuditEventOptions, EventStatus, EventType},
         database::user::AccountName,
@@ -90,7 +90,7 @@ pub(crate) async fn authenticate(
 pub(crate) async fn export(
     state: &TestState,
     key_id: &KeyId,
-) -> Result<LockKeeperResponse<Vec<u8>>, LockKeeperClientError> {
+) -> Result<LockKeeperResponse<Export>, LockKeeperClientError> {
     // Authenticate
     let lock_keeper_client =
         LockKeeperClient::authenticated_client(&state.account_name, &state.password, &state.config)
@@ -136,12 +136,11 @@ pub(crate) async fn import_signing_key(
             .await?
             .into_inner();
     let random_bytes = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+    let import = Import::new(random_bytes.clone())?;
     let LockKeeperResponse {
         data: key_id,
         metadata,
-    } = lock_keeper_client
-        .import_signing_key(random_bytes.clone())
-        .await?;
+    } = lock_keeper_client.import_signing_key(import).await?;
 
     let result = LockKeeperResponse {
         data: (key_id, random_bytes),

--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -25,8 +25,8 @@ pub use arbitrary_secret::Secret;
 use generic::{AssociatedData, EncryptionKey};
 pub use generic::{CryptoError, Encrypted};
 pub use signing_key::{
-    Export, Import, PlaceholderEncryptedSigningKeyPair, Signable, SignableBytes, Signature,
-    SigningKeyPair, SigningPublicKey,
+    Import, PlaceholderEncryptedSigningKeyPair, Signable, SignableBytes, Signature, SigningKeyPair,
+    SigningPublicKey,
 };
 
 /// A session key is produced as shared output for client and server from
@@ -282,6 +282,14 @@ impl KeyId {
     pub fn as_bytes(&self) -> &[u8] {
         &*self.0
     }
+}
+
+/// Raw material for an exported signing key.
+#[derive(Debug, Clone, Serialize, Deserialize, ZeroizeOnDrop)]
+pub struct Export {
+    pub key_material: Vec<u8>,
+    #[zeroize(skip)]
+    pub context: Vec<u8>,
 }
 
 #[cfg(test)]

--- a/lock-keeper/src/crypto/generic.rs
+++ b/lock-keeper/src/crypto/generic.rs
@@ -281,7 +281,6 @@ impl Secret {
     ///
     /// This is currently only used in testing, but it is fine to make it
     /// publicly accessible if necessary.
-    #[cfg(test)]
     pub(super) fn context(&self) -> &AssociatedData {
         &self.context
     }

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -1,3 +1,4 @@
+use super::Export;
 use crate::{types::database::user::UserId, LockKeeperError};
 use k256::ecdsa::{
     self,
@@ -241,7 +242,7 @@ impl Encrypted<SigningKeyPair> {
 /// Raw material for an imported signing key.
 #[derive(Debug, Clone, Serialize, Deserialize, ZeroizeOnDrop)]
 pub struct Import {
-    pub key_material: Vec<u8>,
+    key_material: Vec<u8>,
 }
 
 impl TryFrom<&[u8]> for Import {
@@ -259,6 +260,13 @@ impl TryFrom<&[u8]> for Import {
 }
 
 impl Import {
+    /// Create a new [`Import`] around the bytes representing signing key
+    /// material. Bytes are validated for appropriate format.
+    pub fn new(bytes: Vec<u8>) -> Result<Self, LockKeeperError> {
+        let import = Self::try_from(bytes.as_slice())?;
+        Ok(import)
+    }
+
     /// Convert an [`Import`] into a [`SigningKeyPair`] with appropriate
     /// context.
     ///
@@ -286,14 +294,6 @@ impl Import {
             context,
         })
     }
-}
-
-/// Raw material for an exported signing key.
-#[derive(Debug, Clone, Serialize, Deserialize, ZeroizeOnDrop)]
-pub struct Export {
-    pub key_material: Vec<u8>,
-    #[zeroize(skip)]
-    pub context: Vec<u8>,
 }
 
 impl From<SigningKeyPair> for Export {


### PR DESCRIPTION
Closes #336 

Question about how to handle the Export type: I'm trying to get both `export` and `export_signing_key` to return an "Export" but converting those to bytes for comparison in the tests is looking hard to do without knowing the type that it started out as. Is it worth changing this type to a generic, the same way as LocalStorage was handled?

(the export e2e test is commented out because of this question)