### PR TITLE
Updated spans to manually skip fields #416

### DIFF
--- a/bin/key-server-cli/src/main.rs
+++ b/bin/key-server-cli/src/main.rs
@@ -46,15 +46,14 @@
 //! Please follow the following template for instrumenting your function with
 //! spans:
 //! ```text
-//! #[instrument(skip_all, err(Debug), fields(arg1, arg2))]
-//! fn foo(arg1: _, arg2: _) -> _ {}
+//! #[instrument(skip(sensitive_arg), err(Debug))]
+//! fn foo(arg1: _, arg2: _, sensitive_arg SuperSecret) -> _ {}
 //! ```
 //! By default, `instrument` will create a new span where every argument to a
 //! function is a span field. *This is not desirable for our key server as we
-//! want to avoid logging sensitive data!* So *we always use the `skip_all`
-//! option* to avoid automatically logging all arguments. Instead you can use
-//! the `fields(...)` option to specify which arguments should be recorded as
-//! fields in our span.
+//! want to avoid logging sensitive data!* Make sure to skip sensitive arguments
+//! with the `skip(sensitive_arg_1, sensitive_arg_2)` option. You can also use
+//! the `skip_all` option if none of the function arguments need to be logged.
 //!
 //! Finally, the `err(Debug)` option tells `tracing` that any `Result::Err(_)`
 //! returned from this function should be logged as events (with the default

--- a/lock-keeper-key-server/src/operations/create_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/create_storage_key.rs
@@ -74,7 +74,7 @@ async fn send_user_id<DB: DataStore>(
     Ok(user.user_id)
 }
 
-#[instrument(skip_all, err(Debug), fields(user_id))]
+#[instrument(skip(channel, context), err(Debug))]
 async fn store_storage_key<DB: DataStore>(
     user_id: UserId,
     channel: &mut ServerChannel<Authenticated<StdRng>>,

--- a/lock-keeper-key-server/src/operations/register.rs
+++ b/lock-keeper-key-server/src/operations/register.rs
@@ -84,7 +84,7 @@ async fn register_start<DB: DataStore>(
     }
 }
 
-#[instrument(skip_all, err(Debug))]
+#[instrument(skip(channel, context), err(Debug))]
 async fn register_finish<DB: DataStore>(
     account_name: &AccountName,
     channel: &mut ServerChannel<Unauthenticated>,

--- a/lock-keeper-key-server/src/server/operation.rs
+++ b/lock-keeper-key-server/src/server/operation.rs
@@ -60,7 +60,7 @@ pub(crate) trait Operation<AUTH: Send + 'static, DB: DataStore>:
     }
 }
 
-#[instrument(skip_all, fields(e))]
+#[instrument(skip(channel))]
 async fn handle_error<AUTH>(channel: &mut ServerChannel<AUTH>, e: LockKeeperServerError) {
     error!("{}", e);
     if let Err(e) = channel.send_error(e).await {
@@ -69,7 +69,7 @@ async fn handle_error<AUTH>(channel: &mut ServerChannel<AUTH>, e: LockKeeperServ
 }
 
 /// Log the given action as an audit event.
-#[instrument(skip_all, fields(status))]
+#[instrument(skip(channel, context))]
 async fn audit_event<AUTH, DB: DataStore>(
     channel: &mut ServerChannel<AUTH>,
     context: &Context<DB>,

--- a/persistence/lk-session-mongodb/src/api.rs
+++ b/persistence/lk-session-mongodb/src/api.rs
@@ -76,7 +76,7 @@ impl MongodbSessionCache {
         Ok(())
     }
 
-    #[instrument(skip_all, err(Debug), fields(session_id, user_id))]
+    #[instrument(skip(self), err(Debug))]
     async fn find_session(&self, session_id: SessionId, user_id: UserId) -> Result<Session, Error> {
         let collection = self.handle.collection::<Session>(TABLE);
         let user_id_bson = mongodb::bson::to_bson(&user_id)?;
@@ -96,7 +96,7 @@ impl MongodbSessionCache {
         Ok(session)
     }
 
-    #[instrument(skip_all, err(Debug), fields(session_id))]
+    #[instrument(skip(self), err(Debug))]
     async fn delete_session(&self, session_id: SessionId) -> Result<(), Error> {
         let collection = self.handle.collection::<Session>(TABLE);
         let session_id_bson = mongodb::bson::to_bson(&session_id)?;

--- a/persistence/lock-keeper-mongodb/src/api.rs
+++ b/persistence/lock-keeper-mongodb/src/api.rs
@@ -89,7 +89,7 @@ impl Database {
 impl DataStore for Database {
     type Error = Error;
 
-    #[instrument(skip_all, err(Debug), fields(actor, secret_id, action, status))]
+    #[instrument(skip(self, request_id), err(Debug))]
     async fn create_audit_event(
         &self,
         request_id: Uuid,
@@ -103,7 +103,7 @@ impl DataStore for Database {
         Ok(())
     }
 
-    #[instrument(skip_all, err(Debug), fields(account_name, event_type, options))]
+    #[instrument(skip(self), err(Debug))]
     async fn find_audit_events(
         &self,
         account_name: &AccountName,
@@ -116,13 +116,13 @@ impl DataStore for Database {
         Ok(audit_events)
     }
 
-    #[instrument(skip_all, err(Debug), fields(user_id))]
+    #[instrument(skip_all, err(Debug))]
     async fn add_user_secret(&self, secret: StoredSecret) -> Result<(), Self::Error> {
         self.add_user_secret(secret).await?;
         Ok(())
     }
 
-    #[instrument(skip_all, err(Debug), fields(user_id, key_id))]
+    #[instrument(skip(self, filter), err(Debug))]
     async fn get_user_secret(
         &self,
         user_id: &UserId,
@@ -133,6 +133,7 @@ impl DataStore for Database {
         Ok(stored_encrypted_secret)
     }
 
+    #[instrument(skip(self, server_registration), err(Debug))]
     async fn create_user(
         &self,
         user_id: &UserId,
@@ -145,25 +146,25 @@ impl DataStore for Database {
         Ok(user)
     }
 
-    #[instrument(skip_all, err(Debug), fields(account_name))]
+    #[instrument(skip(self), err(Debug))]
     async fn find_user(&self, account_name: &AccountName) -> Result<Option<User>, Self::Error> {
         let opt_user = self.find_user(account_name).await?;
         Ok(opt_user)
     }
 
-    #[instrument(skip_all, err(Debug), fields(user_id))]
+    #[instrument(skip(self), err(Debug))]
     async fn find_user_by_id(&self, user_id: &UserId) -> Result<Option<User>, Self::Error> {
         let opt_user = self.find_user_by_id(user_id).await?;
         Ok(opt_user)
     }
 
-    #[instrument(skip_all, err(Debug), fields(user_id))]
+    #[instrument(skip(self), err(Debug))]
     async fn delete_user(&self, user_id: &UserId) -> Result<(), Self::Error> {
         self.delete_user(user_id).await?;
         Ok(())
     }
 
-    #[instrument(skip_all, err(Debug), fields(user_id))]
+    #[instrument(skip(self, storage_key), err(Debug))]
     async fn set_storage_key(
         &self,
         user_id: &UserId,


### PR DESCRIPTION
This PR updates `#[instrument]` macros for `tracing` to manually skip function arguments in cases where a subset of arguments should be included in the span.

In cases where all arguments are skipped, we continue to use `skip_all`.

Closes #416 