### PR TITLE
Add request ID to audit event and client response #411

### DIFF
--- a/bin/lock-keeper-client-cli/src/cli_command/authenticate.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/authenticate.rs
@@ -16,7 +16,8 @@ pub struct Authenticate {
 impl CliCommand for Authenticate {
     async fn execute(self: Box<Self>, state: &mut State) -> Result<(), anyhow::Error> {
         LockKeeperClient::authenticated_client(&self.account_name, &self.password, &state.config)
-            .await?;
+            .await
+            .result?;
 
         println!("Logged in to {}", self.account_name);
         state.credentials = Some(Credentials {

--- a/bin/lock-keeper-client-cli/src/cli_command/export.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/export.rs
@@ -26,8 +26,8 @@ impl CliCommand for Export {
             &credentials.password,
             &state.config,
         )
-        .await?
-        .into_inner();
+        .await
+        .result?;
 
         // Get key_id from storage
         let entry = state.get_key_id(&self.name)?;
@@ -35,8 +35,8 @@ impl CliCommand for Export {
         let export = lock_keeper_client
             .export_signing_key(&entry.key_id)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to export signing key. Error: {:?}", e))?
-            .into_inner();
+            .result
+            .map_err(|e| anyhow::anyhow!("Failed to export signing key. Error: {:?}", e))?;
 
         println!("Retrieved: {}", self.name);
         println!("{:?}", export);

--- a/bin/lock-keeper-client-cli/src/cli_command/generate.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/generate.rs
@@ -31,11 +31,11 @@ impl CliCommand for Generate {
             &credentials.password,
             &state.config,
         )
-        .await?
-        .into_inner();
+        .await
+        .result?;
 
         // If successful, proceed to generate a secret with the established session
-        let generate_result = lock_keeper_client.generate_secret().await?.into_inner();
+        let generate_result = lock_keeper_client.generate_secret().await.result?;
 
         // Store Key
         let stored = state.store_entry(self.name, generate_result)?;

--- a/bin/lock-keeper-client-cli/src/cli_command/import.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/import.rs
@@ -21,16 +21,16 @@ impl CliCommand for Import {
             &credentials.password,
             &state.config,
         )
-        .await?
-        .into_inner();
+        .await
+        .result?;
 
         let random_bytes = rand::thread_rng().gen::<[u8; 32]>().to_vec();
         let import = LkImport::new(random_bytes)?;
         let key_id = lock_keeper_client
             .import_signing_key(import)
             .await
-            .map_err(|e| anyhow::anyhow!("Failed to import signing key. Error: {:?}", e))?
-            .into_inner();
+            .result
+            .map_err(|e| anyhow::anyhow!("Failed to import signing key. Error: {:?}", e))?;
 
         let stored = state.store_entry(self.name, key_id)?;
         println!("Stored: {stored}");

--- a/bin/lock-keeper-client-cli/src/cli_command/register.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/register.rs
@@ -15,7 +15,9 @@ pub struct Register {
 #[async_trait]
 impl CliCommand for Register {
     async fn execute(self: Box<Self>, state: &mut State) -> Result<(), anyhow::Error> {
-        LockKeeperClient::register(&self.account_name, &self.password, &state.config).await?;
+        LockKeeperClient::register(&self.account_name, &self.password, &state.config)
+            .await
+            .result?;
 
         println!("Logged in to {}", self.account_name);
         state.credentials = Some(Credentials {

--- a/bin/lock-keeper-client-cli/src/cli_command/remote_generate.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/remote_generate.rs
@@ -19,15 +19,11 @@ impl CliCommand for RemoteGenerate {
             &credentials.password,
             &state.config,
         )
-        .await?
-        .into_inner();
+        .await
+        .result?;
 
         // If successful, proceed to generate a secret with the established session
-        let key_id = lock_keeper_client
-            .remote_generate()
-            .await?
-            .into_inner()
-            .key_id;
+        let key_id = lock_keeper_client.remote_generate().await.result?.key_id;
 
         // Store Key Id
         let stored = state.store_entry(self.name, key_id)?;

--- a/bin/lock-keeper-client-cli/src/cli_command/remote_sign.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/remote_sign.rs
@@ -23,16 +23,16 @@ impl CliCommand for RemoteSign {
             &credentials.password,
             &state.config,
         )
-        .await?
-        .into_inner();
+        .await
+        .result?;
 
         let bytes = SignableBytes(self.data.into_bytes());
 
         // If successful, proceed to generate a secret with the established session
         let signature = lock_keeper_client
             .remote_sign_bytes(entry.key_id.clone(), bytes)
-            .await?
-            .into_inner();
+            .await
+            .result?;
 
         println!("Signature: {}", hex::encode(signature));
         Ok(())

--- a/bin/lock-keeper-client-cli/src/cli_command/retrieve.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/retrieve.rs
@@ -20,15 +20,15 @@ impl CliCommand for Retrieve {
             &credentials.password,
             &state.config,
         )
-        .await?
-        .into_inner();
+        .await
+        .result?;
 
         let entry = state.get_key_id(&self.name)?;
         // Retrieve results for specified key.
         let retrieve_result = lock_keeper_client
             .retrieve_secret(&entry.key_id, RetrieveContext::LocalOnly)
-            .await?
-            .into_inner();
+            .await
+            .result?;
 
         println!("Retrieved: {}", self.name);
         println!("{retrieve_result:?}");

--- a/lock-keeper-client/Cargo.toml
+++ b/lock-keeper-client/Cargo.toml
@@ -37,4 +37,5 @@ tonic.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 zeroize.workspace = true

--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -17,7 +17,8 @@ mod retrieve;
 mod retrieve_audit_events;
 
 use crate::{
-    client::Password, config::Config, LockKeeperClient, LockKeeperClientError, LockKeeperResponse,
+    client::Password, config::Config, response::Metadata, LockKeeperClient, LockKeeperClientError,
+    LockKeeperResponse,
 };
 use lock_keeper::{
     crypto::{Export, Import, KeyId, Secret, Signable, Signature},
@@ -31,7 +32,7 @@ use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::error;
+use uuid::Uuid;
 
 pub use self::{
     generate_secret::GenerateResult, remote_generate_signing_key::RemoteGenerateResult,
@@ -64,18 +65,13 @@ impl LockKeeperClient {
     }
 
     /// Expire the current session and session key for this user.
-    pub async fn logout(&self) -> Result<LockKeeperResponse<()>, LockKeeperClientError> {
+    pub async fn logout(&self) -> LockKeeperResponse<()> {
         // Create channel to send messages to server
-        let metadata = self.create_metadata(ClientAction::Logout);
-        let client_channel = Self::create_authenticated_channel(
-            &mut self.tonic_client(),
-            &metadata,
-            self.session_key().clone(),
-            self.rng.clone(),
-        )
-        .await?;
-
-        self.handle_logout(client_channel).await
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self.handle_logout(request_id).await,
+            metadata: Some(Metadata { request_id }),
+        }
     }
 
     /// Authenticate to the Lock Keeper key server as a previously registered
@@ -86,9 +82,12 @@ impl LockKeeperClient {
         account_name: &AccountName,
         password: &Password,
         config: &Config,
-    ) -> Result<LockKeeperResponse<Self>, LockKeeperClientError> {
-        let rpc_client = Self::connect(config).await?;
-        Self::authenticate(rpc_client, account_name, password, config).await
+    ) -> LockKeeperResponse<Self> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: Self::authenticate(None, account_name, password, config, request_id).await,
+            metadata: Some(Metadata { request_id }),
+        }
     }
 
     /// Register a new user who has not yet interacted with the service.
@@ -102,65 +101,68 @@ impl LockKeeperClient {
         account_name: &AccountName,
         password: &Password,
         config: &Config,
-    ) -> Result<LockKeeperResponse<()>, LockKeeperClientError> {
+    ) -> LockKeeperResponse<()> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: Self::register_helper(account_name, password, config, request_id).await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn register_helper(
+        account_name: &AccountName,
+        password: &Password,
+        config: &Config,
+        request_id: Uuid,
+    ) -> Result<(), LockKeeperClientError> {
         let rng = StdRng::from_entropy();
         let mut client = Self::connect(config).await?;
-        let metadata = RequestMetadata::new(account_name, ClientAction::Register, None, None);
+        let metadata =
+            RequestMetadata::new(account_name, ClientAction::Register, None, None, request_id);
         let rng_arc_mutex = Arc::new(Mutex::new(rng));
         let client_channel = Self::create_channel(&mut client, &metadata).await?;
-        let result = Self::handle_registration(
+        let master_key = Self::handle_registration(
             client_channel,
             rng_arc_mutex.clone(),
             account_name,
             password,
         )
-        .await;
-        match result {
-            Ok(master_key) => {
-                let LockKeeperResponse {
-                    data: client,
-                    metadata: response_metadata,
-                } = Self::authenticate(client, account_name, password, config).await?;
+        .await?;
+        let client =
+            Self::authenticate(Some(client), account_name, password, config, request_id).await?;
+        // After authenticating we can create the storage key
+        let request_metadata = client.create_metadata(ClientAction::CreateStorageKey, request_id);
+        let client_channel = LockKeeperClient::create_authenticated_channel(
+            &mut client.tonic_client(),
+            &request_metadata,
+            client.session_key().clone(),
+            rng_arc_mutex.clone(),
+        )
+        .await?;
+        Self::handle_create_storage_key(client_channel, rng_arc_mutex, account_name, master_key)
+            .await?;
 
-                // After authenticating we can create the storage key
-                let request_metadata = client.create_metadata(ClientAction::CreateStorageKey);
-                let client_channel = LockKeeperClient::create_authenticated_channel(
-                    &mut client.tonic_client(),
-                    &request_metadata,
-                    client.session_key().clone(),
-                    rng_arc_mutex.clone(),
-                )
-                .await?;
-                Self::handle_create_storage_key(
-                    client_channel,
-                    rng_arc_mutex,
-                    account_name,
-                    master_key,
-                )
-                .await?;
-
-                Ok(LockKeeperResponse {
-                    data: (),
-                    metadata: response_metadata,
-                })
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(e)
-            }
-        }
+        Ok(())
     }
 
     /// Export an arbitrary key from the key servers.
     ///
     /// Calling this function on a signing key will generate an error.
     /// Output: If successful, returns the requested key material in byte form.
-    pub async fn export_secret(
+    pub async fn export_secret(&self, key_id: &KeyId) -> LockKeeperResponse<Export> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self.export_secret_helper(key_id, request_id).await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn export_secret_helper(
         &self,
         key_id: &KeyId,
-    ) -> Result<LockKeeperResponse<Export>, LockKeeperClientError> {
-        // Create channel: this will internally be a `retrieve` channel
-        let metadata = self.create_metadata(ClientAction::ExportSecret);
+        request_id: Uuid,
+    ) -> Result<Export, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::ExportSecret, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,
@@ -169,29 +171,37 @@ impl LockKeeperClient {
         )
         .await?;
         // Get local-only secret
-        let LockKeeperResponse { data, metadata } = self
-            .handle_retrieve_secret(client_channel, key_id, RetrieveContext::LocalOnly)
-            .await?;
+        let local_storage = self
+            .handle_retrieve_secret(
+                client_channel,
+                key_id,
+                RetrieveContext::LocalOnly,
+                request_id,
+            )
+            .await?
+            .ok_or(LockKeeperClientError::ExportFailed)?;
 
-        let local_storage = data.ok_or(LockKeeperClientError::ExportFailed)?;
-        let exported_secret = Export::from(local_storage.material);
-
-        Ok(LockKeeperResponse {
-            data: exported_secret,
-            metadata,
-        })
+        Ok(Export::from(local_storage.material))
     }
 
     /// Export signing key pair material from the key servers.
     ///
     /// Calling this function on an arbitrary key will generated an error.
     /// Output: If successful, returns the requested key material in byte form.
-    pub async fn export_signing_key(
+    pub async fn export_signing_key(&self, key_id: &KeyId) -> LockKeeperResponse<Export> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self.export_signing_key_helper(key_id, request_id).await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn export_signing_key_helper(
         &self,
         key_id: &KeyId,
-    ) -> Result<LockKeeperResponse<Export>, LockKeeperClientError> {
-        // Create channel: this will internally be a `retrieve` channel
-        let metadata = self.create_metadata(ClientAction::ExportSigningKey);
+        request_id: Uuid,
+    ) -> Result<Export, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::ExportSigningKey, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,
@@ -200,25 +210,29 @@ impl LockKeeperClient {
         )
         .await?;
         // Get local-only secret
-        let LockKeeperResponse { data, metadata } = self
+        let local_storage = self
             .handle_retrieve_signing_key(client_channel, key_id, RetrieveContext::LocalOnly)
-            .await?;
+            .await?
+            .ok_or(LockKeeperClientError::ExportFailed)?;
 
-        let local_storage = data.ok_or(LockKeeperClientError::ExportFailed)?;
-        let exported_signing_key = Export::from(local_storage.material);
-
-        Ok(LockKeeperResponse {
-            data: exported_signing_key,
-            metadata,
-        })
+        Ok(Export::from(local_storage.material))
     }
 
     /// Generate an arbitrary secret client-side, store this secret in the key
     /// server.
-    pub async fn generate_secret(
+    pub async fn generate_secret(&self) -> LockKeeperResponse<GenerateResult> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self.generate_secret_helper(request_id).await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn generate_secret_helper(
         &self,
-    ) -> Result<LockKeeperResponse<GenerateResult>, LockKeeperClientError> {
-        let metadata = self.create_metadata(ClientAction::GenerateSecret);
+        request_id: Uuid,
+    ) -> Result<GenerateResult, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::GenerateSecret, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,
@@ -227,15 +241,27 @@ impl LockKeeperClient {
         )
         .await?;
 
-        self.handle_generate_secret(client_channel).await
+        self.handle_generate_secret(client_channel, request_id)
+            .await
     }
 
     /// Import signing key material to the key server
-    pub async fn import_signing_key(
+    pub async fn import_signing_key(&self, key_material: Import) -> LockKeeperResponse<KeyId> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self
+                .import_signing_key_helper(key_material, request_id)
+                .await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn import_signing_key_helper(
         &self,
         key_material: Import,
-    ) -> Result<LockKeeperResponse<KeyId>, LockKeeperClientError> {
-        let metadata = self.create_metadata(ClientAction::ImportSigningKey);
+        request_id: Uuid,
+    ) -> Result<KeyId, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::ImportSigningKey, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,
@@ -254,8 +280,23 @@ impl LockKeeperClient {
         &self,
         key_id: &KeyId,
         context: RetrieveContext,
-    ) -> Result<LockKeeperResponse<Option<LocalStorage<Secret>>>, LockKeeperClientError> {
-        let metadata = self.create_metadata(ClientAction::RetrieveSecret);
+    ) -> LockKeeperResponse<Option<LocalStorage<Secret>>> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self
+                .retrieve_secret_helper(key_id, context, request_id)
+                .await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn retrieve_secret_helper(
+        &self,
+        key_id: &KeyId,
+        context: RetrieveContext,
+        request_id: Uuid,
+    ) -> Result<Option<LocalStorage<Secret>>, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::RetrieveSecret, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,
@@ -264,15 +305,24 @@ impl LockKeeperClient {
         )
         .await?;
 
-        self.handle_retrieve_secret(client_channel, key_id, context)
+        self.handle_retrieve_secret(client_channel, key_id, context, request_id)
             .await
     }
 
     /// Request that the server generate a new signing key.
-    pub async fn remote_generate(
+    pub async fn remote_generate(&self) -> LockKeeperResponse<RemoteGenerateResult> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self.remote_generate_helper(request_id).await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn remote_generate_helper(
         &self,
-    ) -> Result<LockKeeperResponse<RemoteGenerateResult>, LockKeeperClientError> {
-        let metadata = self.create_metadata(ClientAction::RemoteGenerateSigningKey);
+        request_id: Uuid,
+    ) -> Result<RemoteGenerateResult, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::RemoteGenerateSigningKey, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,
@@ -292,8 +342,23 @@ impl LockKeeperClient {
         &self,
         key_id: KeyId,
         bytes: impl Signable,
-    ) -> Result<LockKeeperResponse<Signature>, LockKeeperClientError> {
-        let metadata = self.create_metadata(ClientAction::RemoteSignBytes);
+    ) -> LockKeeperResponse<Signature> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self
+                .remote_sign_bytes_helper(key_id, bytes, request_id)
+                .await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn remote_sign_bytes_helper(
+        &self,
+        key_id: KeyId,
+        bytes: impl Signable,
+        request_id: Uuid,
+    ) -> Result<Signature, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::RemoteSignBytes, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,
@@ -326,8 +391,23 @@ impl LockKeeperClient {
         &self,
         event_type: EventType,
         options: AuditEventOptions,
-    ) -> Result<LockKeeperResponse<Vec<AuditEvent>>, LockKeeperClientError> {
-        let metadata = self.create_metadata(ClientAction::RetrieveAuditEvents);
+    ) -> LockKeeperResponse<Vec<AuditEvent>> {
+        let request_id = Uuid::new_v4();
+        LockKeeperResponse {
+            result: self
+                .retrieve_audit_event_log_helper(event_type, options, request_id)
+                .await,
+            metadata: Some(Metadata { request_id }),
+        }
+    }
+
+    async fn retrieve_audit_event_log_helper(
+        &self,
+        event_type: EventType,
+        options: AuditEventOptions,
+        request_id: Uuid,
+    ) -> Result<Vec<AuditEvent>, LockKeeperClientError> {
+        let metadata = self.create_metadata(ClientAction::RetrieveAuditEvents, request_id);
         let client_channel = Self::create_authenticated_channel(
             &mut self.tonic_client(),
             &metadata,

--- a/lock-keeper-client/src/api/authenticate.rs
+++ b/lock-keeper-client/src/api/authenticate.rs
@@ -1,7 +1,4 @@
-use crate::{
-    client::{AuthenticateResult, LockKeeperClient, Password},
-    LockKeeperResponse,
-};
+use crate::client::{AuthenticateResult, LockKeeperClient, Password};
 use std::sync::Arc;
 
 use crate::LockKeeperClientError;
@@ -24,7 +21,7 @@ impl LockKeeperClient {
         rng: Arc<Mutex<StdRng>>,
         account_name: &AccountName,
         password: &Password,
-    ) -> Result<LockKeeperResponse<AuthenticateResult>, LockKeeperClientError> {
+    ) -> Result<AuthenticateResult, LockKeeperClientError> {
         let client_login_start_result = {
             let mut rng = rng.lock().await;
             ClientLogin::<OpaqueCipherSuite>::start(&mut *rng, password.as_bytes())?
@@ -44,7 +41,7 @@ impl LockKeeperClient {
         )
         .await?;
 
-        Ok(LockKeeperResponse::from_channel(channel, auth_result))
+        Ok(auth_result)
     }
 }
 

--- a/lock-keeper-client/src/api/import.rs
+++ b/lock-keeper-client/src/api/import.rs
@@ -1,4 +1,4 @@
-use crate::{LockKeeperClient, LockKeeperClientError, LockKeeperResponse};
+use crate::{LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
     crypto::{Import, KeyId},
     infrastructure::channel::{Authenticated, ClientChannel},
@@ -11,7 +11,7 @@ impl LockKeeperClient {
         &self,
         mut channel: ClientChannel<Authenticated<StdRng>>,
         key_material: Import,
-    ) -> Result<LockKeeperResponse<KeyId>, LockKeeperClientError> {
+    ) -> Result<KeyId, LockKeeperClientError> {
         // Send UserId and key material to server
         let request = client::Request {
             user_id: self.user_id().clone(),
@@ -21,10 +21,6 @@ impl LockKeeperClient {
 
         // Get KeyId for imported key from server
         let server_response: server::Response = channel.receive().await?;
-
-        Ok(LockKeeperResponse::from_channel(
-            channel,
-            server_response.key_id,
-        ))
+        Ok(server_response.key_id)
     }
 }

--- a/lock-keeper-client/src/api/remote_generate_signing_key.rs
+++ b/lock-keeper-client/src/api/remote_generate_signing_key.rs
@@ -1,4 +1,4 @@
-use crate::{LockKeeperClient, LockKeeperClientError, LockKeeperResponse};
+use crate::{LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
     crypto::{KeyId, SigningPublicKey},
     infrastructure::channel::{Authenticated, ClientChannel},
@@ -11,7 +11,7 @@ impl LockKeeperClient {
     pub(crate) async fn handle_remote_generate_signing_key(
         &self,
         mut channel: ClientChannel<Authenticated<StdRng>>,
-    ) -> Result<LockKeeperResponse<RemoteGenerateResult>, LockKeeperClientError> {
+    ) -> Result<RemoteGenerateResult, LockKeeperClientError> {
         let request = client::RequestRemoteGenerate {
             user_id: self.user_id().clone(),
         };
@@ -19,12 +19,10 @@ impl LockKeeperClient {
         channel.send(request).await?;
 
         let response: server::ReturnKeyId = channel.receive().await?;
-        let result = RemoteGenerateResult {
+        Ok(RemoteGenerateResult {
             key_id: response.key_id,
             public_key: response.public_key,
-        };
-
-        Ok(LockKeeperResponse::from_channel(channel, result))
+        })
     }
 }
 

--- a/lock-keeper-client/src/api/remote_sign_bytes.rs
+++ b/lock-keeper-client/src/api/remote_sign_bytes.rs
@@ -1,4 +1,4 @@
-use crate::{LockKeeperClient, LockKeeperClientError, LockKeeperResponse};
+use crate::{LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
     crypto::{KeyId, Signable, SignableBytes, Signature},
     infrastructure::channel::{Authenticated, ClientChannel},
@@ -12,7 +12,7 @@ impl LockKeeperClient {
         mut channel: ClientChannel<Authenticated<StdRng>>,
         key_id: KeyId,
         bytes: impl Signable,
-    ) -> Result<LockKeeperResponse<Signature>, LockKeeperClientError> {
+    ) -> Result<Signature, LockKeeperClientError> {
         let request = client::RequestRemoteSign {
             user_id: self.user_id().clone(),
             key_id,
@@ -23,9 +23,6 @@ impl LockKeeperClient {
 
         let response: server::ReturnSignature = channel.receive().await?;
 
-        Ok(LockKeeperResponse::from_channel(
-            channel,
-            response.signature,
-        ))
+        Ok(response.signature)
     }
 }

--- a/lock-keeper-client/src/api/retrieve.rs
+++ b/lock-keeper-client/src/api/retrieve.rs
@@ -1,4 +1,4 @@
-use crate::{api::LocalStorage, LockKeeperClient, LockKeeperClientError, LockKeeperResponse};
+use crate::{api::LocalStorage, LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
     crypto::{Encrypted, KeyId, Secret, SigningKeyPair},
     infrastructure::channel::{Authenticated, ClientChannel},
@@ -8,6 +8,7 @@ use lock_keeper::{
     },
 };
 use rand::rngs::StdRng;
+use uuid::Uuid;
 
 impl LockKeeperClient {
     /// Handles the retrieval of arbitrary secrets
@@ -17,9 +18,10 @@ impl LockKeeperClient {
         mut channel: ClientChannel<Authenticated<StdRng>>,
         key_id: &KeyId,
         context: RetrieveContext,
-    ) -> Result<LockKeeperResponse<Option<LocalStorage<Secret>>>, LockKeeperClientError> {
+        request_id: Uuid,
+    ) -> Result<Option<LocalStorage<Secret>>, LockKeeperClientError> {
         // Retrieve the storage key
-        let storage_key = self.retrieve_storage_key().await?;
+        let storage_key = self.retrieve_storage_key(request_id).await?;
 
         // TODO spec#39 look up key ID in local storage before making request to server
 
@@ -47,7 +49,7 @@ impl LockKeeperClient {
             }
         };
 
-        Ok(LockKeeperResponse::from_channel(channel, result))
+        Ok(result)
     }
 
     /// Handles the retrieval of signing keys
@@ -57,8 +59,7 @@ impl LockKeeperClient {
         mut channel: ClientChannel<Authenticated<StdRng>>,
         key_id: &KeyId,
         context: RetrieveContext,
-    ) -> Result<LockKeeperResponse<Option<LocalStorage<SigningKeyPair>>>, LockKeeperClientError>
-    {
+    ) -> Result<Option<LocalStorage<SigningKeyPair>>, LockKeeperClientError> {
         // TODO spec#39 look up key ID in local storage before making request to server
 
         // Send UserId to server
@@ -83,6 +84,6 @@ impl LockKeeperClient {
             }
         };
 
-        Ok(LockKeeperResponse::from_channel(channel, result))
+        Ok(result)
     }
 }

--- a/lock-keeper-client/src/api/retrieve_audit_events.rs
+++ b/lock-keeper-client/src/api/retrieve_audit_events.rs
@@ -1,4 +1,4 @@
-use crate::{LockKeeperClient, LockKeeperClientError, LockKeeperResponse};
+use crate::{LockKeeperClient, LockKeeperClientError};
 use lock_keeper::{
     infrastructure::channel::{Authenticated, ClientChannel},
     types::{
@@ -14,7 +14,7 @@ impl LockKeeperClient {
         mut channel: ClientChannel<Authenticated<StdRng>>,
         event_type: EventType,
         options: AuditEventOptions,
-    ) -> Result<LockKeeperResponse<Vec<AuditEvent>>, LockKeeperClientError> {
+    ) -> Result<Vec<AuditEvent>, LockKeeperClientError> {
         // Send audit event request and filters
         let client_request = client::Request {
             event_type,
@@ -24,10 +24,6 @@ impl LockKeeperClient {
 
         // Receive audit event log and return
         let server_response: server::Response = channel.receive().await?;
-
-        Ok(LockKeeperResponse::from_channel(
-            channel,
-            server_response.summary_record,
-        ))
+        Ok(server_response.summary_record)
     }
 }

--- a/lock-keeper-client/src/response.rs
+++ b/lock-keeper-client/src/response.rs
@@ -1,22 +1,13 @@
-use lock_keeper::{infrastructure::channel::ClientChannel, types::operations::ResponseMetadata};
+use crate::LockKeeperClientError;
+use uuid::Uuid;
 
 #[derive(Clone, Debug)]
-pub struct LockKeeperResponse<T> {
-    pub data: T,
-    pub metadata: ResponseMetadata,
+pub struct Metadata {
+    pub request_id: Uuid,
 }
 
-impl<T> LockKeeperResponse<T> {
-    /// Consumes a [`ClientChannel`] and returns a response.
-    pub fn from_channel<AUTH>(channel: ClientChannel<AUTH>, data: T) -> Self {
-        Self {
-            data,
-            metadata: channel.into_metadata(),
-        }
-    }
-
-    /// Consumes the response and returns the inner data.
-    pub fn into_inner(self) -> T {
-        self.data
-    }
+#[derive(Debug)]
+pub struct LockKeeperResponse<T> {
+    pub result: Result<T, LockKeeperClientError>,
+    pub metadata: Option<Metadata>,
 }

--- a/lock-keeper-key-server/src/database.rs
+++ b/lock-keeper-key-server/src/database.rs
@@ -17,6 +17,7 @@ use lock_keeper::{
     },
 };
 use opaque_ke::ServerRegistration;
+use uuid::Uuid;
 
 /// Defines the expected interface between a key server and its database.
 ///
@@ -29,6 +30,7 @@ pub trait DataStore: Send + Sync + 'static {
     /// Create a new [`AuditEvent`] for the given actor, action, and outcome
     async fn create_audit_event(
         &self,
+        request_id: Uuid,
         actor: &AccountName,
         secret_id: &Option<KeyId>,
         action: ClientAction,

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -7,7 +7,6 @@ pub(crate) use operation::Operation;
 pub use service::start_lock_keeper_server;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{info, instrument};
-use uuid::Uuid;
 
 use crate::{config::Config, error::LockKeeperServerError, operations};
 
@@ -16,10 +15,7 @@ use lock_keeper::{
     crypto::KeyId,
     infrastructure::channel::{Authenticated, ServerChannel, Unauthenticated},
     rpc::{lock_keeper_rpc_server::LockKeeperRpc, HealthCheck},
-    types::{
-        operations::{RequestMetadata, ResponseMetadata},
-        Message, MessageStream,
-    },
+    types::{operations::RequestMetadata, Message, MessageStream},
 };
 
 use crate::{database::DataStore, server::session_cache::SessionCache};
@@ -277,15 +273,7 @@ impl<DB: DataStore> LockKeeperKeyServer<DB> {
     {
         info!("Handling new client request.");
         let (channel, rx) = ServerChannel::new(request)?;
-
-        let metadata = ResponseMetadata {
-            request_id: Uuid::new_v4(),
-        };
-
-        let mut response = Response::new(ReceiverStream::new(rx));
-        let _ = response
-            .metadata_mut()
-            .insert(METADATA, metadata.try_into()?);
+        let response = Response::new(ReceiverStream::new(rx));
 
         Ok((channel, response))
     }

--- a/lock-keeper-tests/Cargo.toml
+++ b/lock-keeper-tests/Cargo.toml
@@ -29,6 +29,7 @@ tonic.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 
 # Other dependencies
 colored = "2.0"

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
@@ -21,7 +21,9 @@ pub(crate) struct TestState {
 pub(crate) async fn init_test_state(config: &Config) -> Result<TestState, LockKeeperClientError> {
     let account_name = AccountName::from_str(tagged("user").as_str())?;
     let password = Password::from_str(tagged("password").as_str())?;
-    LockKeeperClient::register(&account_name, &password, config).await?;
+    LockKeeperClient::register(&account_name, &password, config)
+        .await
+        .result?;
     Ok(TestState {
         account_name,
         password,

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
@@ -36,19 +36,18 @@ pub async fn run_tests(config: &Config, filters: &TestFilters) -> Result<Vec<Tes
 
 async fn retrieve_local_only_works(config: Config) -> Result<()> {
     let state = init_test_state(&config).await?;
-    let client = authenticate(&state).await?;
+    let client = authenticate(&state).await.result?;
 
     let GenerateResult {
         key_id,
         local_storage,
-    } = client.generate_secret().await?.into_inner();
+    } = client.generate_secret().await.result?;
     let local_storage_res = client
         .retrieve_secret(&key_id, RetrieveContext::LocalOnly)
         .await;
-    assert!(local_storage_res.is_ok());
 
-    let local_storage_opt = local_storage_res?.into_inner();
-    assert!(local_storage_opt.is_some());
+    let local_storage_opt = local_storage_res.result?;
+    let request_id = local_storage_res.metadata.clone().unwrap().request_id;
 
     let local_storage_new = local_storage_opt.unwrap();
     assert_eq!(local_storage_new.material, local_storage.material);
@@ -56,6 +55,7 @@ async fn retrieve_local_only_works(config: Config) -> Result<()> {
         &state,
         EventStatus::Successful,
         ClientAction::RetrieveSecret,
+        request_id,
     )
     .await?;
 
@@ -64,21 +64,22 @@ async fn retrieve_local_only_works(config: Config) -> Result<()> {
 
 async fn retrieve_null_works(config: Config) -> Result<()> {
     let state = init_test_state(&config).await?;
-    let client = authenticate(&state).await?;
+    let client = authenticate(&state).await.result?;
 
     let GenerateResult {
         key_id,
         local_storage: _,
-    } = client.generate_secret().await?.into_inner();
+    } = client.generate_secret().await.result?;
     let local_storage_res = client.retrieve_secret(&key_id, RetrieveContext::Null).await;
-    assert!(local_storage_res.is_ok());
 
-    let local_storage_opt = local_storage_res?.into_inner();
+    let local_storage_opt = local_storage_res.result?;
+    let request_id = local_storage_res.metadata.unwrap().request_id;
     assert!(local_storage_opt.is_none());
     check_audit_events(
         &state,
         EventStatus::Successful,
         ClientAction::RetrieveSecret,
+        request_id,
     )
     .await?;
 
@@ -87,28 +88,35 @@ async fn retrieve_null_works(config: Config) -> Result<()> {
 
 async fn cannot_retrieve_fake_key(config: Config) -> Result<()> {
     let state = init_test_state(&config).await?;
-    let client = authenticate(&state).await?;
+    let client = authenticate(&state).await.result?;
 
     let fake_key_id = generate_fake_key_id(&client).await?;
     let local_storage_res = client
         .retrieve_secret(&fake_key_id, RetrieveContext::LocalOnly)
         .await;
+    let request_id = local_storage_res.metadata.clone().unwrap().request_id;
     compare_errors(local_storage_res, Status::internal("Internal server error"));
-    check_audit_events(&state, EventStatus::Failed, ClientAction::RetrieveSecret).await?;
+    check_audit_events(
+        &state,
+        EventStatus::Failed,
+        ClientAction::RetrieveSecret,
+        request_id,
+    )
+    .await?;
 
     Ok(())
 }
 
 async fn cannot_retrieve_after_logout(config: Config) -> Result<()> {
     let state = init_test_state(&config).await?;
-    let client = authenticate(&state).await?;
+    let client = authenticate(&state).await.result?;
 
     // Generate a secret before waiting out the timeout
     let GenerateResult {
         key_id,
         local_storage: _,
-    } = client.generate_secret().await?.into_inner();
-    client.logout().await?;
+    } = client.generate_secret().await.result?;
+    client.logout().await.result?;
 
     let res = client.retrieve_secret(&key_id, RetrieveContext::Null).await;
     compare_status_errors(res, Status::unauthenticated("No session key for this user"))?;

--- a/lock-keeper/src/types/audit_event.rs
+++ b/lock-keeper/src/types/audit_event.rs
@@ -9,6 +9,7 @@ use bson::DateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use strum::IntoEnumIterator;
+use uuid::Uuid;
 
 /// Options for the outcome of a given action in a [`AuditEvent`]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,6 +23,7 @@ pub enum EventStatus {
 /// any related key for a logged audit event
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AuditEvent {
+    request_id: String,
     actor: AccountName,
     secret_id: Option<KeyId>,
     date: DateTime,
@@ -31,12 +33,14 @@ pub struct AuditEvent {
 
 impl AuditEvent {
     pub fn new(
+        request_id: Uuid,
         actor: AccountName,
         secret_id: Option<KeyId>,
         action: ClientAction,
         status: EventStatus,
     ) -> Self {
         AuditEvent {
+            request_id: request_id.to_string(),
             actor,
             secret_id,
             date: DateTime::now(),
@@ -47,6 +51,10 @@ impl AuditEvent {
 }
 
 impl AuditEvent {
+    pub fn request_id(&self) -> &str {
+        &self.request_id
+    }
+
     pub fn action(&self) -> ClientAction {
         self.action
     }
@@ -68,8 +76,8 @@ impl Display for AuditEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "AuditEvent: User <{:?}> performed action <{:?}> on {} with outcome <{:?}>",
-            self.actor, self.action, self.date, self.status
+            "AuditEvent: User <{:?}> performed action <{:?}> on {} with outcome <{:?}>. Request ID: {:?}",
+            self.actor, self.action, self.date, self.status, self.request_id
         )
     }
 }
@@ -107,4 +115,5 @@ pub struct AuditEventOptions {
     pub key_ids: Option<Vec<KeyId>>,
     pub after_date: Option<DateTime>,
     pub before_date: Option<DateTime>,
+    pub request_id: Option<Uuid>,
 }

--- a/persistence/lock-keeper-mongodb/Cargo.toml
+++ b/persistence/lock-keeper-mongodb/Cargo.toml
@@ -18,6 +18,7 @@ serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 
 # Other dependencies
 mongodb = "2.3.0"

--- a/persistence/lock-keeper-mongodb/src/api.rs
+++ b/persistence/lock-keeper-mongodb/src/api.rs
@@ -25,6 +25,7 @@ use mongodb::{
 };
 use opaque_ke::ServerRegistration;
 use tracing::instrument;
+use uuid::Uuid;
 
 mod audit_event;
 mod secret;
@@ -91,12 +92,13 @@ impl DataStore for Database {
     #[instrument(skip_all, err(Debug), fields(actor, secret_id, action, status))]
     async fn create_audit_event(
         &self,
+        request_id: Uuid,
         actor: &AccountName,
         secret_id: &Option<KeyId>,
         action: ClientAction,
         status: EventStatus,
     ) -> Result<(), Self::Error> {
-        self.create_audit_event(actor, secret_id, action, status)
+        self.create_audit_event(request_id, actor, secret_id, action, status)
             .await?;
         Ok(())
     }

--- a/persistence/lock-keeper-mongodb/src/constants.rs
+++ b/persistence/lock-keeper-mongodb/src/constants.rs
@@ -9,6 +9,7 @@ pub(crate) const SECRETS: &str = "secrets";
 pub(crate) const ACTION: &str = "action";
 pub(crate) const ACTOR: &str = "actor";
 pub(crate) const DATE: &str = "date";
+pub(crate) const REQUEST_ID: &str = "request_id";
 pub(crate) const SECRET_ID: &str = "secret_id";
 pub(crate) const STORAGE_KEY: &str = "storage_key";
 


### PR DESCRIPTION
Closes #411 

Other changes:
- Change LockKeeperResponse to return the entire result so we can return it in the error case as well
- Generate request IDs client-side instead of server-side
- A request ID spans an entire client operation, not each individual request to the server that the operation might take

This ended up touching more files than expected, so I may try to split out some of the refactoring into another PR if people don't review before I'm back!