### PR TITLE
Update protobuf action and add token #420

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,9 +26,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Install stable toolchain
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,9 +43,10 @@ jobs:
         uses: supercharge/mongodb-github-action@1.7.0
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-make
         uses: actions-rs/cargo@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,10 @@ jobs:
           submodules: recursive
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v1.1.2
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Ensure Rust is the latest version
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
This PR updates the GitHub action for installing protobuf to the latest version and adds `repo-token` to the action which should solve the issue.

See: https://github.com/actions/runner-images/issues/602

Closes #420