### PR TITLE
Create separate table for secrets in db

### DIFF
--- a/lock-keeper-key-server/src/database.rs
+++ b/lock-keeper-key-server/src/database.rs
@@ -47,11 +47,7 @@ pub trait DataStore: Send + Sync + 'static {
     // Secret
     /// Add a [`StoredSecret`] to a [`User`]'s list of arbitrary
     /// secrets
-    async fn add_user_secret(
-        &self,
-        user_id: &UserId,
-        secret: StoredSecret,
-    ) -> Result<(), Self::Error>;
+    async fn add_user_secret(&self, secret: StoredSecret) -> Result<(), Self::Error>;
 
     /// Get a [`User`]'s [`StoredSecret`] based on its [`KeyId`].
     /// A [`StoredSecret`] will only be returned if it matches the given

--- a/lock-keeper-key-server/src/operations/generate_secret.rs
+++ b/lock-keeper-key-server/src/operations/generate_secret.rs
@@ -82,12 +82,16 @@ async fn store_key<DB: DataStore>(
 ) -> Result<(), LockKeeperServerError> {
     // Receive Encrypted<Secret> from client
     let store_message: client::Store = channel.receive().await?;
-    let secret = StoredSecret::from_arbitrary_secret(key_id.clone(), store_message.ciphertext)?;
+    let secret = StoredSecret::from_arbitrary_secret(
+        key_id.clone(),
+        store_message.user_id,
+        store_message.ciphertext,
+    )?;
 
     // Check validity of ciphertext and store in DB
     context
         .db
-        .add_user_secret(&store_message.user_id, secret)
+        .add_user_secret(secret)
         .await
         .map_err(LockKeeperServerError::database)?;
     info!("Client's cypher text stored successfully.");

--- a/lock-keeper-key-server/src/operations/import_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/import_signing_key.rs
@@ -54,13 +54,16 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for ImportSigningKey {
                 .encrypt_signing_key_pair(&mut *rng, signing_key)?
         };
 
-        let secret =
-            StoredSecret::from_remote_signing_key_pair(key_id.clone(), encrypted_key_pair)?;
+        let secret = StoredSecret::from_remote_signing_key_pair(
+            key_id.clone(),
+            encrypted_key_pair,
+            request.user_id,
+        )?;
 
         // Check validity of ciphertext and store in DB
         context
             .db
-            .add_user_secret(&request.user_id, secret)
+            .add_user_secret(secret)
             .await
             .map_err(LockKeeperServerError::database)?;
 

--- a/lock-keeper-key-server/src/operations/remote_generate_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/remote_generate_signing_key.rs
@@ -57,13 +57,16 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RemoteGenerateSigni
                 .encrypt_signing_key_pair(&mut *rng, key_pair)?
         };
 
-        let secret =
-            StoredSecret::from_remote_signing_key_pair(key_id.clone(), encrypted_key_pair)?;
+        let secret = StoredSecret::from_remote_signing_key_pair(
+            key_id.clone(),
+            encrypted_key_pair,
+            request.user_id,
+        )?;
 
         // Store key in database
         context
             .db
-            .add_user_secret(&request.user_id, secret)
+            .add_user_secret(secret)
             .await
             .map_err(LockKeeperServerError::database)?;
 

--- a/lock-keeper-tests/src/test_suites/database/secret.rs
+++ b/lock-keeper-tests/src/test_suites/database/secret.rs
@@ -96,8 +96,8 @@ async fn add_arbitrary_secret(
     let key_id = KeyId::generate(rng, user_id)?;
     let (_, encrypted) = Secret::create_and_encrypt(rng, storage_key, user_id, &key_id)?;
 
-    let secret = StoredSecret::from_arbitrary_secret(key_id.clone(), encrypted)?;
-    db.add_user_secret(user_id, secret).await?;
+    let secret = StoredSecret::from_arbitrary_secret(key_id.clone(), user_id.clone(), encrypted)?;
+    db.add_user_secret(secret).await?;
 
     Ok(key_id)
 }
@@ -113,8 +113,12 @@ async fn import_signing_key(db: &Database, rng: &mut StdRng, user_id: &UserId) -
     // encrypt key_pair
     let encrypted_key_pair = encryption_key.encrypt_signing_key_pair(rng, signing_key)?;
 
