### PR TITLE
Add audit event support to client CLI #272

### DIFF
--- a/bin/lock-keeper-client-cli/Cargo.toml
+++ b/bin/lock-keeper-client-cli/Cargo.toml
@@ -10,16 +10,17 @@ lock-keeper = { version = "0.2.0", path = "../../lock-keeper" }
 lock-keeper-client = { version = "0.2.0", path = "../../lock-keeper-client" }
 
 # Workspace dependencies
+async-trait.workspace = true
 clap.workspace = true
+rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true
-rand.workspace = true
+uuid.workspace = true
 zeroize.workspace = true
-async-trait.workspace = true
 
 # Other dependencies
 anyhow = "1"

--- a/bin/lock-keeper-client-cli/README.md
+++ b/bin/lock-keeper-client-cli/README.md
@@ -13,53 +13,7 @@ but it also means that it will break alongside the client crate.
 
 
 ## Commands
-To see this list in the application, type `help` in the CLI's prompt.
-
-```
-Enter a command at the prompt. The prompt will display `|` if you are logged out and `>` if you are logged in.
-
-command: register [account_name] [password]
-aliases: reg
-description: Registers a new account with the given account_name and password
-
-command: authenticate [account_name] [password]
-aliases: auth, a, login
-description: Authenticates to a previously registered account. Authentication is required for most commands.
-
-command: generate [key_name (optional)]
-aliases: gen, g
-description: Generate a new key. If you provide a name, the key can be referenced by that name. 
-             If you don't provide a name, the key can be referenced by the number printed to the screen after generation.
-
-command: retrieve [key_name]
-aliases: ret, r
-description: Retrieve a previously generated key from the key server and update local storage.
-
-command: remote-generate [key_name (optional)]
-aliases: rgen, rg
-description: Generate a new key remotely. This key will be generated entirely in the server.
-             If you provide a name, the key can be referenced by that name. 
-             If you don't provide a name, the key can be referenced by the number printed to the screen after generation.
-
-command: print [key_name]
-aliases: p
-description: Prints all stored information about the given key.
-
-command: list
-aliases: ls
-description: Prints stored information about every key associated with the current account.
-
-command: logout
-description: Log out of currently authenticated account.
-
-command: help
-aliases: h
-description: Prints help text.
-
-command: quit
-aliases: q, exit
-description: Quits the application
-```
+Type `help` in the CLI's prompt to see info about all commands.
 
 ## Examples
 
@@ -133,6 +87,31 @@ data: Arbitrary Key - 8fa9f08e7d3d846ce32e33d3081887c368708ff441eb7ee957dca74164
 name: 2
 key_id: 29b47e89b962a703ddf7c9fb57638b72c810ef968296734931d5dcfc913889bd
 data: Arbitrary Key - 4a92b4603e556330fb3e9df51cec0fd623336e560af549b7870b20270925f914
