### PR TITLE
Manually close channel at the end of handle operation #386

### DIFF
--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -144,7 +144,7 @@ impl<DB: DataStore> LockKeeperRpc for LockKeeperKeyServer<DB> {
     async fn get_user_id(
         &self,
         request: Request<tonic::Streaming<Message>>,
-    ) -> Result<Response<Self::GenerateSecretStream>, Status> {
+    ) -> Result<Response<Self::GetUserIdStream>, Status> {
         // `create_authenticated_channel` gets the `user_id` out of the request metadata
         // in order to retrieve the session key. Since the client doesn't know
         // its `user_id` before the `GetUserId` operation is called, we can't call the

--- a/lock-keeper/src/infrastructure/channel/server.rs
+++ b/lock-keeper/src/infrastructure/channel/server.rs
@@ -56,6 +56,10 @@ impl<AUTH> ServerChannel<AUTH> {
         let payload = Err(status.into());
         Ok(self.sender.send(payload).await?)
     }
+
+    pub async fn closed(&mut self) {
+        self.sender.closed().await;
+    }
 }
 
 impl ServerChannel<Unauthenticated> {

--- a/lock-keeper/src/types/operations.rs
+++ b/lock-keeper/src/types/operations.rs
@@ -96,6 +96,9 @@ impl TryFrom<HexBytes> for SessionId {
     }
 }
 
+/// Metadata attached to each request to the server. Note that the request ID is
+/// an ID for an entire operation, not each `ClientAction` that the operation is
+/// composed of.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RequestMetadata {
     account_name: AccountName,


### PR DESCRIPTION
Closes #386 

It seems like the broken pipe error was happening when the client drops its receiver at the end of a protocol, so I added a manual call to `closed` to the server's sender which tells it that the receivers have dropped.
I'd only gotten the error when running the server locally - I don't get it anymore, but I'd like if folks tested this out wherever they were seeing the error before too.

Also includes a quick doc string for RequestMetadata.