### PR TITLE
Simplified server tasks in Makefile.toml #368

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
           args: --debug cargo-make
 
       - name: Start Server
-        run: cargo make start-server-detached-all
+        run: cargo make start
           
       - name: Run all tests
         run: cargo make all-tests

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -3,13 +3,13 @@ default_to_workspace = false
 
 # -- Server Tasks --
 
+# Shorthand task to start server and monitor its output.
+[tasks.run]
+alias = "start-server-attached"
+
 # Shorthand task to start server in the background.
 [tasks.start]
 alias = "start-server-detached"
-
-# Shorthand task to start both servers in the background.
-[tasks.start-all]
-alias = "start-server-detached-all"
 
 # Shorthand task to stop a server running in the background.
 [tasks.stop]
@@ -24,19 +24,7 @@ alias = "teardown-server"
 dependencies = ["teardown", "start"]
 
 # Start a key server and monitor its output.
-[tasks.start-server]
-command = "docker"
-args = ["compose", "up", "--build", "mongodb", "key_server", "--attach", "key_server"]
-dependencies = ["certs"]
-
-# Start a key server with mutual auth enabled and monitor its output.
-[tasks.start-server-mutual-auth]
-command = "docker"
-args = ["compose", "up", "--build", "mongodb", "key_server_mutual_auth", "--attach", "key_server_mutual_auth"]
-dependencies = ["certs"]
-
-# Starts two key servers, one with mutual auth and one without
-[tasks.start-server-all]
+[tasks.start-server-attached]
 command = "docker"
 args = ["compose", "up",
         "--build", "mongodb", "key_server", "key_server_mutual_auth",
@@ -45,22 +33,13 @@ args = ["compose", "up",
 ]
 dependencies = ["certs"]
 
-# Start a key server in the background.
+# Start a key server in the background
 [tasks.start-server-detached]
 command = "docker"
-args = ["compose", "up", "--build", "mongodb", "key_server", "--detach", "--wait"]
-dependencies = ["certs"]
-
-# Start a key server with mutual auth enabled in the background.
-[tasks.start-server-detached-mutual-auth]
-command = "docker"
-args = ["compose", "up", "--build", "mongodb", "key_server_mutual_auth", "--detach", "--wait"]
-dependencies = ["certs"]
-
-# Starts two key servers in the background, one with mutual auth and one without
-[tasks.start-server-detached-all]
-command = "docker"
-args = ["compose", "up", "--build", "mongodb", "key_server", "key_server_mutual_auth", "--detach", "--wait"]
+args = ["compose", "up", 
+        "--build", "mongodb", "key_server", "key_server_mutual_auth",
+        "--wait"
+]
 dependencies = ["certs"]
 
 # Stop a key server running in the background.
@@ -72,12 +51,6 @@ args = ["compose", "stop"]
 [tasks.teardown-server]
 command = "docker"
 args = ["compose", "down", "--rmi", "local", "--volumes", "--remove-orphans"]
-
-# Start a server running on your local machine without Docker.
-[tasks.start-server-local]
-command = "cargo"
-args = ["run", "--bin", "key-server-cli", "./dev/server/config/Local.toml"]
-dependencies = ["certs"]
 
 # -- Testing Tasks --
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Integration tests are separated into two categories, end-to-end tests and genera
 
 Start the server running in the background. This will compile the project from scratch the first time you run it so it will take a while. It should be faster for future runs.
 ```bash
-cargo make start-all
+cargo make start
 ```
 
 To run the end-to-end tests:
@@ -93,7 +93,7 @@ cargo make stop
 
 If you want to watch server output in real-time, you can run the server in the foreground with:
 ```bash
-cargo make start-server
+cargo make run
 ```
 
 Running the test binary directly offers some extra command line options.
@@ -109,25 +109,13 @@ To run the server locally, first make sure MongoDB is running. You can run Mongo
 
 Then run:
 ```bash
-cargo make start-server-local
-```
-
-Tests can be run against a local server with:
-```bash
-cargo make e2e
+cargo run --bin key-server-cli ./dev/local/Server.toml
 ```
 
 ## TLS mutual authentication
 
 Mutual authentication can be enabled in server and client configs. See `ServerMutualAuth.toml` and `ClientMutualAuth.toml` 
 for examples.
-
-To run a server with mutual auth enabled, use your preferred `cargo make` task and append `-mutual-auth` to the end. For example, 
-to run a server in the foreground with mutual auth use `cargo make start-server-mutual-auth`.
-
-To run both servers at the same time, append `-all` to the end. For example, `cargo make start-server-all`.
-
-In order to run the mutual authentication integration tests, you must have both servers running.
 
 # Private key security
 The key server always requires a private key. 

--- a/lock-keeper-client/src/config.rs
+++ b/lock-keeper-client/src/config.rs
@@ -13,7 +13,6 @@ use crate::LockKeeperClientError;
 #[derive(Clone)]
 pub struct Config {
     pub server_uri: Uri,
-    pub client_auth_enabled: bool,
     pub tls_config: ClientConfig,
 }
 
@@ -33,7 +32,6 @@ impl Config {
     ) -> Result<Self, LockKeeperClientError> {
         Ok(Self {
             server_uri: Uri::from_str(&config.server_uri)?,
-            client_auth_enabled: config.client_auth.is_some(),
             tls_config: config.tls_config(private_key_bytes)?,
         })
     }

--- a/lock-keeper-tests/src/utils.rs
+++ b/lock-keeper-tests/src/utils.rs
@@ -235,12 +235,6 @@ pub async fn wait_for_server(config: &ClientConfig) -> Result<()> {
     const NUM_RETRIES: u32 = 10;
     const RETRY_DELAY: Duration = Duration::from_secs(10);
 
-    let server_start_command = if config.client_auth_enabled {
-        "cargo make start-all"
-    } else {
-        "cargo make start"
-    };
-
     for i in 0..NUM_RETRIES {
         println!("Attempting to connect to server...");
         match LockKeeperClient::health(config).await {
@@ -248,7 +242,7 @@ pub async fn wait_for_server(config: &ClientConfig) -> Result<()> {
             Err(_) => {
                 println!("Server connection failed. Retrying in {:?}", RETRY_DELAY);
                 if i == 0 {
-                    println!("Did you remember to run `{}`?", server_start_command);
+                    println!("Did you remember to run `cargo make start`?");
                 }
                 std::thread::sleep(RETRY_DELAY);
             }


### PR DESCRIPTION
This PR simplifies the `cargo make` server commands.

- Added shorthand alias `cargo make run` to start server in the foreground.
- Renamed attached/detached tasks to be explicit.
- `cargo make start` and `cargo make run` start two servers, one with mutual auth enabled and one with mutual auth disabled.
- Removed task to run locally since it's just a basic `cargo run`.
- Removed `client_auth_enabled` from client `Config` since its only use was invalidated by these changes.
-  Updated README.

Closes #368 