### PR TITLE
Implement logging support for server implementation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,11 @@ Please be kind, courteous, and respectful. This project, although not formally a
 Please report any violations of this code of conduct to
 [conduct@boltlabs.io](mailto:conduct@boltlabs.io).
 
+## Logging
+Our repository uses the [`tracing`](https://crates.io/crates/tracing) library for logging. The server automatically writes `INFO`-level logs
+to standard output if the logging event originated from our `lock-keeper` crates.
+
+Here we cover adding your own logging messages.
 
 ## Understanding inline issues
 Issues are described in the issue tracker, but there is also supporting inline documentation noting the specific location of various types of problems in the code. These are marked as `TODO #(issue) (optional modifiers):`. Potential modifiers include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,6 @@ toml = "0.5"
 tonic = "0.8"
 tracing = "0.1"
 tracing-futures = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = "1.1.2"
 zeroize = "1.5"

--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ cargo make cli
 ```
 
 ## Troubleshooting
+### Logging
+The server writes logs to a few locations:
+- **Standard Output**: `INFO` level logs get written out to standard output for any events originating from any lock-keeper crates.
+- **Sever-only logs**: `INFO` level logs written to a file based on user config (see below) for any events originating from any lock-keeper crates.
+- **All logs**: `TRACE` or higher level logs written to a file based on user config (see below) for any event from any crate including dependencies.
+
+The following may be configured via the server configuration file:
+- The log directory may be specified via the `log_directory` field in the server config file.
+- The sever-only log file may be specified via the `lock_keeper_logs_file_name` field.
+- The all log file may be specified via the `all_logs_file_name` field.
+
+### No Space Left
 
 If you get a `no space left on device` error from Docker, try running:
 ```bash

--- a/bin/key-server-cli/Cargo.toml
+++ b/bin/key-server-cli/Cargo.toml
@@ -9,6 +9,7 @@ lock-keeper = { version = "0.2.0", path = "../../lock-keeper" }
 lock-keeper-key-server = { version = "0.2.0", path = "../../lock-keeper-key-server" }
 lock-keeper-mongodb = { version = "0.2.0", path = "../../persistence/lock-keeper-mongodb" }
 lk-session-hashmap = { version = "0.2.0", path = "../../persistence/lk-session-hashmap" }
+tracing-appender = "0.2"
 
 # Workspace dependencies
 clap.workspace = true

--- a/bin/key-server-cli/src/main.rs
+++ b/bin/key-server-cli/src/main.rs
@@ -1,9 +1,177 @@
-use std::path::PathBuf;
+//! Implementation of our LockKeeper server.
+//!
+//! ## Logging
+//! Our server supports logging using the [`tracing`](https://docs.rs/tracing/latest/tracing/)
+//! crate.
+//!
+//! ### Main `tracing` Concepts.
+//! We utilize the following concept from `tracing`:
+//!
+//! - **Events**: These are the individual logging events that are called as our
+//!   program executes.
+//! Events have an info level attached to them. You may create a new event by
+//! using the appropriate macro event macro from `tracing`, e.g:
+//! ```
+//! info!("This is a logging event!");
+//! ```
+//!   You may add runtime values to our events as well:
+//! ```
+//! info!("Logging config settings: {:?}", config.logging);
+//! ```
+//! This uses the same syntax as Rust string formatting.
+//!
+//! - **Spans** represent logical regions of code, usually a function. All
+//!   _event_s within a span
+//! will have additional span data attached to the event. This allows us to add
+//! context-relevant data to an event without having to explicitly add this data
+//! to our event. For example an event like `info!(This operation completed
+//! successfully!)` within our span will look like:
+//! ```text
+//!   2022-12-06T18:57:40.022422Z  INFO lock_keeper_key_server::server::operation: This operation completed successfully!
+//!     at lock-keeper-key-server/src/server/operation.rs:72
+//!     in lock_keeper_key_server::server::operation::handle_request with request_id: "52ad8008-1eb9-4ad5-8bce-0344a958fd1e", action: "Authenticate"
+//! ```
+//! This event has the `handle_request` span attached to it. Additionally, spans
+//! may contain _fields_. These fields attached relevant data to all events
+//! within our span. In the log message above, we see our span has fields
+//! `request_id` and `action` attached.
+//!
+//! #### Adding your Own Span.
+//! The best way to create your own span is using the
+//! [`instrument`](https://docs.rs/tracing/0.1.37/tracing/attr.instrument.html) macro. This macro
+//! will automatically create a new span when the instrumented function is
+//! called. This span will have the name of the function and the module path as
+//! the `target` (this can be used for filtering by certain targets).
+//!
+//! Please follow the following template for instrumenting your function with
+//! spans:
+//! ```text
+//! #[instrument(skip_all, err(Debug), fields(arg1, arg2))]
+//! fn foo(arg1: _, arg2: _) -> _ {}
+//! ```
+//! By default, `instrument` will create a new span where every argument to a
+//! function is a span field. *This is not desirable for our key server as we
+//! want to avoid logging sensitive data!* So *we always use the `skip_all`
+//! option* to avoid automatically logging all arguments. Instead you can use
+//! the `fields(...)` option to specify which arguments should be recorded as
+//! fields in our span.
+//!
+//! Finally, the `err(Debug)` option tells `tracing` that any `Result::Err(_)`
+//! returned from this function should be logged as events (with the default
+//! level of `INFO`). This is useful for logging where errors originated from in
+//! our code. The `Debug` part tells tracing to use the `Debug` implementation
+//! of this type for formatting, instead of the default `Display`.
+//!
+//! Note that by default, return values of functions are not recorded. You can
+//! add the `ret` option to `instrument` if you wish to record the Ok(_) return
+//! value as a field.
+//!
+//! `tracing` relies on the `Debug` implementation of types for printing values.
+//! Your type must implement `Debug` if you wish to include it as a field.
+//!
+//! #### Recording Fields Not Immediately Available as Arguments.
+//! Sometimes we want to add a field to a span where the field data isn't
+//! immediately available as an argument to the function. Consider the following
+//! example:
+//! ```text
+//! #[instrument(skip_all, err(Debug), fields(action, user_id, request_id))]
+//!     async fn handle_request(
+//!         self,
+//!         mut context: Context<DB>,
+//!         request: Request<Streaming<Message>>,
+//!     ) -> Result<_, _> {
+//!
+//!         let request_id = Uuid::new_v4();
+//!         logging::record_field("request_id", &request_id);
+//!         info!("Handling new client request.");
+//!
+//!         ... // Lots more things happen afterwards.
+//!     }
+//! ```
+//! Here we specify the fields `action`, `user_id`, `request_id` even though
+//! none of these are function arguments! When the function body executes, we
+//! create a `request_id` which we _record_
+//! using our [record_field][lock_keeper::infrastructure::logging::record_field]
+//! function. So our event `info!("Handling new client request.");` will have
+//! the `request_id` field attached:
+//! ```text
+//!   2022-12-06T18:57:39.667194Z  INFO
+//! lock_keeper_key_server::server::operation: Handling new client request.
+//!     at lock-keeper-key-server/src/server/operation.rs:48
+//!     in lock_keeper_key_server::server::operation::handle_request with request_id: "52ad8008-1eb9-4ad5-8bce-0344a958fd1e"
+//! ```
+//!
+//! Notice we have recorded the `action` and `request_id` fields by the time
+//! this event is logged, so these fields are not included. Span fields can be
+//! recorded later as long as they are declared along with the span.
+//!
+//! Note: While it is possible to create your own spans, it is not recommended.
+//! The `instrument` macro handles spans for asynchronous functions. Ensuring
+//! spans are properly kept track of, even when `.await`ing across spans.
+//!
+//! #### Which Arguments Should be Recorded as Fields?
+//! In general, we should only include fields for our span that provide
+//! important information that should be attached to every event that happens
+//! within that span.
+//!
+//! Fields are useful for attaching data to every event without having to
+//! explicitly pass that data to the event.
+//!
+//! Note: *We should be careful to avoid recording any sensitive data as
+//! fields!*
+//!
+//! #### Which Function Should be `instrument`ed?
+//! We want to instrument functions which either:
+//! 1) Logically represent an important step in our server processing.
+//! 2) Record useful fields to be attached to event within that span.
+//! 3) Have return values which are useful to log.
+//!
+//! Instrumenting multiple functions which call each other will create a useful
+//! "backtrace-like" context which allows us to understand the calling context
+//! of an event. For example:
+//! ```text
+//!   2022-12-06T18:57:39.669808Z  INFO
+//! lock_keeper_key_server::operations::authenticate: Starting authentication protocol.
+//!     at lock-keeper-key-server/src/operations/authenticate.rs:38
+//!     in lock_keeper_key_server::operations::authenticate::operation
+//!     in lock_keeper_key_server::server::operation::handle_request with request_id: "52ad8008-1eb9-4ad5-8bce-0344a958fd1e", action: "Authenticate"
+//! ```
+//! We want to avoid instrumenting uninteresting functions, e.g. functions which
+//! represent an implementation detail instead of a logical step in our server
+//! execution.
+//!
+//! ### Logging Levels
+//! So far our logging documentation has focused on the default tracing level of
+//! `INFO`. Events may be added for the following tracing levels: `error`,
+//! `warn`, `info`, `debug`, and `trace`. Here we give a brief overview of what
+//! falls under every level:
+//! - **error**: Report unexpected errors or failures in the system.
+//! - **warn**: Warn of unexpected errors, unforeseen program states, or
+//!   possible issues that are not necessarily fatal, but should be logged so
+//!   they may be debugged later.
+//! - **info**: For high-level, relevant, events to the execution of the code.
+//!   This is our default
+//! logging level and should produce useful messages for developers.
+//! - **debug**: More verbose, good to have information for debugging purposes.
+//! - **trace**: Very verbose information that allows you to trace the execution
+//!   of a program at a
+//! fine granularity, e.g. program control flow.
+
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 use clap::Parser;
 use lk_session_hashmap::HashmapKeyCache;
-use lock_keeper_key_server::{config::Config, server::start_lock_keeper_server};
+use lock_keeper_key_server::{
+    config::Config, server::start_lock_keeper_server, LockKeeperServerError,
+};
 use lock_keeper_mongodb::Database;
+use tracing::{info, Level};
+use tracing_appender::{self, non_blocking::WorkerGuard};
+
+use tracing_subscriber::{filter::Targets, prelude::*};
 
 #[derive(Debug, Parser)]
 pub struct Cli {
@@ -16,7 +184,6 @@ pub struct Cli {
 
 #[tokio::main]
 pub async fn main() {
-    tracing_subscriber::fmt().init();
     let cli = Cli::parse();
     let private_key_bytes = cli
         .private_key
@@ -27,9 +194,96 @@ pub async fn main() {
 
     let config = Config::from_file(&cli.config, private_key_bytes).unwrap();
 
+    // We keep `_logging` around for the lifetime of the server. On drop, this value
+    // will ensure that our logs are flushed.
+    let _logging = init_logging(
+        &config.logging.all_logs_file_name,
+        &config.logging.lock_keeper_logs_file_name,
+    )
+    .unwrap();
+
+    info!("Sever started!");
+    info!("Logging config settings: {:?}", config.logging);
+
     let mongo = Database::connect(&config.database).await.unwrap();
+    info!("Database config Settings: {:?}", config.database);
+
     let hashmap_cache = HashmapKeyCache::new(config.session_timeout);
     start_lock_keeper_server(config, mongo, hashmap_cache)
         .await
         .unwrap();
+}
+
+/// Object representing our logging. Should be kept around as our logging
+/// writers return guards that should live for the lifetime of the program. Do
+/// not do anything with the guards. Just make sure they are not dropped!
+struct Logging {
+    _all_layer_guard: WorkerGuard,
+    _server_layer_guard: WorkerGuard,
+}
+
+/// Initialize our logging with three different logging layers:
+/// 1) Log all INFO-level messages (or higher) from our key_server* crates to
+/// standard out. 2) Log all messages (TRACE or higher) from our key_server*
+/// crates to the path specified by `server_logs`.
+/// 3) Log all messages ((TRACE or higher) from any crate to the path specified
+/// by `all_logs`.
+///
+/// Returns an object which should be kept around for the lifetime of the
+/// program.
+fn init_logging(all_logs: &Path, server_logs: &Path) -> Result<Logging, LockKeeperServerError> {
+    let (all_logs_dir, all_logs_file) = get_paths(all_logs)?;
+    let (server_logs_dir, server_logs_file) = get_paths(server_logs)?;
+
+    // Initialize logging. Three different files:
+    let stdout_layer = tracing_subscriber::fmt::layer()
+        .pretty()
+        .with_filter(our_targets_filter(Level::INFO));
+
+    let all_appender = tracing_appender::rolling::hourly(all_logs_dir, all_logs_file);
+    let (non_blocking, _all_layer_guard) = tracing_appender::non_blocking(all_appender);
+    let all_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(non_blocking);
+
+    let server_appender = tracing_appender::rolling::hourly(server_logs_dir, server_logs_file);
+    let (non_blocking, _server_layer_guard) = tracing_appender::non_blocking(server_appender);
+    let server_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_filter(our_targets_filter(Level::TRACE));
+
+    tracing_subscriber::registry()
+        .with(stdout_layer)
+        .with(server_layer)
+        .with(all_layer)
+        .init();
+
+    return Ok(Logging {
+        _all_layer_guard,
+        _server_layer_guard,
+    });
+
+    /// Return the path directory and the file name. Needed for passing to
+    /// tracing_appender.
+    fn get_paths(path: &Path) -> Result<(&Path, &OsStr), LockKeeperServerError> {
+        let dir = path
+            .parent()
+            .ok_or_else(|| LockKeeperServerError::InvalidLogFilePath(path.into()))?;
+
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| LockKeeperServerError::InvalidLogFilePath(path.into()))?;
+        Ok((dir, file_name))
+    }
+
+    /// Create filters for logging events originating from our lock_keeper*
+    /// crates.
+    fn our_targets_filter(level: Level) -> Targets {
+        Targets::new()
+            // List our different targets here. Anything under our server.
+            .with_target("key_server_cli", level)
+            .with_target("lock_keeper_key_server", level)
+            .with_target("lock_keeper", level)
+    }
 }

--- a/dev/docker/Server.toml
+++ b/dev/docker/Server.toml
@@ -10,3 +10,7 @@ opaque_server_key = "/app/opaque/server_setup"
 [database]
 mongodb_uri = 'mongodb://mongodb:27017'
 db_name = 'lock-keeper-test-db'
+
+[logging]
+lock_keeper_logs_file_name = "/app/logs/server.log"
+all_logs_file_name = "/app/logs/all.log"

--- a/dev/docker/ServerMutualAuth.toml
+++ b/dev/docker/ServerMutualAuth.toml
@@ -10,3 +10,7 @@ opaque_server_key = "/app/opaque/server_setup"
 [database]
 mongodb_uri = 'mongodb://mongodb:27017'
 db_name = 'lock-keeper-test-db'
+
+[logging]
+lock_keeper_logs_file_name = "/app/logs/server.log"
+all_logs_file_name = "/app/logs/all.log"

--- a/dev/local/Server.toml
+++ b/dev/local/Server.toml
@@ -9,3 +9,7 @@ opaque_server_key = "dev/opaque/server_setup"
 [database]
 mongodb_uri = 'mongodb://localhost:27017'
 db_name = 'lock-keeper-test-db'
+
+[logging]
+lock_keeper_logs_file_name = "./dev/logs/server.log"
+all_logs_file_name = "./dev/logs/all.log"

--- a/lock-keeper-key-server/Cargo.toml
+++ b/lock-keeper-key-server/Cargo.toml
@@ -31,7 +31,6 @@ toml.workspace = true
 tonic.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
-tracing-subscriber.workspace = true
 uuid.workspace = true
 zeroize.workspace = true
 

--- a/lock-keeper-key-server/src/error.rs
+++ b/lock-keeper-key-server/src/error.rs
@@ -1,4 +1,5 @@
 use crate::server::session_key_cache::SessionCacheError;
+use std::path::PathBuf;
 use thiserror::Error;
 use tonic::Status;
 
@@ -15,9 +16,11 @@ pub enum LockKeeperServerError {
     // Infrastructure errors
     #[error("Invalid OPAQUE directory")]
     InvalidOpaqueDirectory,
+    #[error("Invalid log file path: {0}")]
+    InvalidLogFilePath(PathBuf),
 
     // Protocol errors
-    #[error("Account already registered")]
+    #[error("Account already registered.")]
     AccountAlreadyRegistered,
     #[error("Invalid account")]
     InvalidAccount,
@@ -93,6 +96,7 @@ impl From<LockKeeperServerError> for Status {
 
             // Errors that the client should not see
             LockKeeperServerError::MissingService
+            | LockKeeperServerError::InvalidLogFilePath(_)
             | LockKeeperServerError::SessionCache(_)
             | LockKeeperServerError::Hyper(_)
             | LockKeeperServerError::Io(_)

--- a/lock-keeper-key-server/src/operations/create_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/create_storage_key.rs
@@ -13,74 +13,100 @@ use lock_keeper::{
     },
 };
 use rand::rngs::StdRng;
+use tracing::{error, info, instrument};
 
 #[derive(Debug)]
 pub struct CreateStorageKey;
 
 #[async_trait]
 impl<DB: DataStore> Operation<DB> for CreateStorageKey {
+    #[instrument(skip_all, err(Debug))]
     async fn operation(
         self,
         channel: &mut ServerChannel<StdRng>,
         context: &mut Context<DB>,
     ) -> Result<(), LockKeeperServerError> {
+        info!("Starting create storage key operation.");
+
         let user_id = send_user_id(channel, context).await?;
         store_storage_key(user_id, channel, context).await?;
+        info!("Successfully finished set storage key protocol.");
         Ok(())
     }
 }
 
+/// Look up account and ensure the user doesn't already have a key stored.
+/// 1) Get request from channel.
+/// 2) Look up user in database.
+/// 3) Ensure this user doesn't already have a storage key.
+/// 4) Reply to client via channel.
+#[instrument(skip_all, err(Debug))]
 async fn send_user_id<DB: DataStore>(
     channel: &mut ServerChannel<StdRng>,
     context: &Context<DB>,
 ) -> Result<UserId, LockKeeperServerError> {
     let request: client::RequestUserId = channel.receive().await?;
+    info!(
+        "Attempting to create storage key for {:?}",
+        request.account_name
+    );
+
     let user = context
         .db
         .find_user(&request.account_name)
         .await
-        .map_err(LockKeeperServerError::database)?;
+        .map_err(LockKeeperServerError::database)?
+        .ok_or(LockKeeperServerError::InvalidAccount)?;
 
-    if let Some(user) = user {
-        if user.storage_key.is_some() {
-            return Err(LockKeeperServerError::StorageKeyAlreadySet);
-        }
+    info!("User found: {:?}", user);
 
-        let reply = server::SendUserId {
-            user_id: user.user_id.clone(),
-        };
-
-        channel.send(reply).await?;
-
-        Ok(user.user_id)
-    } else {
-        Err(LockKeeperServerError::InvalidAccount)
+    if user.storage_key.is_some() {
+        return Err(LockKeeperServerError::StorageKeyAlreadySet);
     }
+
+    let reply = server::SendUserId {
+        user_id: user.user_id.clone(),
+    };
+
+    channel.send(reply).await?;
+
+    info!("Successfully completed create storage key protocol.");
+    Ok(user.user_id)
 }
 
+#[instrument(skip_all, err(Debug), fields(user_id))]
 async fn store_storage_key<DB: DataStore>(
     user_id: UserId,
     channel: &mut ServerChannel<StdRng>,
     context: &Context<DB>,
 ) -> Result<(), LockKeeperServerError> {
+    info!("Storing storage key.");
     let client_message: client::SendStorageKey = channel.receive().await?;
 
     if client_message.user_id != user_id {
+        error!(
+            "Newly received message contain a different user ID: ({:?})",
+            client_message.user_id
+        );
         return Err(LockKeeperServerError::InvalidAccount);
     }
 
-    if let Err(error) = context
+    let store_key_result = context
         .db
         .set_storage_key(&user_id, client_message.storage_key)
         .await
-        .map_err(|e| LockKeeperServerError::Database(Box::new(e)))
-    {
+        .map_err(|e| LockKeeperServerError::Database(Box::new(e)));
+
+    // Delete user if we fail to set the storage key.
+    if let Err(e) = store_key_result {
+        error!("Failed to set storage key for user.");
         context
             .db
             .delete_user(&user_id)
             .await
             .map_err(LockKeeperServerError::database)?;
-        return Err(error);
+        info!("Deleted user due to failure to set storage key.");
+        return Err(e);
     }
 
     let reply = server::CreateStorageKeyResult { success: true };

--- a/lock-keeper-key-server/src/operations/remote_sign_bytes.rs
+++ b/lock-keeper-key-server/src/operations/remote_sign_bytes.rs
@@ -1,3 +1,5 @@
+//! This operation allows client to specify a key ID for a key that was remotely
+//! generated on the server and use this key to sign a message.
 use crate::{
     server::{Context, Operation},
     LockKeeperServerError,
@@ -11,17 +13,25 @@ use lock_keeper::{
     types::operations::remote_sign_bytes::{client, server},
 };
 use rand::rngs::StdRng;
+use tracing::{info, instrument};
 
 #[derive(Debug)]
 pub struct RemoteSignBytes;
 
 #[async_trait]
 impl<DB: DataStore> Operation<DB> for RemoteSignBytes {
+    /// Remotely sign protocol:
+    /// 1) Receive remote sign request from client.
+    /// 2) Look up signing key based on client-provided key ID.
+    /// 3) Use signing key to sign client-provided data.
+    /// 4) Respond to client with signed data, the signature.
+    #[instrument(skip_all, err(Debug))]
     async fn operation(
         self,
         channel: &mut ServerChannel<StdRng>,
         context: &mut Context<DB>,
     ) -> Result<(), LockKeeperServerError> {
+        info!("Starting remote sign protocol.");
         let request: client::RequestRemoteSign = channel.receive().await?;
         let key_pair: PlaceholderEncryptedSigningKeyPair = context
             .db
@@ -29,15 +39,16 @@ impl<DB: DataStore> Operation<DB> for RemoteSignBytes {
             .await
             .map_err(LockKeeperServerError::database)?
             .try_into()?;
+        info!("Signing key found. Signing...");
 
         // Pretend to decrypt our placeholder type
         let key: SigningKeyPair = key_pair.try_into()?;
 
         let signature = request.data.sign(&key);
-
         let response = server::ReturnSignature { signature };
         channel.send(response).await?;
 
+        info!("Successfully completed remote sign protocol.");
         Ok(())
     }
 }

--- a/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
@@ -1,3 +1,4 @@
+//! This operation allows client to retrieve the stored audit event logs.
 use crate::{
     database::DataStore,
     server::{Context, Operation},
@@ -9,17 +10,20 @@ use lock_keeper::{
     types::operations::retrieve_audit_events::{client, server},
 };
 use rand::rngs::StdRng;
+use tracing::{info, instrument};
 
 #[derive(Debug)]
 pub struct RetrieveAuditEvents;
 
 #[async_trait]
 impl<DB: DataStore> Operation<DB> for RetrieveAuditEvents {
+    #[instrument(skip_all, err(Debug))]
     async fn operation(
         self,
         channel: &mut ServerChannel<StdRng>,
         context: &mut Context<DB>,
     ) -> Result<(), LockKeeperServerError> {
+        info!("Starting retrieve audit events protocol");
         // Receive event type and options for audit events to return
         let request: client::Request = channel.receive().await?;
 
@@ -35,7 +39,7 @@ impl<DB: DataStore> Operation<DB> for RetrieveAuditEvents {
         };
 
         channel.send(reply).await?;
-
+        info!("Successfully completed retrieve audit events protocol");
         Ok(())
     }
 }

--- a/lock-keeper-key-server/src/server/session_key_cache.rs
+++ b/lock-keeper-key-server/src/server/session_key_cache.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialOrd, PartialEq, Eq)]
 pub enum SessionCacheError {
-    #[error("TODO")]
+    #[error("Session key already exists for this user.")]
     SessionKeyExists,
     #[error("Session key has expired.")]
     ExpiredSessionKey,

--- a/lock-keeper/Cargo.toml
+++ b/lock-keeper/Cargo.toml
@@ -32,6 +32,7 @@ tracing.workspace = true
 uuid.workspace = true
 zeroize.workspace = true
 
+
 # Other dependencies
 chacha20poly1305 = "0.10"
 hkdf = "0.12"

--- a/lock-keeper/src/infrastructure.rs
+++ b/lock-keeper/src/infrastructure.rs
@@ -1,3 +1,4 @@
 //! Modules that facilitate basic client-server operations
 pub mod channel;
+pub mod logging;
 pub mod pem_utils;

--- a/lock-keeper/src/infrastructure/channel.rs
+++ b/lock-keeper/src/infrastructure/channel.rs
@@ -11,7 +11,10 @@ use crate::{
     constants::METADATA,
     crypto::{Encrypted, OpaqueSessionKey},
     rpc::Message,
-    types::operations::{RequestMetadata, ResponseMetadata},
+    types::{
+        database::user::UserId,
+        operations::{ClientAction, RequestMetadata, ResponseMetadata},
+    },
     LockKeeperError,
     LockKeeperError::AlreadyAuthenticated,
 };
@@ -20,6 +23,16 @@ const BUFFER_SIZE: usize = 2;
 
 pub type ServerChannel<G> = Channel<Result<Message, Status>, RequestMetadata, G>;
 pub type ClientChannel<G> = Channel<Message, ResponseMetadata, G>;
+
+impl<G: CryptoRng + RngCore> ServerChannel<G> {
+    pub fn user_id(&self) -> Option<&UserId> {
+        self.metadata.user_id().as_ref()
+    }
+
+    pub fn action(&self) -> ClientAction {
+        self.metadata.action()
+    }
+}
 
 /// A two-way channel between a client and server used to communicate with
 /// `Message` objects. `Channel` uses `tonic` types to receive messages. It can

--- a/lock-keeper/src/infrastructure/logging.rs
+++ b/lock-keeper/src/infrastructure/logging.rs
@@ -1,0 +1,34 @@
+//! Utilities for our logging (tracing) infrastructure.
+
+use std::fmt::Debug;
+use tracing::{warn, Span};
+
+/// For the current active span, record `field_value` for the field
+/// `field_name`. This fields must already be defined in the current span.
+///
+/// All events that happen inside this span will have these fields attached as
+/// additional data.
+///
+/// For example:
+/// ```text
+///   2022-12-05T19:47:03.090605Z  INFO lock_keeper_key_server::operations::authenticate: Starting authentication protocol.
+///     at lock-keeper-key-server/src/operations/authenticate.rs:38
+///     in lock_keeper_key_server::operations::authenticate::operation
+///     in lock_keeper_key_server::server::operation::handle_request with request_id: "9cb5e6fe-aa86-43e9-b7c9-413c005cbb50", action: "Authenticate"
+/// ```
+/// We can see here the `handle_request` span has fields "request_id" and
+/// "action".
+///
+/// If running on development mode, this function will check if the field has
+/// NOT been defined and log a warning.
+///
+///  Note: We use dynamic dispatch for the `field_value` argument as we expect
+/// lots of types to call this function.
+pub fn record_field(field_name: &str, field_value: &dyn Debug) {
+    if cfg!(debug_assertions) && !Span::current().has_field(field_name) {
+        warn!("Field {} not defined in current span!", field_name);
+    }
+
+    // Ignore the resulting span.
+    let _ = Span::current().record(field_name, format!("{:?}", field_value));
+}

--- a/persistence/lock-keeper-mongodb/Cargo.toml
+++ b/persistence/lock-keeper-mongodb/Cargo.toml
@@ -15,6 +15,7 @@ async-trait.workspace = true
 futures.workspace = true
 opaque-ke.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 
 # Other dependencies
 mongodb = "2.3.0"

--- a/persistence/lock-keeper-mongodb/src/api.rs
+++ b/persistence/lock-keeper-mongodb/src/api.rs
@@ -23,11 +23,14 @@ use mongodb::{
     Client, Database as MongoDB, IndexModel,
 };
 use opaque_ke::ServerRegistration;
+use tracing::instrument;
 
 mod audit_event;
 mod secret;
 mod user;
 
+/// Our wrapper around the [`MongoDB`] type. We implement the trait
+/// [`DataStore`] for this type.
 #[derive(Debug, Clone)]
 pub struct Database {
     handle: MongoDB,
@@ -71,6 +74,7 @@ impl Database {
 impl DataStore for Database {
     type Error = Error;
 
+    #[instrument(skip_all, err(Debug), fields(actor, secret_id, action, status))]
     async fn create_audit_event(
         &self,
         actor: &AccountName,
@@ -83,6 +87,7 @@ impl DataStore for Database {
         Ok(())
     }
 
+    #[instrument(skip_all, err(Debug), fields(account_name, event_type, options))]
     async fn find_audit_events(
         &self,
         account_name: &AccountName,
@@ -95,6 +100,7 @@ impl DataStore for Database {
         Ok(audit_events)
     }
 
+    #[instrument(skip_all, err(Debug), fields(user_id))]
     async fn add_user_secret(
         &self,
         user_id: &UserId,
@@ -104,6 +110,7 @@ impl DataStore for Database {
         Ok(())
     }
 
+    #[instrument(skip_all, err(Debug), fields(user_id, key_id))]
     async fn get_user_secret(
         &self,
         user_id: &UserId,
@@ -126,21 +133,25 @@ impl DataStore for Database {
         Ok(user)
     }
 
+    #[instrument(skip_all, err(Debug), fields(account_name))]
     async fn find_user(&self, account_name: &AccountName) -> Result<Option<User>, Self::Error> {
         let opt_user = self.find_user(account_name).await?;
         Ok(opt_user)
     }
 
+    #[instrument(skip_all, err(Debug), fields(user_id))]
     async fn find_user_by_id(&self, user_id: &UserId) -> Result<Option<User>, Self::Error> {
         let opt_user = self.find_user_by_id(user_id).await?;
         Ok(opt_user)
     }
 
+    #[instrument(skip_all, err(Debug), fields(user_id))]
     async fn delete_user(&self, user_id: &UserId) -> Result<(), Self::Error> {
         self.delete_user(user_id).await?;
         Ok(())
     }
 
+    #[instrument(skip_all, err(Debug), fields(user_id))]
     async fn set_storage_key(
         &self,
         user_id: &UserId,


### PR DESCRIPTION
This is the initial impl of the logging support. I wanted to submit a draft so people could see what I'm up to. Let me know if you have any thoughts or concerns on my current approach.

I'm currently focusing on logging our operations and the server "entry point" functions for requests. I'm trying to minimize my refactoring of the code, even though I want to :grimacing: . Some small refactoring helps keep the recording of fields in a logical place. I try to record fields (for spans) in reasonable places, but this is often a tradeoff with refactoring. So I try to find a balance.

Currently I am using a outputting the logs to stdout with a "pretty" logger. Which makes it easy to visually parse the logs. When we switch to writing to a file we will use a more compact/parsable format.

As an example, succesfully logging in produces the following `info` level logging events:
```
  2022-11-30T19:51:26.471762Z  INFO lock_keeper_key_server::server::service: Accepted Connection from., client: 127.0.0.1:41428
    at lock-keeper-key-server/src/server/service.rs:78

  2022-11-30T19:51:26.477866Z  INFO lock_keeper_key_server::server::operation: This operation does not require authentication.
    at lock-keeper-key-server/src/server/operation.rs:96
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"

  2022-11-30T19:51:26.526707Z  INFO lock_keeper_key_server::operations::authenticate: Starting authentication operation.
    at lock-keeper-key-server/src/operations/authenticate.rs:43
    in lock_keeper_key_server::operations::authenticate::operation with account_name: "omar"
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"

  2022-11-30T19:51:26.532213Z  INFO lock_keeper_key_server::operations::authenticate: User ID found.
    at lock-keeper-key-server/src/operations/authenticate.rs:82
    in lock_keeper_key_server::operations::authenticate::authenticate_start with user_id: "\"84e8936e-e24b-0478-c824-30b33abbd4b2\""
    in lock_keeper_key_server::operations::authenticate::operation with account_name: "omar"
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"

  2022-11-30T19:51:26.537638Z  INFO lock_keeper_key_server::operations::authenticate: Hi
    at lock-keeper-key-server/src/operations/authenticate.rs:118
    in lock_keeper_key_server::operations::authenticate::authenticate_finish
    in lock_keeper_key_server::operations::authenticate::operation with account_name: "omar"
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"

  2022-11-30T19:51:26.834229Z  INFO lock_keeper_key_server::operations::authenticate: Received finish message from client.
    at lock-keeper-key-server/src/operations/authenticate.rs:121
    in lock_keeper_key_server::operations::authenticate::authenticate_finish
    in lock_keeper_key_server::operations::authenticate::operation with account_name: "omar"
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"

  2022-11-30T19:51:26.834577Z  INFO lock_keeper_key_server::operations::authenticate: Authentication succeeded.
    at lock-keeper-key-server/src/operations/authenticate.rs:126
    in lock_keeper_key_server::operations::authenticate::authenticate_finish
    in lock_keeper_key_server::operations::authenticate::operation with account_name: "omar"
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"

  2022-11-30T19:51:26.834773Z  INFO lock_keeper_key_server::server::session_key_cache: Previous session key overwritten.
    at lock-keeper-key-server/src/server/session_key_cache.rs:68
    in lock_keeper_key_server::operations::authenticate::operation with account_name: "omar"
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"

  2022-11-30T19:51:26.834826Z  INFO lock_keeper_key_server::operations::authenticate: Session key established and saved.
    at lock-keeper-key-server/src/operations/authenticate.rs:51
    in lock_keeper_key_server::operations::authenticate::operation with account_name: "omar"
    in lock_keeper_key_server::server::operation::handle_request with action: "Authenticate"
```