-    let secret = StoredSecret::from_remote_signing_key_pair(key_id.clone(), encrypted_key_pair)?;
-    db.add_user_secret(user_id, secret).await?;
+    let secret = StoredSecret::from_remote_signing_key_pair(
+        key_id.clone(),
+        encrypted_key_pair,
+        user_id.clone(),
+    )?;
+    db.add_user_secret(secret).await?;
 
     Ok(key_id)
 }
@@ -132,7 +136,11 @@ async fn remote_generate_signing_key(
     // encrypt key_pair
     let encrypted_key_pair = encryption_key.encrypt_signing_key_pair(rng, signing_key)?;
 
-    let secret = StoredSecret::from_remote_signing_key_pair(key_id.clone(), encrypted_key_pair)?;
-    db.add_user_secret(user_id, secret).await?;
+    let secret = StoredSecret::from_remote_signing_key_pair(
+        key_id.clone(),
+        encrypted_key_pair,
+        user_id.clone(),
+    )?;
+    db.add_user_secret(secret).await?;
     Ok(key_id)
 }

--- a/lock-keeper/src/constants.rs
+++ b/lock-keeper/src/constants.rs
@@ -5,5 +5,6 @@ pub const LOCAL_SERVER_URI: &str = "https://localhost:1113";
 
 pub const ACCOUNT_NAME: &str = "account_name";
 pub const ACTION: &str = "action";
+pub const KEY_ID: &str = "key_id";
 pub const METADATA: &str = "metadata";
 pub const USER_ID: &str = "user_id";

