### PR TITLE
Add nginx with TLS #348

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,9 +27,10 @@ dependencies = ["teardown", "start"]
 [tasks.start-server-attached]
 command = "docker"
 args = ["compose", "up",
-        "--build", "mongodb", "key_server", "key_server_client_auth",
+        "--build", "mongodb", "nginx", "key_server", "ks_client_auth", "ks_nginx",
         "--attach", "key_server", 
-        "--attach", "key_server_client_auth"
+        "--attach", "ks_client_auth",
+        "--attach", "ks_nginx",
 ]
 dependencies = ["certs", "remote-storage-key"]
 
@@ -37,8 +38,8 @@ dependencies = ["certs", "remote-storage-key"]
 [tasks.start-server-detached]
 command = "docker"
 args = ["compose", "up", 
-        "--build", "mongodb", "key_server", "key_server_client_auth",
-        "--wait"
+        "--build", "mongodb",  "nginx", "key_server", "ks_client_auth", "ks_nginx",
+        "--wait",
 ]
 dependencies = ["certs", "remote-storage-key"]
 

--- a/dev/config/TestEnvironments.toml
+++ b/dev/config/TestEnvironments.toml
@@ -1,0 +1,3 @@
+standard = "./dev/config/local/Client.toml"
+client_auth = "./dev/config/local-client-auth/Client.toml"
+nginx = "./dev/config/nginx-tls/Client.toml"

--- a/dev/config/local/Binary.toml
+++ b/dev/config/local/Binary.toml
@@ -1,4 +1,4 @@
 # Local server, no client auth, mongo DB
-server = "dev/config/server/Server.toml"
+server = "dev/config/local/Server.toml"
 database = "dev/config/MongoDB.toml"
 session_cache = "dev/config/SessionCache.toml"

--- a/dev/config/nginx-tls/Binary.toml
+++ b/dev/config/nginx-tls/Binary.toml
@@ -1,0 +1,3 @@
+server = "/app/config/nginx-tls/Server.toml"
+database = "/app/config/MongoDB.toml"
+session_cache = "/app/config/SessionCache.toml"

--- a/dev/config/nginx-tls/Client.toml
+++ b/dev/config/nginx-tls/Client.toml
@@ -1,0 +1,6 @@
+server_uri = "https://localhost:1115"
+ca_chain = "dev/test-pki/gen/ca/signing-ca.chain"
+
+[client_auth]
+certificate_chain = "dev/test-pki/gen/certs/client.chain"
+private_key = "dev/test-pki/gen/certs/client.key"

--- a/dev/config/nginx-tls/Server.toml
+++ b/dev/config/nginx-tls/Server.toml
@@ -1,0 +1,9 @@
+address = "0.0.0.0"
+port = 1113
+opaque_path = "/app/opaque"
+opaque_server_key = "/app/opaque/server_setup"
+remote_storage_key = "/app/remote-storage-key/gen/remote_storage.key"
+
+[logging]
+lock_keeper_logs_file_name = "/app/logs/server.log"
+all_logs_file_name = "/app/logs/all.log"