+```
+
+Get all audit events for a user:
+```
+> audit
+Audit Events:
+----------------------------------
+Request ID: 37fd925f-96a6-4f41-add0-7d8aea883ae0
+2023-01-05 23:44:53.424 +00:00:00
+Register
+Started
+----------------------------------
+```
+
+Get audit events for a key with name `my_favorite_key`:
+```
+> audit key:my_favorite_key
+Audit Events:
+----------------------------------
+Request ID: edce607b-daa8-42f4-9d1a-acb312ba759a
+KeyId("7268ed67a1207c1d4a09b40a5c4f6b5f1848b95451302ae5c1f53044f2f51adf")
+2023-01-05 23:46:35.889 +00:00:00
+GenerateSecret
+Successful
+----------------------------------
 ```
 
 Quit:

--- a/bin/lock-keeper-client-cli/src/cli_command/get_audit_events.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/get_audit_events.rs
@@ -1,29 +1,111 @@
-use std::time::Duration;
+use std::{
+    str::FromStr,
+    time::{Duration, SystemTime},
+};
 
 use crate::{cli_command::CliCommand, state::State};
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use async_trait::async_trait;
+use lock_keeper::types::audit_event::{AuditEventOptions, EventType};
+use lock_keeper_client::LockKeeperClient;
+use uuid::Uuid;
 
 #[derive(Debug)]
-pub struct GetAuditEvents {}
+pub struct GetAuditEvents {
+    event_type: EventType,
+    key_names: Option<Vec<String>>,
+    request_id: Option<Uuid>,
+}
 
 #[async_trait]
 impl CliCommand for GetAuditEvents {
-    async fn execute(self: Box<Self>, _state: &mut State) -> Result<Duration, Error> {
-        println!("{:?}: Not implemented", GetAuditEvents {});
-        // Return zero duration since this command is not implemented
-        Ok(Duration::ZERO)
+    async fn execute(self: Box<Self>, state: &mut State) -> Result<Duration, Error> {
+        let key_ids = match self.key_names {
+            Some(key_names) => {
+                let mut key_ids = Vec::new();
+                for key_name in key_names {
+                    key_ids.push(state.get_key_id(&key_name)?.key_id.clone());
+                }
+
+                Some(key_ids)
+            }
+            None => None,
+        };
+        let options = AuditEventOptions {
+            key_ids,
+            request_id: self.request_id,
+            ..Default::default()
+        };
+
+        let credentials = state.get_credentials()?;
+
+        // Authenticate user to the key server
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &credentials.account_name,
+            &credentials.password,
+            &state.config,
+        )
+        .await
+        .result?;
+
+        let now = SystemTime::now();
+        // If successful, proceed to generate a secret with the established session
+        let audit_event_log = lock_keeper_client
+            .retrieve_audit_event_log(self.event_type, options)
+            .await
+            .result?;
+        let elapsed = now.elapsed()?;
+
+        println!("Audit Events:");
+        for event in audit_event_log {
+            println!("----------------------------------");
+            println!("{event}");
+        }
+        println!("----------------------------------");
+
+        Ok(elapsed)
     }
 
     fn parse_command_args(slice: &[&str]) -> Option<Self> {
         match slice {
-            [] => Some(GetAuditEvents {}),
-            _ => None,
+            [] => Some(GetAuditEvents {
+                event_type: EventType::All,
+                key_names: None,
+                request_id: None,
+            }),
+            options => {
+                let mut result = GetAuditEvents {
+                    event_type: EventType::All,
+                    key_names: None,
+                    request_id: None,
+                };
+
+                for option in options {
+                    let parsed_option = match parse_option(option) {
+                        Ok(p) => p,
+                        _ => return None,
+                    };
+
+                    match parsed_option {
+                        ParsedAuditEventOption::EventType(event_type) => {
+                            result.event_type = event_type;
+                        }
+                        ParsedAuditEventOption::KeyNames(key_names) => {
+                            result.key_names = Some(key_names);
+                        }
+                        ParsedAuditEventOption::RequestId(request_id) => {
+                            result.request_id = Some(request_id);
+                        }
+                    }
+                }
+
+                Some(result)
+            }
         }
     }
 
     fn format() -> &'static str {
-        "audit"
+        "audit [query_options (see help)]"
     }
 
     fn aliases() -> Vec<&'static str>
@@ -37,6 +119,45 @@ impl CliCommand for GetAuditEvents {
     where
         Self: Sized,
     {
-        "Not implemented."
+        "Retrieves audit events for the authenticated user.
+         Additional query options are available with the following commands.
+         Options:
+            - type:event_type (all, key-only, system-only)
+            - keys:key_name1,key_name_2
+            - request-id:uuid
+        "
     }
+}
+
+fn parse_option(text: &str) -> Result<ParsedAuditEventOption, Error> {
+    const ERROR_MESSAGE: &str = "Invalid audit event option";
+
+    let mut option_split = text.splitn(2, ':');
+
+    let option_name = option_split.next().ok_or_else(|| anyhow!(ERROR_MESSAGE))?;
+    let option_value = option_split.next().ok_or_else(|| anyhow!(ERROR_MESSAGE))?;
+
+    match option_name {
+        "type" => Ok(ParsedAuditEventOption::EventType(EventType::from_str(
+            option_value,
+        )?)),
+        "keys" | "key" => {
+            let key_names: Vec<String> = option_value.split(',').map(ToString::to_string).collect();
+            Ok(ParsedAuditEventOption::KeyNames(key_names))
+        }
+        "request-id" => Ok(ParsedAuditEventOption::RequestId(option_value.parse()?)),
+        "before" => {
+            anyhow::bail!("`before` option is not implemented");
+        }
+        "after" => {
+            anyhow::bail!("`after` option is not implemented");
+        }
+        _ => anyhow::bail!(ERROR_MESSAGE),
+    }
+}
+
+enum ParsedAuditEventOption {
+    EventType(EventType),
+    KeyNames(Vec<String>),
+    RequestId(Uuid),
 }

--- a/bin/lock-keeper-client-cli/src/cli_command/remote_sign.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/remote_sign.rs
@@ -44,9 +44,10 @@ impl CliCommand for RemoteSign {
 
     fn parse_command_args(slice: &[&str]) -> Option<Self> {
         match slice {
-            [key_name, string_to_sign] => Some(RemoteSign {
+            // All arguments after the key name are joined by spaces to form the text to be signed
+            [key_name, string_to_sign @ ..] => Some(RemoteSign {
                 name: key_name.to_string(),
-                data: string_to_sign.to_string(),
+                data: string_to_sign.join(" "),
             }),
             _ => None,
         }
@@ -57,7 +58,7 @@ impl CliCommand for RemoteSign {
     }
 
     fn aliases() -> Vec<&'static str> {
-        vec!["remote-sign", "rs"]
+        vec!["remote-sign", "sign", "rs"]
     }
 
     fn description() -> &'static str {

--- a/lock-keeper-tests/src/test_suites/database/audit_event.rs
+++ b/lock-keeper-tests/src/test_suites/database/audit_event.rs
@@ -212,7 +212,7 @@ async fn create_random_audit_events(
 
 fn compare_actions(audit_events: Vec<AuditEvent>, event_type: EventType) {
     let actual_actions: Vec<ClientAction> = audit_events.iter().map(|a| a.action()).collect();
-    let expected_actions = event_type.into_client_actions();
+    let expected_actions = event_type.client_actions();
     assert!(actual_actions
         .iter()
         .all(|item| expected_actions.contains(item)));

--- a/lock-keeper/src/types/audit_event.rs
+++ b/lock-keeper/src/types/audit_event.rs
@@ -8,11 +8,11 @@ use crate::crypto::KeyId;
 use bson::DateTime;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
-use strum::IntoEnumIterator;
+use strum::{Display, EnumString};
 use uuid::Uuid;
 
 /// Options for the outcome of a given action in a [`AuditEvent`]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Display)]
 pub enum EventStatus {
     Started,
     Successful,
@@ -74,46 +74,96 @@ impl AuditEvent {
 
 impl Display for AuditEvent {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "AuditEvent: User <{:?}> performed action <{:?}> on {} with outcome <{:?}>. Request ID: {:?}",
-            self.actor, self.action, self.date, self.status, self.request_id
-        )
+        writeln!(f, "Request ID: {}", self.request_id())?;
+        if let Some(key_id) = self.key_id() {
+            writeln!(f, "{key_id:?}")?;
+        }
+        writeln!(f, "{}", self.date())?;
+        writeln!(f, "{}", self.action())?;
+        writeln!(f, "{}", self.status())
     }
 }
 
 /// Options for which types of events to retrieve from the key server
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, EnumString, Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum EventType {
     All,
     SystemOnly,
     KeyOnly,
 }
 
+const ALL_ACTIONS: &[ClientAction] = &[
+    ClientAction::Authenticate,
+    ClientAction::CreateStorageKey,
+    ClientAction::ExportSecret,
+    ClientAction::ExportSigningKey,
+    ClientAction::GenerateSecret,
+    ClientAction::GetUserId,
+    ClientAction::ImportSigningKey,
+    ClientAction::Logout,
+    ClientAction::Register,
+    ClientAction::RemoteGenerateSigningKey,
+    ClientAction::RemoteSignBytes,
+    ClientAction::RetrieveSecret,
+    ClientAction::RetrieveAuditEvents,
+    ClientAction::RetrieveSigningKey,
+    ClientAction::RetrieveStorageKey,
+];
+
+const SYSTEM_ONLY_ACTIONS: &[ClientAction] = &[
+    ClientAction::Authenticate,
+    ClientAction::CreateStorageKey,
+    ClientAction::GetUserId,
+    ClientAction::Logout,
+    ClientAction::Register,
+    ClientAction::RetrieveAuditEvents,
+    ClientAction::RetrieveStorageKey,
+];
+
+const KEY_ONLY_ACTIONS: &[ClientAction] = &[
+    ClientAction::ExportSecret,
+    ClientAction::ExportSigningKey,
+    ClientAction::GenerateSecret,
+    ClientAction::ImportSigningKey,
+    ClientAction::RemoteGenerateSigningKey,
+    ClientAction::RemoteSignBytes,
+    ClientAction::RetrieveSecret,
+    ClientAction::RetrieveSigningKey,
+];
+
 impl EventType {
-    pub fn into_client_actions(self) -> Vec<ClientAction> {
-        let system_only = vec![
-            ClientAction::Authenticate,
-            ClientAction::CreateStorageKey,
-            ClientAction::Register,
-            ClientAction::RetrieveAuditEvents,
-            ClientAction::RetrieveStorageKey,
-        ];
+    pub fn client_actions(&self) -> &[ClientAction] {
         match self {
-            Self::All => ClientAction::iter().collect::<Vec<_>>(),
-            Self::SystemOnly => system_only,
-            Self::KeyOnly => ClientAction::iter()
-                .filter(|x| !system_only.contains(x))
-                .collect::<Vec<_>>(),
+            Self::All => ALL_ACTIONS,
+            Self::SystemOnly => SYSTEM_ONLY_ACTIONS,
+            Self::KeyOnly => KEY_ONLY_ACTIONS,
         }
     }
 }
 
 /// Optional parameters to filter [`AuditEvent`]s by
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AuditEventOptions {
     pub key_ids: Option<Vec<KeyId>>,
     pub after_date: Option<DateTime>,
     pub before_date: Option<DateTime>,
     pub request_id: Option<Uuid>,
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    /// The ALL_ACTIONS constant exists so that we can use it as a constant
+    /// without something like `lazy_static!`. This test ensures that any
+    /// actions added to `ClientAction` are covered by this constant.
+    #[test]
+    fn all_actions_constant_includes_all_actions() {
+        for action in ClientAction::iter() {
+            assert!(ALL_ACTIONS.contains(&action))
+        }
+    }
 }

--- a/persistence/lock-keeper-mongodb/src/api/audit_event.rs
+++ b/persistence/lock-keeper-mongodb/src/api/audit_event.rs
@@ -49,7 +49,7 @@ impl Database {
         event_type: EventType,
         options: AuditEventOptions,
     ) -> Result<Vec<AuditEvent>, Error> {
-        let actions = event_type.into_client_actions();
+        let actions = event_type.client_actions();
         let mut query = doc! { ACTOR: account_name.to_string(), ACTION: {"$in": mongodb::bson::to_bson(&actions)?} };
         query = construct_query_with_options(options, query)?;
         let collection = self.handle.collection::<AuditEvent>(AUDIT_EVENTS);


### PR DESCRIPTION
Client CLI can now retrieve audit event logs. I implemented all of the filters except for the date filters since they depend on `mongodb` types which will be replaced soon.

Other changes:
- Removed help text from README. This will end up being outdated so I don't think it's worth trying to maintain.
- Remote signing now accepts all remaining text after the key name as the data to be signed. This lets you use spaces in your data string.

I added a `merge` method to `AuditEventOptions` which didn't end up being used due to the `CliComand` trait definition for `parse_command_args`. I still plan to use this method after more refactoring so I'd like to leave this in.

Closes #272 