### PR TITLE
A small fix to private docs + additional flag to docs test

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -111,7 +111,7 @@ args = ["test", "--all-features", "--doc", "--workspace"]
 [tasks.ci-docs]
 env = { "RUSTDOCFLAGS" = "-Dwarnings" }
 command = "cargo"
-args = ["doc", "--all-features", "--no-deps", "--workspace"]
+args = ["doc", "--all-features", "--no-deps", "--document-private-items", "--workspace"]
 
 # -- Utility Tasks --
 

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -209,7 +209,7 @@ impl LockKeeperClient {
         Ok(channel)
     }
 
-    /// Helper to create the appropriate [`AuthenticatedClientChannel`] to send
+    /// Helper to create the appropriate authenticated [`ClientChannel`] to send
     /// to tonic handler functions based on the client's action.
     pub(crate) async fn create_authenticated_channel(
         &self,


### PR DESCRIPTION
The "Publish Docs" workflow runs only on develop and uses the `--document-private-items` flag, this introduced inconsistencies with what was tested on a PR. This PR fixes one such inconsistency, as well as add the flag to the docs test on every PR.