### PR TITLE
Added some CLI scripts for quick testing

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -121,10 +121,33 @@ alias = "ci-clippy"
 [tasks.test]
 alias = "ci-test"
 
-# Run the interactive client.
+# -- Client CLI tasks --
+
+# Run the client CLI in interactive mode
 [tasks.cli]
 command = "cargo"
 args = ["run", "--bin", "lock-keeper-client-cli"]
+
+# Runs a CLI script to generate a retrieve a few keys
+[tasks.script-generate]
+command = "cargo"
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/generate.lk"]
+
+# Runs a CLI script to remotely generate a signing key and sign some data
+[tasks.script-sign]
+command = "cargo"
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/sign.lk"]
+
+# Runs a CLI script to export a remotely generated signing key
+[tasks.script-export]
+command = "cargo"
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/export.lk"]
+
+# Runs a CLI script to import and then export a signing key
+[tasks.script-import]
+command = "cargo"
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/import.lk"]
+
 
 # Generate certificates in the dev/certs/gen directory
 [tasks.certs]

--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Then run the client CLI:
 cargo make cli
 ```
 
+There are a few `cargo make` tasks that run specific CLI scripts for quick testing. Check the CLI section of  `Makefile.toml` for available tasks.
+
 ## Troubleshooting
 ### Logging
 The server writes logs to a few locations:

--- a/dev/cli-scripts/export.lk
+++ b/dev/cli-scripts/export.lk
@@ -1,0 +1,3 @@
+register
+remote-generate
+export 1

--- a/dev/cli-scripts/generate.lk
+++ b/dev/cli-scripts/generate.lk
@@ -1,0 +1,9 @@
+register
+
+repeat 3 {
+    generate
+}
+
+retrieve 1
+retrieve 2
+retrieve 3

--- a/dev/cli-scripts/import.lk
+++ b/dev/cli-scripts/import.lk
@@ -1,0 +1,3 @@
+register
+import
+export 1

--- a/dev/cli-scripts/sign.lk
+++ b/dev/cli-scripts/sign.lk
@@ -1,0 +1,3 @@
+register
+remote-generate
+remote-sign 1 abcdefg


### PR DESCRIPTION
This PR adds a few CLI scripts to the `dev` directory that can be used for quick testing. I also added some `cargo make` tests for them so they can be run without a giant command.