--- a/dev/config/nginx-tls/nginx.conf
+++ b/dev/config/nginx-tls/nginx.conf
@@ -1,0 +1,16 @@
+events {}
+http {
+    server {
+        listen     1115 ssl http2;
+
+        ssl_protocols  TLSv1.2;
+        ssl_ciphers ALL;
+        ssl_session_cache shared:SSL:1m;
+        ssl_certificate        /etc/ssl/certs/server.crt;
+        ssl_certificate_key    /etc/ssl/certs/server.key;
+
+        location / {
+            grpc_pass grpc://ks_nginx:1113;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,20 @@ services:
     ports:
       - 27017:27017
     stdin_open: true
-    tty: true 
+    tty: true
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx_tls
+    restart: always
+    ports:
+      - 1115:1115
+    depends_on:
+      - "ks_nginx"
+    volumes:
+      - ./dev/config/nginx-tls/nginx.conf:/etc/nginx/nginx.conf
+      - ./dev/test-pki/gen/certs/server.key:/etc/ssl/certs/server.key
+      - ./dev/test-pki/gen/certs/server.chain:/etc/ssl/certs/server.crt
 
   key_server:
     build: .
@@ -20,7 +33,7 @@ services:
     ports:
       - 1113:1113
     healthcheck:
-      test: "chmod +x healthcheck.sh && ./healthcheck.sh http://localhost:1113"
+      test: "sh ./healthcheck.sh http://localhost:1113"
       interval: 10s
       timeout: 5s
     depends_on:
@@ -28,20 +41,32 @@ services:
     stdin_open: true
     tty: true 
 
-  key_server_client_auth:
+  ks_client_auth:
     build: .
     restart: always
     volumes:
       - ./dev:/app
-    # The main difference for this service is the config file.
-    # We'll override the entrypoint and pass a different config instead of
-    # dealing with multiple Dockerfiles.
     environment:
       CONFIG: "/app/config/docker-client-auth/Binary.toml"
     ports:
       - 1114:1114
     healthcheck:
-      test: "chmod +x healthcheck.sh && ./healthcheck.sh http://localhost:1114"
+      test: "sh ./healthcheck.sh http://localhost:1114"
+      interval: 10s
+      timeout: 5s
+    depends_on:
+      - "mongodb"
+    stdin_open: true
+    tty: true
+
+  ks_nginx:
+    build: .
+    volumes:
+      - ./dev:/app
+    environment:
+      CONFIG: "/app/config/nginx-tls/Binary.toml"
+    healthcheck:
+      test: "sh ./healthcheck.sh http://localhost:1113"
       interval: 10s
       timeout: 5s
     depends_on:

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -4,6 +4,15 @@
 curl -f $1
 if [ 52 -eq $? ]; then
   exit 0
+elif [ 1 -eq $? ]; then
+  # Workaround for servers without TLS running
+  RESULT=$( (curl $1) 2>&1)
+  FOUND=$(echo $RESULT | grep "Received HTTP/0.9 when not allowed" | wc -l)
+  if [ 1 -eq $FOUND ]; then
+    exit 0
+  else
+    exit 1
+  fi;
 else
   exit 1
 fi;

--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -1,7 +1,6 @@
 //! Client object to interact with the key server.
 
 use crate::{config::Config, LockKeeperClientError, LockKeeperResponse, Result};
-use http::uri::Scheme;
 use http_body::combinators::UnsyncBoxBody;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
@@ -100,13 +99,9 @@ impl LockKeeperClient {
     pub(crate) async fn connect(
         config: &Config,
     ) -> Result<LockKeeperRpcClient<LockKeeperRpcClientInner>> {
-        if config.server_uri.scheme() != Some(&Scheme::HTTPS) {
-            return Err(LockKeeperClientError::HttpNotAllowed);
-        }
-
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_tls_config(config.tls_config.clone())
-            .https_only()
+            .https_or_http()
             .enable_http2()
             .build();
 

--- a/lock-keeper-client/src/error.rs
+++ b/lock-keeper-client/src/error.rs
@@ -8,8 +8,6 @@ pub type Result<T> = std::result::Result<T, LockKeeperClientError>;
 pub enum LockKeeperClientError {
     #[error("Health check failed: {0}")]
     HealthCheckFailed(String),
-    #[error("Tried to connect to a server without an https link")]
-    HttpNotAllowed,
     #[error("Server returned failure")]
     ServerReturnedFailure,
     #[error("This key server requires TLS client authentication.")]

--- a/lock-keeper-tests/Cargo.toml
+++ b/lock-keeper-tests/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+toml.workspace = true
 tonic.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true

--- a/lock-keeper-tests/src/config.rs
+++ b/lock-keeper-tests/src/config.rs
@@ -1,33 +1,77 @@
 //! Test config types
 
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
-use crate::{error::LockKeeperTestError, Cli};
-use lock_keeper_client::Config as ClientConfig;
+use lock_keeper_client::Config;
 
-#[derive(Debug, Clone)]
-pub struct Config {
-    pub client_config: ClientConfig,
-    pub client_config_path: PathBuf,
-    pub client_auth_client_config: ClientConfig,
-    pub client_auth_client_config_path: PathBuf,
+use crate::{error::LockKeeperTestError, utils, Cli};
+
+pub const STANDARD_CONFIG_NAME: &str = "standard";
+pub const CLIENT_AUTH_CONFIG_NAME: &str = "client_auth";
+pub const REQUIRED_CONFIGS: &[&str] = &[STANDARD_CONFIG_NAME, CLIENT_AUTH_CONFIG_NAME];
+
+/// Contains test configs for all environments defined in the test environment
+/// configuration file. This allows us to use specific configs for certain tests
+/// or to run certain tests in all environments.
+#[derive(Clone, Debug)]
+pub struct Environments {
+    pub configs: HashMap<String, Config>,
     pub filters: TestFilters,
 }
 
-impl TryFrom<Cli> for Config {
+impl TryFrom<Cli> for Environments {
     type Error = LockKeeperTestError;
 
     fn try_from(cli: Cli) -> Result<Self, Self::Error> {
-        let client_config = ClientConfig::from_file(&cli.client_config, None)?;
-        let client_auth_client_config =
-            ClientConfig::from_file(&cli.client_auth_client_config, None)?;
-        Ok(Self {
-            client_config,
-            client_config_path: cli.client_config.clone(),
-            client_auth_client_config,
-            client_auth_client_config_path: cli.client_auth_client_config.clone(),
-            filters: cli.filters.unwrap_or_default().into(),
-        })
+        let environments_string = std::fs::read_to_string(&cli.environments)?;
+        let environment_paths: HashMap<String, PathBuf> = toml::from_str(&environments_string)?;
+
+        let filters: TestFilters = cli.filters.unwrap_or_default().into();
+
+        let mut configs = HashMap::new();
+        for (name, path) in environment_paths {
+            let client_config = Config::from_file(path, None)?;
+            configs.insert(name, client_config);
+        }
+
+        for required_config in REQUIRED_CONFIGS {
+            if !configs.contains_key(*required_config) {
+                return Err(LockKeeperTestError::MissingRequiredConfig(
+                    required_config.to_string(),
+                ));
+            }
+        }
+
+        Ok(Self { configs, filters })
+    }
+}
+
+impl Environments {
+    pub async fn wait(&self) -> Result<(), LockKeeperTestError> {
+        for (name, config) in &self.configs {
+            println!("Waiting for environment: {name}");
+            if let Err(LockKeeperTestError::WaitForServerTimedOut) =
+                utils::wait_for_server(config).await
+            {
+                return Err(LockKeeperTestError::WaitForEnvironmentFailed(name.clone()));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn config(&self, environment_name: &str) -> Result<&Config, LockKeeperTestError> {
+        self.configs
+            .get(environment_name)
+            .ok_or_else(|| LockKeeperTestError::UndefinedEnvironment(environment_name.to_string()))
+    }
+
+    pub fn standard_config(&self) -> Result<&Config, LockKeeperTestError> {
+        self.config(STANDARD_CONFIG_NAME)
+    }
+
+    pub fn client_auth_config(&self) -> Result<&Config, LockKeeperTestError> {
+        self.config(CLIENT_AUTH_CONFIG_NAME)
     }
 }
 

--- a/lock-keeper-tests/src/error.rs
+++ b/lock-keeper-tests/src/error.rs
@@ -4,16 +4,24 @@ pub type Result<T> = std::result::Result<T, LockKeeperTestError>;
 
 #[derive(Debug, Error)]
 pub enum LockKeeperTestError {
+    #[error("Client config missing for required environment: \"{0}\". Check TestEnvironments.toml if you're using the default environment config.")]
+    MissingRequiredConfig(String),
     #[error("Invalid test type: {0}")]
     InvalidTestType(String),
     #[error("One or more test cases failed.")]
     TestFailed,
+    #[error("Undefined environment: {0}")]
+    UndefinedEnvironment(String),
+    #[error("Could not contact environment {0}")]
+    WaitForEnvironmentFailed(String),
     #[error("Failed to contact key server after maximum number of retries.")]
     WaitForServerTimedOut,
     #[error("Wrong error returned")]
     WrongErrorReturned,
 
     // Wrapped Errors
+    #[error(transparent)]
+    Clap(#[from] clap::Error),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error("LockKeeperError: {0:?}")]
@@ -28,4 +36,6 @@ pub enum LockKeeperTestError {
     MongoDb(#[from] mongodb::error::Error),
     #[error("RandError: {0:?}")]
     Rand(#[from] rand::Error),
+    #[error(transparent)]
+    Toml(#[from] toml::de::Error),
 }

--- a/lock-keeper-tests/src/main.rs
+++ b/lock-keeper-tests/src/main.rs
@@ -3,18 +3,19 @@ pub mod error;
 pub mod test_suites;
 pub mod utils;
 
-use crate::{error::LockKeeperTestError, utils::TestResult};
+use crate::{
+    error::LockKeeperTestError,
+    utils::{report_test_results, TestResult},
+};
 use clap::Parser;
 use colored::Colorize;
-use config::Config;
+use config::Environments;
 use std::{path::PathBuf, str::FromStr};
 
 #[derive(Debug, Parser)]
 pub struct Cli {
-    #[clap(default_value = "./dev/config/local/Client.toml")]
-    pub client_config: PathBuf,
-    #[clap(default_value = "./dev/config/local-client-auth/Client.toml")]
-    pub client_auth_client_config: PathBuf,
+    #[clap(long, default_value = "./dev/config/TestEnvironments.toml")]
+    pub environments: PathBuf,
     #[clap(long = "filter")]
     pub filters: Option<Vec<String>>,
     #[clap(long, default_value = "all")]
@@ -43,35 +44,46 @@ impl FromStr for TestType {
 
 #[tokio::main]
 pub async fn main() {
-    let cli = Cli::parse();
-    let test_type = cli.test_type;
-    let config = Config::try_from(cli).unwrap();
-    utils::wait_for_server(&config.client_config).await.unwrap();
+    // Run tests and print nice errors if any occur.
+    if let Err(e) = run().await {
+        eprintln!("{}", e.to_string().red());
+        std::process::exit(1);
+    }
+}
 
-    match run_tests(test_type, config).await {
+async fn run() -> Result<(), LockKeeperTestError> {
+    let cli = Cli::try_parse()?;
+    let test_type = cli.test_type;
+    let environments = Environments::try_from(cli)?;
+
+    environments.wait().await?;
+
+    match run_tests(test_type, environments).await {
         Err(e @ LockKeeperTestError::TestFailed) => {
             // Manually report error to avoid a useless stack trace
             eprintln!("{}", e.to_string().red());
             std::process::exit(1);
         }
         Err(e) => panic!("{e}"),
-        Ok(()) => (),
+        _ => (),
     }
+
+    Ok(())
 }
 
-async fn run_tests(test_type: TestType, config: Config) -> Result<(), LockKeeperTestError> {
+async fn run_tests(
+    test_type: TestType,
+    environments: Environments,
+) -> Result<(), LockKeeperTestError> {
     let results = match test_type {
-        TestType::All => test_suites::run_all(&config).await?,
-        TestType::E2E => test_suites::end_to_end::run_tests(&config).await?,
-        TestType::Integration => {
-            let mut results = Vec::new();
+        TestType::All => {
+            let integration_results = run_integration_tests(&environments).await?;
+            let e2e_results = test_suites::end_to_end::run_tests(&environments).await?;
 
-            results.extend(test_suites::config_files::run_tests(&config).await?);
-            results.extend(test_suites::database::run_tests(&config).await?);
-            results.extend(test_suites::client_auth::run_tests(&config).await?);
-
-            results
+            [integration_results, e2e_results].concat()
         }
+        TestType::E2E => test_suites::end_to_end::run_tests(&environments).await?,
+        TestType::Integration => run_integration_tests(&environments).await?,
     };
 
     if results.iter().any(|r| *r == TestResult::Failed) {
@@ -79,4 +91,24 @@ async fn run_tests(test_type: TestType, config: Config) -> Result<(), LockKeeper
     } else {
         Ok(())
     }
+}
+
+async fn run_integration_tests(
+    environments: &Environments,
+) -> Result<Vec<TestResult>, LockKeeperTestError> {
+    let config_file_results = test_suites::config_files::run_tests(&environments.filters).await?;
+    let database_results = test_suites::database::run_tests(&environments.filters).await?;
+    let client_auth_results = test_suites::client_auth::run_tests(environments).await?;
+
+    println!(
+        "config file tests: {}",
+        report_test_results(&config_file_results)
+    );
+    println!("database tests: {}", report_test_results(&database_results));
+    println!(
+        "client auth tests: {}",
+        report_test_results(&client_auth_results)
+    );
+
+    Ok([config_file_results, database_results, client_auth_results].concat())
 }

--- a/lock-keeper-tests/src/test_suites.rs
+++ b/lock-keeper-tests/src/test_suites.rs
@@ -1,39 +1,4 @@
-use crate::{
-    config::Config,
-    error::Result,
-    utils::{report_test_results, TestResult},
-};
-
 pub mod client_auth;
 pub mod config_files;
 pub mod database;
 pub mod end_to_end;
-
-pub async fn run_all(config: &Config) -> Result<Vec<TestResult>> {
-    let config_file_results = config_files::run_tests(config).await?;
-    let database_results = database::run_tests(config).await?;
-    let end_to_end_results = end_to_end::run_tests(config).await?;
-    let client_auth_results = client_auth::run_tests(config).await?;
-
-    println!(
-        "config file tests: {}",
-        report_test_results(&config_file_results)
-    );
-    println!("database tests: {}", report_test_results(&database_results));
-    println!(
-        "end to end tests: {}",
-        report_test_results(&end_to_end_results)
-    );
-    println!(
-        "client auth tests: {}",
-        report_test_results(&client_auth_results)
-    );
-
-    Ok([
-        config_file_results,
-        database_results,
-        end_to_end_results,
-        client_auth_results,
-    ]
-    .concat())
-}

--- a/lock-keeper-tests/src/test_suites/config_files.rs
+++ b/lock-keeper-tests/src/test_suites/config_files.rs
@@ -8,19 +8,19 @@ use lock_keeper_client::LockKeeperClientError;
 use lock_keeper_key_server::LockKeeperServerError;
 
 use crate::{
-    config::Config,
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::database::TestDatabase,
     utils::{report_test_results, TestResult},
 };
 
-pub async fn run_tests(config: &Config) -> Result<Vec<TestResult>> {
+pub async fn run_tests(filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running config file tests".cyan());
 
     let db = TestDatabase::new("config_file_tests").await?;
     let results = run_parallel!(
-        config.clone(),
+        filters,
         client_config_with_file_private_key_works(),
         client_config_with_manual_private_key_works(),
         client_config_without_private_key_fails(),

--- a/lock-keeper-tests/src/test_suites/database.rs
+++ b/lock-keeper-tests/src/test_suites/database.rs
@@ -8,9 +8,9 @@ use generic_array::{typenum::U64, GenericArray};
 use std::{ops::Deref, str::FromStr};
 
 use crate::{
+    config::TestFilters,
     error::Result,
     utils::{report_test_results, TestResult},
-    Config,
 };
 use lock_keeper::{
     crypto::{Encrypted, MasterKey, StorageKey},
@@ -24,12 +24,12 @@ use crate::utils::{server_registration, tagged};
 
 pub const USERS_TABLE: &str = "users";
 
-pub async fn run_tests(config: &Config) -> Result<Vec<TestResult>> {
+pub async fn run_tests(filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("Running database tests");
 
-    let audit_event_results = audit_event::run_tests(config.clone()).await?;
-    let user_results = user::run_tests(config.clone()).await?;
-    let secret_results = secret::run_tests(config.clone()).await?;
+    let audit_event_results = audit_event::run_tests(filters).await?;
+    let user_results = user::run_tests(filters).await?;
+    let secret_results = secret::run_tests(filters).await?;
 
     // Report results after all tests finish so results show up together
     println!(

--- a/lock-keeper-tests/src/test_suites/database/audit_event.rs
+++ b/lock-keeper-tests/src/test_suites/database/audit_event.rs
@@ -19,16 +19,16 @@ use rand::{
 };
 use strum::IntoEnumIterator;
 
-use crate::{error::Result, run_parallel, utils::TestResult, Config};
+use crate::{config::TestFilters, error::Result, run_parallel, utils::TestResult};
 
 use super::TestDatabase;
 
-pub async fn run_tests(config: Config) -> Result<Vec<TestResult>> {
+pub async fn run_tests(filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running audit event tests".cyan());
 
     let db = TestDatabase::new("audit_event_tests").await?;
     let result = run_parallel!(
-        config.clone(),
+        filters,
         event_type_filter_works(db.clone()),
         key_id_filter_works(db.clone()),
         after_date_filter_works(db.clone()),

--- a/lock-keeper-tests/src/test_suites/database/secret.rs
+++ b/lock-keeper-tests/src/test_suites/database/secret.rs
@@ -9,16 +9,16 @@ use lock_keeper_key_server::database::DataStore;
 use lock_keeper_mongodb::Database;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use crate::{error::Result, run_parallel, utils::TestResult, Config};
+use crate::{config::TestFilters, error::Result, run_parallel, utils::TestResult};
 
 use super::TestDatabase;
 
-pub async fn run_tests(config: Config) -> Result<Vec<TestResult>> {
+pub async fn run_tests(filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running secret tests".cyan());
 
     let db = TestDatabase::new("secret_tests").await?;
     let result = run_parallel!(
-        config.clone(),
+        filters,
         user_is_serializable_after_adding_secrets(db.clone()),
         cannot_get_another_users_secrets(db.clone()),
     )?;

--- a/lock-keeper-tests/src/test_suites/database/user.rs
+++ b/lock-keeper-tests/src/test_suites/database/user.rs
@@ -9,21 +9,21 @@ use lock_keeper_mongodb::error::Error;
 use rand::{rngs::StdRng, SeedableRng};
 
 use crate::{
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::database::USERS_TABLE,
     utils::{server_registration, tagged, TestResult},
-    Config,
 };
 
 use super::TestDatabase;
 
-pub async fn run_tests(config: Config) -> Result<Vec<TestResult>> {
+pub async fn run_tests(filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running user tests".cyan());
 
     let db = TestDatabase::new("user_tests").await?;
     let result = run_parallel!(
-        config.clone(),
+        filters,
         user_findable_by_account_name(db.clone()),
         user_findable_by_id(db.clone()),
         multiple_connections_do_not_overwrite_db(),

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
@@ -18,13 +18,13 @@ pub(crate) struct TestState {
     pub(crate) config: Config,
 }
 
-pub(crate) async fn init_test_state(config: Config) -> Result<TestState, LockKeeperClientError> {
+pub(crate) async fn init_test_state(config: &Config) -> Result<TestState, LockKeeperClientError> {
     let account_name = AccountName::from_str(tagged("user").as_str())?;
     let password = Password::from_str(tagged("password").as_str())?;
-    LockKeeperClient::register(&account_name, &password, &config).await?;
+    LockKeeperClient::register(&account_name, &password, config).await?;
     Ok(TestState {
         account_name,
         password,
-        config,
+        config: config.clone(),
     })
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/export.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/export.rs
@@ -7,6 +7,7 @@ use lock_keeper_client::{api::GenerateResult, Config};
 use tonic::Status;
 
 use crate::{
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
@@ -17,29 +18,28 @@ use crate::{
         test_cases::init_test_state,
     },
     utils::TestResult,
-    Config as TestConfig,
 };
 
-pub async fn run_tests(config: TestConfig) -> Result<Vec<TestResult>> {
+pub async fn run_tests(config: &Config, filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running export tests".cyan());
 
     let result = run_parallel!(
-        config.clone(),
-        export_works(config.client_config.clone()),
-        cannot_export_fake_key(config.client_config.clone()),
-        cannot_export_signing_key_as_secret(config.client_config.clone()),
-        cannot_export_after_logout(config.client_config.clone()),
-        export_signing_key_works(config.client_config.clone()),
-        cannot_export_fake_signing_key(config.client_config.clone()),
-        cannot_export_secret_as_signing_key(config.client_config.clone()),
-        cannot_export_signing_key_after_logout(config.client_config.clone()),
+        filters,
+        export_works(config.clone()),
+        cannot_export_fake_key(config.clone()),
+        cannot_export_signing_key_as_secret(config.clone()),
+        cannot_export_after_logout(config.clone()),
+        export_signing_key_works(config.clone()),
+        cannot_export_fake_signing_key(config.clone()),
+        cannot_export_secret_as_signing_key(config.clone()),
+        cannot_export_signing_key_after_logout(config.clone()),
     )?;
 
     Ok(result)
 }
 
 async fn export_works(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let GenerateResult {
@@ -58,7 +58,7 @@ async fn export_works(config: Config) -> Result<()> {
 }
 
 async fn cannot_export_fake_key(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let fake_key_id = generate_fake_key_id(&client).await?;
@@ -70,7 +70,7 @@ async fn cannot_export_fake_key(config: Config) -> Result<()> {
 }
 
 async fn cannot_export_signing_key_as_secret(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let (key_id, _) = import_signing_key(&client).await?.into_inner();
@@ -82,7 +82,7 @@ async fn cannot_export_signing_key_as_secret(config: Config) -> Result<()> {
 }
 
 async fn cannot_export_after_logout(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let GenerateResult {
@@ -98,7 +98,7 @@ async fn cannot_export_after_logout(config: Config) -> Result<()> {
 }
 
 async fn export_signing_key_works(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let (key_id, bytes_original) = import_signing_key(&client).await?.into_inner();
@@ -122,7 +122,7 @@ async fn export_signing_key_works(config: Config) -> Result<()> {
 }
 
 async fn cannot_export_fake_signing_key(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let fake_key_id = generate_fake_key_id(&client).await?;
@@ -134,7 +134,7 @@ async fn cannot_export_fake_signing_key(config: Config) -> Result<()> {
 }
 
 async fn cannot_export_secret_as_signing_key(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let GenerateResult {
@@ -149,7 +149,7 @@ async fn cannot_export_secret_as_signing_key(config: Config) -> Result<()> {
 }
 
 async fn cannot_export_signing_key_after_logout(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let (key_id, _) = import_signing_key(&client).await?.into_inner();

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
@@ -4,6 +4,7 @@ use lock_keeper_client::Config;
 use tonic::Status;
 
 use crate::{
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
@@ -11,23 +12,22 @@ use crate::{
         test_cases::init_test_state,
     },
     utils::TestResult,
-    Config as TestConfig,
 };
 
-pub async fn run_tests(config: TestConfig) -> Result<Vec<TestResult>> {
+pub async fn run_tests(config: &Config, filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running generate tests".cyan());
 
     let result = run_parallel!(
-        config.clone(),
-        generate_works(config.client_config.clone()),
-        cannot_generate_after_logout(config.client_config.clone())
+        filters,
+        generate_works(config.clone()),
+        cannot_generate_after_logout(config.clone())
     )?;
 
     Ok(result)
 }
 
 async fn generate_works(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let _ = client.generate_secret().await?;
@@ -42,7 +42,7 @@ async fn generate_works(config: Config) -> Result<()> {
 }
 
 async fn cannot_generate_after_logout(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     client.logout().await?;

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
@@ -4,6 +4,7 @@ use lock_keeper_client::Config;
 use tonic::Status;
 
 use crate::{
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
@@ -11,23 +12,22 @@ use crate::{
         test_cases::init_test_state,
     },
     utils::TestResult,
-    Config as TestConfig,
 };
 
-pub async fn run_tests(config: TestConfig) -> Result<Vec<TestResult>> {
+pub async fn run_tests(config: &Config, filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running import tests".cyan());
 
     let result = run_parallel!(
-        config.clone(),
-        import_works(config.client_config.clone()),
-        cannot_import_after_logout(config.client_config.clone())
+        filters,
+        import_works(config.clone()),
+        cannot_import_after_logout(config.clone())
     )?;
 
     Ok(result)
 }
 
 async fn import_works(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let import_res = import_signing_key(&client).await;
@@ -43,7 +43,7 @@ async fn import_works(config: Config) -> Result<()> {
 }
 
 async fn cannot_import_after_logout(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     client.logout().await?;

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/register.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/register.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use tonic::Status;
 
 use crate::{
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
@@ -14,16 +15,12 @@ use crate::{
         test_cases::TestState,
     },
     utils::{tagged, TestResult},
-    Config as TestConfig,
 };
 
-pub async fn run_tests(config: TestConfig) -> Result<Vec<TestResult>> {
+pub async fn run_tests(config: &Config, filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running register tests".cyan());
 
-    let result = run_parallel!(
-        config.clone(),
-        register_same_user_twice_fails(config.client_config.clone()),
-    )?;
+    let result = run_parallel!(filters, register_same_user_twice_fails(config.clone()),)?;
 
     Ok(result)
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
@@ -4,6 +4,7 @@ use lock_keeper_client::Config;
 use tonic::Status;
 
 use crate::{
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
@@ -11,23 +12,22 @@ use crate::{
         test_cases::init_test_state,
     },
     utils::TestResult,
-    Config as TestConfig,
 };
 
-pub async fn run_tests(config: TestConfig) -> Result<Vec<TestResult>> {
+pub async fn run_tests(config: &Config, filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running remote generate tests".cyan());
 
     let result = run_parallel!(
-        config.clone(),
-        remote_generate_works(config.client_config.clone()),
-        cannot_remote_generate_after_logout(config.client_config.clone()),
+        filters,
+        remote_generate_works(config.clone()),
+        cannot_remote_generate_after_logout(config.clone()),
     )?;
 
     Ok(result)
 }
 
 async fn remote_generate_works(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let remote_gen_res = client.remote_generate().await;
@@ -44,7 +44,7 @@ async fn remote_generate_works(config: Config) -> Result<()> {
 }
 
 async fn cannot_remote_generate_after_logout(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     client.logout().await?;

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
@@ -7,6 +7,7 @@ use lock_keeper_client::{api::GenerateResult, Config};
 use tonic::Status;
 
 use crate::{
+    config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
@@ -17,25 +18,24 @@ use crate::{
         test_cases::init_test_state,
     },
     utils::TestResult,
-    Config as TestConfig,
 };
 
-pub async fn run_tests(config: TestConfig) -> Result<Vec<TestResult>> {
+pub async fn run_tests(config: &Config, filters: &TestFilters) -> Result<Vec<TestResult>> {
     println!("{}", "Running retrieve tests".cyan());
 
     let result = run_parallel!(
-        config.clone(),
-        retrieve_local_only_works(config.client_config.clone()),
-        retrieve_null_works(config.client_config.clone()),
-        cannot_retrieve_fake_key(config.client_config.clone()),
-        cannot_retrieve_after_logout(config.client_config.clone()),
+        filters,
+        retrieve_local_only_works(config.clone()),
+        retrieve_null_works(config.clone()),
+        cannot_retrieve_fake_key(config.clone()),
+        cannot_retrieve_after_logout(config.clone()),
     )?;
 
     Ok(result)
 }
 
 async fn retrieve_local_only_works(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let GenerateResult {
@@ -63,7 +63,7 @@ async fn retrieve_local_only_works(config: Config) -> Result<()> {
 }
 
 async fn retrieve_null_works(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let GenerateResult {
@@ -86,7 +86,7 @@ async fn retrieve_null_works(config: Config) -> Result<()> {
 }
 
 async fn cannot_retrieve_fake_key(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     let fake_key_id = generate_fake_key_id(&client).await?;
@@ -100,7 +100,7 @@ async fn cannot_retrieve_fake_key(config: Config) -> Result<()> {
 }
 
 async fn cannot_retrieve_after_logout(config: Config) -> Result<()> {
-    let state = init_test_state(config).await?;
+    let state = init_test_state(&config).await?;
     let client = authenticate(&state).await?;
 
     // Generate a secret before waiting out the timeout


### PR DESCRIPTION
This PR adds TLS termination via `nginx` and creates a new environment where this setup can be tested.

In order to make testing easier, I introduced an `Environments` type to `lock-keeper-tests`. This type expands the `client_config` and `mutual_auth_config` fields that were in `lock_keeper_tests::Config` into a mapping from environment name to client config. This allows us to run end-to-end tests across all of our different environments, as well as being able to pull out configs for specific environments for tests that require them.

`client_config` is given the name `standard`. `mutual_auth_config` was given the name `client_auth` (see #410). These two configs are required to be in the environment definition file. The test binary will return an error if one of them is missing.

Other changes:
- root CA cert is now generated using `sha256` instead of `sha1`.
- `key_server_mutual_auth` was renamed `ks_client_auth` in docker compose.
- `http` urls are now allowed in the client. Previously, only `https` urls were allowed.
- `lock-keeper-tests` now prints error messages instead of panicking.
- `lock-keeper-tests::Config` was removed.
- The `run_parallel!` macro now takes a `&TestFilters` instead of a `lock-keeper-tests::Config`.


Closes #348