### PR TITLE
Add a healthcheck script to docker compose #398

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,17 @@ services:
 
   key_server:
     build: .
+    restart: always
     volumes:
       - ./dev:/app
     environment:
       CONFIG: "/app/config/docker/Binary.toml"
     ports:
       - 1113:1113
+    healthcheck:
+      test: "chmod +x healthcheck.sh && ./healthcheck.sh http://localhost:1113"
+      interval: 10s
+      timeout: 5s
     depends_on:
       - "mongodb"
     stdin_open: true
@@ -25,6 +30,7 @@ services:
 
   key_server_mutual_auth:
     build: .
+    restart: always
     volumes:
       - ./dev:/app
     # The main difference for this service is the config file.
@@ -34,6 +40,10 @@ services:
       CONFIG: "/app/config/docker-mutual-auth/Binary.toml"
     ports:
       - 1114:1114
+    healthcheck:
+      test: "chmod +x healthcheck.sh && ./healthcheck.sh http://localhost:1114"
+      interval: 10s
+      timeout: 5s
     depends_on:
       - "mongodb"
     stdin_open: true

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,9 @@
+# Accept the 52 error code as valid because the grpc
+# server can't respond to curl requests. If the server
+# was not running, we would receive a different error code.
+curl -f $1
+if [ 52 -eq $? ]; then
+  exit 0
+else
+  exit 1
+fi;


### PR DESCRIPTION
Closes #398 

@picklenerd I added `restart: always` like you mentioned! I did want to note that it takes ~12s to claim a container is healthy but only ~2.5s to claim it's unhealthy which feels odd to me.