### PR TITLE
Use volume mounts for dev/ files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/src/lock-keeper-key-server/target \
     cargo install --path ./bin/key-server-cli
 
+VOLUME /app
+
 CMD ["sh", "-c", "key-server-cli ${CONFIG}"]

--- a/dev/docker/Server.toml
+++ b/dev/docker/Server.toml
@@ -1,11 +1,11 @@
 address = "0.0.0.0"
 port = 1113
 session_timeout = "60s"
-private_key = "dev/test-pki/gen/certs/server.key"
-certificate_chain = "dev/test-pki/gen/certs/server.chain"
+private_key = "/app/test-pki/gen/certs/server.key"
+certificate_chain = "/app/test-pki/gen/certs/server.chain"
 client_auth = false
-opaque_path = "dev/opaque"
-opaque_server_key = "dev/opaque/server_setup"
+opaque_path = "/app/opaque"
+opaque_server_key = "/app/opaque/server_setup"
 
 [database]
 mongodb_uri = 'mongodb://mongodb:27017'

--- a/dev/docker/ServerMutualAuth.toml
+++ b/dev/docker/ServerMutualAuth.toml
@@ -1,11 +1,11 @@
 address = "0.0.0.0"
 port = 1114
 session_timeout = "60s"
-private_key = "dev/test-pki/gen/certs/server.key"
-certificate_chain = "dev/test-pki/gen/certs/server.chain"
+private_key = "/app/test-pki/gen/certs/server.key"
+certificate_chain = "/app/test-pki/gen/certs/server.chain"
 client_auth = true
-opaque_path = "dev/opaque"
-opaque_server_key = "dev/opaque/server_setup"
+opaque_path = "/app/opaque"
+opaque_server_key = "/app/opaque/server_setup"
 
 [database]
 mongodb_uri = 'mongodb://mongodb:27017'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,10 @@ services:
 
   key_server:
     build: .
+    volumes:
+      - ./dev:/app
     environment:
-      CONFIG: "./dev/docker/Server.toml"
+      CONFIG: "/app/docker/Server.toml"
     ports:
       - 1113:1113
     depends_on:
@@ -23,11 +25,13 @@ services:
 
   key_server_mutual_auth:
     build: .
+    volumes:
+      - ./dev:/app
     # The main difference for this service is the config file.
     # We'll override the entrypoint and pass a different config instead of
     # dealing with multiple Dockerfiles.
     environment:
-      CONFIG: "./dev/docker/ServerMutualAuth.toml"
+      CONFIG: "/app/docker/ServerMutualAuth.toml"
     ports:
       - 1114:1114
     depends_on:


### PR DESCRIPTION
I mapped the local dev/ folder to a /develop volume on the Docker image and changed some of the config file paths around to match. This also seems to be working with the service provider both with a local build and a github build.