--- a/lock-keeper/src/error.rs
+++ b/lock-keeper/src/error.rs
@@ -16,6 +16,8 @@ pub enum LockKeeperError {
     UnknownSecretType(String),
     #[error("Invalid secret type")]
     InvalidSecretType,
+    #[error("Invalid KeyId length")]
+    InvalidKeyIdLength,
 
     // Request errors
     #[error("Invalid client action")]
@@ -42,6 +44,8 @@ pub enum LockKeeperError {
     InvalidRemoteStorageKey,
 
     // Wrapped errors
+    #[error(transparent)]
+    Hex(#[from] hex::FromHexError),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("OPAQUE protocol error: {}", .0)]
@@ -82,7 +86,9 @@ impl From<LockKeeperError> for Status {
             | LockKeeperError::AlreadyAuthenticated
             | LockKeeperError::ShouldBeAuthenticated
             | LockKeeperError::Crypto(_)
+            | LockKeeperError::Hex(_)
             | LockKeeperError::Io(_)
+            | LockKeeperError::InvalidKeyIdLength
             | LockKeeperError::InvalidPrivateKey
             | LockKeeperError::InvalidRemoteStorageKey
             | LockKeeperError::OpaqueProtocol(_)

--- a/lock-keeper/src/types/database.rs
+++ b/lock-keeper/src/types/database.rs
@@ -2,3 +2,49 @@
 
 pub mod secrets;
 pub mod user;
+
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::LockKeeperError;
+
+/// Convenience type for serializing byte arrays as hex strings.
+/// Add the `#[serde(try_from = "HexBytes", into = "HexBytes")]` attribute macro
+/// above any type you'd like to serialize this way. This type should only be
+/// used to serialize byte collections. It should not be used directly.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct HexBytes(String);
+
+impl Display for HexBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<T: AsRef<[u8]>> From<T> for HexBytes {
+    fn from(bytes: T) -> Self {
+        Self(hex::encode(bytes))
+    }
+}
+
+impl TryFrom<HexBytes> for Vec<u8> {
+    type Error = LockKeeperError;
+
+    fn try_from(bytes: HexBytes) -> Result<Self, Self::Error> {
+        Ok(hex::decode(bytes.0)?)
+    }
+}
+
+impl<const N: usize> TryFrom<HexBytes> for [u8; N] {
+    type Error = LockKeeperError;
+
+    fn try_from(bytes: HexBytes) -> Result<Self, Self::Error> {
+        let byte_array = hex::decode(bytes.0)?
+            .try_into()
+            // We know that we have a sequence of bytes so the only possible error is that it's the
+            // wrong length
+            .map_err(|_| LockKeeperError::InvalidKeyIdLength)?;
+        Ok(byte_array)
+    }
+}

--- a/lock-keeper/src/types/database/secrets.rs
+++ b/lock-keeper/src/types/database/secrets.rs
@@ -6,10 +6,13 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::user::UserId;
+
 /// Generic representation of a secret that is stored in a database.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct StoredSecret {
     pub key_id: KeyId,
+    pub user_id: UserId,
     pub secret_type: String,
     pub bytes: Vec<u8>,
     pub retrieved: bool,
@@ -18,6 +21,7 @@ pub struct StoredSecret {
 impl StoredSecret {
     pub fn new(
         key_id: KeyId,
+        user_id: UserId,
         secret_type: impl Into<String>,
         secret: impl Into<Vec<u8>>,
     ) -> Result<Self, LockKeeperError> {
@@ -25,6 +29,7 @@ impl StoredSecret {
 
         Ok(Self {
             key_id,
+            user_id,
             secret_type: secret_type.into(),
             bytes: serde_json::to_vec(&secret)?,
             retrieved: false,
@@ -33,10 +38,12 @@ impl StoredSecret {
 
     pub fn from_arbitrary_secret(
         key_id: KeyId,
+        user_id: UserId,
         secret: Encrypted<Secret>,
     ) -> Result<Self, LockKeeperError> {
         Ok(Self {
             key_id,
+            user_id,
             secret_type: secret_types::ARBITRARY_SECRET.to_string(),
             bytes: serde_json::to_vec(&secret)?,
             retrieved: false,
@@ -45,10 +52,12 @@ impl StoredSecret {
 
     pub fn from_signing_key_pair(
         key_id: KeyId,
+        user_id: UserId,
         secret: Encrypted<SigningKeyPair>,
     ) -> Result<Self, LockKeeperError> {
         Ok(Self {
             key_id,
+            user_id,
             secret_type: secret_types::SIGNING_KEY_PAIR.to_string(),
             bytes: serde_json::to_vec(&secret)?,
             retrieved: false,
@@ -58,9 +67,11 @@ impl StoredSecret {
     pub fn from_remote_signing_key_pair(
         key_id: KeyId,
         secret: Encrypted<SigningKeyPair>,
+        user_id: UserId,
     ) -> Result<Self, LockKeeperError> {
         Ok(Self {
             key_id,
+            user_id,
             secret_type: secret_types::REMOTE_SIGNING_KEY.to_string(),
             bytes: serde_json::to_vec(&secret)?,
             retrieved: false,

--- a/persistence/lock-keeper-mongodb/src/api/secret.rs
+++ b/persistence/lock-keeper-mongodb/src/api/secret.rs
@@ -1,13 +1,10 @@
 //! Operations on secrets in the database.
 
-use crate::{constants::USERS, error::Error};
+use crate::{constants::SECRETS, error::Error};
 use lock_keeper::{
-    constants::USER_ID,
+    constants::{KEY_ID, USER_ID},
     crypto::KeyId,
-    types::database::{
-        secrets::StoredSecret,
-        user::{User, UserId},
-    },
+    types::database::{secrets::StoredSecret, user::UserId},
 };
 use lock_keeper_key_server::database::SecretFilter;
 use mongodb::bson::doc;
@@ -15,55 +12,40 @@ use mongodb::bson::doc;
 use super::Database;
 
 impl Database {
-    /// Add a [`StoredSecret] to a [`User`]'s list of arbitrary
-    /// secrets
-    pub(crate) async fn add_user_secret(
-        &self,
-        user_id: &UserId,
-        secret: StoredSecret,
-    ) -> Result<(), Error> {
-        let collection = self.handle.collection::<User>(USERS);
-        let stored_secret_bson = mongodb::bson::to_bson(&secret)?;
-        let filter = doc! { USER_ID: user_id };
-        let update = doc! { "$push":  { "secrets": stored_secret_bson } };
-        let _ = collection
-            .find_one_and_update(filter, update, None)
-            .await?
-            .ok_or(Error::InvalidAccount)?;
+    /// Add a [`StoredSecret] to the to database.
+    pub(crate) async fn add_user_secret(&self, secret: StoredSecret) -> Result<(), Error> {
+        let collection = self.handle.collection::<StoredSecret>(SECRETS);
+        let _ = collection.insert_one(&secret, None).await?;
         Ok(())
     }
 
-    /// Get a [`User`]'s [`StoredSecret`] based on its [`KeyId`]
+    /// Get a [`StoredSecret`] based on its [`KeyId`].
+    /// Ensures that the [`UserId`] also matches before returning the
+    /// [`StoredSecret`]
     pub(crate) async fn get_user_secret(
         &self,
         user_id: &UserId,
         key_id: &KeyId,
         filter: SecretFilter,
     ) -> Result<StoredSecret, Error> {
-        // Get user collection
-        let collection = self.handle.collection::<User>(USERS);
+        // Get secret collection
+        let collection = self.handle.collection::<StoredSecret>(SECRETS);
         // Match on UserId and KeyId, update "retrieved" field to true
+        let user_id_bson = mongodb::bson::to_bson(user_id)?;
         let key_id_bson = mongodb::bson::to_bson(key_id)?;
         let mut query_filter = doc! {
-            USER_ID: user_id,
-            "secrets.key_id": key_id_bson,
+            USER_ID: user_id_bson,
+            KEY_ID: key_id_bson,
         };
         if let Some(st) = filter.secret_type {
-            let _ = query_filter.insert("secrets.secret_type", st);
+            let _ = query_filter.insert("secret_type", st);
         }
 
-        let update = doc! { "$set": { "secrets.$.retrieved": true } };
-        let user = collection
+        let update = doc! { "$set": { "retrieved": true } };
+        let stored_secret = collection
             .find_one_and_update(query_filter, update, None)
             .await?
             .ok_or(Error::InvalidAccount)?;
-
-        // Filter found user to return stored secret
-        let stored_secret = user
-            .secrets
-            .into_iter()
-            .find(|x| x.key_id == *key_id)
-            .ok_or(Error::KeyNotFound)?;
 
         Ok(stored_secret)
     }

--- a/persistence/lock-keeper-mongodb/src/api/user.rs
+++ b/persistence/lock-keeper-mongodb/src/api/user.rs
@@ -53,7 +53,8 @@ impl Database {
     /// Find a [`User`] by their machine-readable [`UserId`].
     pub(crate) async fn find_user_by_id(&self, user_id: &UserId) -> Result<Option<User>, Error> {
         let collection = self.handle.collection::<User>(USERS);
-        let query = doc! { USER_ID: user_id };
+        let user_id_bson = mongodb::bson::to_bson(user_id)?;
+        let query = doc! { USER_ID: user_id_bson };
         let user = collection.find_one(query, None).await?;
         Ok(user)
     }
@@ -61,7 +62,8 @@ impl Database {
     /// Delete a [`User`] by their [`UserId`]
     pub(crate) async fn delete_user(&self, user_id: &UserId) -> Result<(), Error> {
         let collection = self.handle.collection::<User>(USERS);
-        let query = doc! { USER_ID: user_id };
+        let user_id_bson = mongodb::bson::to_bson(user_id)?;
+        let query = doc! { USER_ID: user_id_bson };
         let result = collection.delete_one(query, None).await?;
 
         if result.deleted_count == 0 {
@@ -86,7 +88,8 @@ impl Database {
         let storage_key_bson = mongodb::bson::to_bson(&storage_key)?;
 
         let collection = self.handle.collection::<User>(USERS);
-        let filter = doc! { USER_ID: user_id };
+        let user_id_bson = mongodb::bson::to_bson(user_id)?;
+        let filter = doc! { USER_ID: user_id_bson };
         let update = doc! { "$set": { STORAGE_KEY: storage_key_bson } };
 
         let user = collection.find_one_and_update(filter, update, None).await?;

--- a/persistence/lock-keeper-mongodb/src/constants.rs
+++ b/persistence/lock-keeper-mongodb/src/constants.rs
@@ -3,6 +3,7 @@
 /* TABLE NAMES */
 pub(crate) const AUDIT_EVENTS: &str = "audit_events";
 pub(crate) const USERS: &str = "users";
+pub(crate) const SECRETS: &str = "secrets";
 
 /* FIELD NAMES */
 pub(crate) const ACTION: &str = "action";


### PR DESCRIPTION
This PR separates users and secrets into different database tables. This allows us to return a user's info without returning all of their secrets.

Since key ids are 32 bytes, we can't use the same UUID generation method as user ids. Instead, I made a helper type called `HexBytes` that allows us to serialize byte collections as hex strings. This type ensures that the serialized representation of a type is a plain string that will place nice with databases, while the Rust representation is a pure byte array.

@marsella Since this exists now, I changed the `UserId` type back to bytes similar to the `KeyId` type. It's still generated the same way, but we don't use the randomly generated bytes to create a UUID anymore.