### PR TITLE
Make TLS optional on the server #348

### DIFF
--- a/dev/docker/Server.toml
+++ b/dev/docker/Server.toml
@@ -1,11 +1,13 @@
 address = "0.0.0.0"
 port = 1113
 session_timeout = "60s"
+opaque_path = "/app/opaque"
+opaque_server_key = "/app/opaque/server_setup"
+
+[tls_config]
 private_key = "/app/test-pki/gen/certs/server.key"
 certificate_chain = "/app/test-pki/gen/certs/server.chain"
 client_auth = false
-opaque_path = "/app/opaque"
-opaque_server_key = "/app/opaque/server_setup"
 
 [database]
 mongodb_uri = 'mongodb://mongodb:27017'

--- a/dev/docker/ServerMutualAuth.toml
+++ b/dev/docker/ServerMutualAuth.toml
@@ -1,11 +1,13 @@
 address = "0.0.0.0"
 port = 1114
 session_timeout = "60s"
+opaque_path = "/app/opaque"
+opaque_server_key = "/app/opaque/server_setup"
+
+[tls_config]
 private_key = "/app/test-pki/gen/certs/server.key"
 certificate_chain = "/app/test-pki/gen/certs/server.chain"
 client_auth = true
-opaque_path = "/app/opaque"
-opaque_server_key = "/app/opaque/server_setup"
 
 [database]
 mongodb_uri = 'mongodb://mongodb:27017'

--- a/dev/local/Server.toml
+++ b/dev/local/Server.toml
@@ -1,10 +1,12 @@
 address = "127.0.0.1"
 port = 1113
+opaque_path = "dev/opaque"
+opaque_server_key = "dev/opaque/server_setup"
+
+[tls_config]
 private_key = "dev/test-pki/gen/certs/server.key"
 certificate_chain = "dev/test-pki/gen/certs/server.chain"
 client_auth = false
-opaque_path = "dev/opaque"
-opaque_server_key = "dev/opaque/server_setup"
 
 [database]
 mongodb_uri = 'mongodb://localhost:27017'

--- a/dev/local/ServerMutualAuth.toml
+++ b/dev/local/ServerMutualAuth.toml
@@ -1,10 +1,12 @@
 address = "127.0.0.1"
 port = 1114
+opaque_path = "dev/opaque"
+opaque_server_key = "dev/opaque/server_setup"
+
+[tls_config]
 private_key = "dev/test-pki/gen/certs/server.key"
 certificate_chain = "dev/test-pki/gen/certs/server.chain"
 client_auth = true
-opaque_path = "dev/opaque"
-opaque_server_key = "dev/opaque/server_setup"
 
 [database]
 mongodb_uri = 'mongodb://localhost:27017'

--- a/lock-keeper-tests/src/test_suites/config_files.rs
+++ b/lock-keeper-tests/src/test_suites/config_files.rs
@@ -124,10 +124,12 @@ private_key = "dev/test-pki/gen/certs/client.key"
 const SERVER_CONFIG_NO_KEY: &str = r#"
 address = "127.0.0.1"
 port = 1114
-certificate_chain = "dev/test-pki/gen/certs/server.chain"
-client_auth = true
 opaque_path = "dev/opaque"
 opaque_server_key = "dev/opaque/server_setup"
+
+[tls_config]
+certificate_chain = "dev/test-pki/gen/certs/server.chain"
+client_auth = true
 
 [database]
 mongodb_uri = 'mongodb://localhost:27017'
@@ -141,11 +143,13 @@ all_logs_file_name = "/app/logs/all.log"
 const SERVER_CONFIG_WITH_KEY: &str = r#"
 address = "127.0.0.1"
 port = 1114
-certificate_chain = "dev/test-pki/gen/certs/server.chain"
-private_key = "dev/test-pki/gen/certs/server.key"
-client_auth = true
 opaque_path = "dev/opaque"
 opaque_server_key = "dev/opaque/server_setup"
+
+[tls_config]
+private_key = "dev/test-pki/gen/certs/server.key"
+certificate_chain = "dev/test-pki/gen/certs/server.chain"
+client_auth = true
 
 [database]
 mongodb_uri = 'mongodb://localhost:27017'


### PR DESCRIPTION
This PR makes TLS optional on the server and updates the configs accordingly.

I will make a separate PR to integrate `nginx` into our test stack.