### PR TITLE
Use randomly generated session keys in tests #415

### DIFF
--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -358,7 +358,9 @@ mod test {
 
     // In practice, a session key will be a pseudorandom output from OPAQUE.
     // We'll use random bytes for the test key.
-    fn create_test_session_key(rng: &mut (impl CryptoRng + RngCore)) -> OpaqueSessionKey {
+    pub(crate) fn create_test_session_key(
+        rng: &mut (impl CryptoRng + RngCore),
+    ) -> OpaqueSessionKey {
         let mut key = [0_u8; 64];
         rng.try_fill(&mut key)
             .expect("Failed to generate random key");
@@ -490,8 +492,9 @@ mod test {
 
     #[test]
     fn session_key_to_vec_u8_conversion_works() -> Result<(), LockKeeperError> {
+        let mut rng = rand::thread_rng();
         for _ in 0..1000 {
-            let session_key = OpaqueSessionKey::try_from(GenericArray::from([42; 64]))?;
+            let session_key = create_test_session_key(&mut rng);
 
             let vec: Vec<u8> = session_key.clone().into();
             let output_session_key = vec.try_into()?;

--- a/lock-keeper/src/crypto/storage_key.rs
+++ b/lock-keeper/src/crypto/storage_key.rs
@@ -157,8 +157,7 @@ impl Encrypted<StorageKey> {
 #[cfg(test)]
 pub(super) mod test {
     use super::*;
-    use crate::crypto::KeyId;
-    use generic_array::GenericArray;
+    use crate::crypto::{test::create_test_session_key, KeyId};
     use rand::{rngs::StdRng, Rng, SeedableRng};
     use std::collections::HashSet;
 
@@ -338,7 +337,7 @@ pub(super) mod test {
     fn session_key_encryption_works() -> Result<(), LockKeeperError> {
         let mut rng = rand::thread_rng();
         let encryption_key = RemoteStorageKey::generate(&mut rng);
-        let session_key = OpaqueSessionKey::try_from(GenericArray::from([42; 64]))?;
+        let session_key = create_test_session_key(&mut rng);
         let encrypted = encryption_key.encrypt_session_key(&mut rng, session_key.clone())?;
 
         let result = encrypted.decrypt_session_key(&encryption_key)?;


### PR DESCRIPTION
Closes #415 

Apologies, I think I missed the `create_test_session_key` function the first time!