### PR TITLE
Implements follow-up database ticket #435

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ argon2 = "0.4"
 async-trait = "0.1"
 bincode = "1"
 bytes = { version = "1", features = ["serde"] }
-clap = { version = "3", features = ["derive"] }
+clap = { version = "3", features = ["derive", "env"] }
 futures = "0.3"
 generic-array = "0.14"
 http = "0.2"

--- a/lock-keeper-tests/src/test_suites/database/secret.rs
+++ b/lock-keeper-tests/src/test_suites/database/secret.rs
@@ -1,13 +1,9 @@
 //! Integration tests for secret objects in the database
 
 use colored::Colorize;
-use lock_keeper::{
-    crypto::{Import, KeyId, RemoteStorageKey, Secret, SigningKeyPair, StorageKey},
-    types::database::{secrets::StoredSecret, user::UserId},
-};
 use lock_keeper_key_server::database::{DataStore, SecretFilter};
-use lock_keeper_postgres::{PostgresDB, PostgresError};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use lock_keeper_postgres::PostgresError;
+use rand::{rngs::StdRng, SeedableRng};
 
 use crate::{config::TestFilters, error::Result, run_parallel, utils::TestResult};
 
@@ -36,13 +32,15 @@ async fn user_is_serializable_after_adding_secrets(db: TestDatabase) -> Result<(
     let mut rng = StdRng::from_entropy();
 
     // Create secret of each type and make sure user is valid after each
-    let _ = add_arbitrary_secret(&db, &mut rng, &storage_key, &user_id).await?;
+    let _ = db
+        .add_arbitrary_secret(&mut rng, &storage_key, &user_id)
+        .await?;
     assert!(db.is_user_valid(&account_name).await);
 
-    let _ = import_signing_key(&db, &mut rng, &user_id).await?;
+    let _ = db.import_signing_key(&mut rng, &user_id).await?;
     assert!(db.is_user_valid(&account_name).await);
 
-    let _ = remote_generate_signing_key(&db, &mut rng, &user_id).await?;
+    let _ = db.remote_generate_signing_key(&mut rng, &user_id).await?;
     assert!(db.is_user_valid(&account_name).await);
 
     Ok(())
@@ -60,9 +58,11 @@ async fn cannot_get_another_users_secrets(db: TestDatabase) -> Result<()> {
     let (other_user, _) = db.create_test_user().await?;
 
     // Create secret of each type for first user
-    let key_id1 = add_arbitrary_secret(&db, &mut rng, &storage_key, &user).await?;
-    let key_id2 = import_signing_key(&db, &mut rng, &user).await?;
-    let key_id3 = remote_generate_signing_key(&db, &mut rng, &user).await?;
+    let key_id1 = db
+        .add_arbitrary_secret(&mut rng, &storage_key, &user)
+        .await?;
+    let key_id2 = db.import_signing_key(&mut rng, &user).await?;
+    let key_id3 = db.remote_generate_signing_key(&mut rng, &user).await?;
 
     // Attempt to retrieve each secret using other user's ID. Rust does not support
     // async closures. So we do not refactor this code.
@@ -94,7 +94,7 @@ async fn incorrect_key_type_specified(db: TestDatabase) -> Result<()> {
 
     // Add a user and get their storage key
     let (user, _) = db.create_test_user().await?;
-    let key_id = import_signing_key(&db, &mut rng, &user).await?;
+    let key_id = db.import_signing_key(&mut rng, &user).await?;
 
     assert!(
         db.db
@@ -113,62 +113,4 @@ async fn incorrect_key_type_specified(db: TestDatabase) -> Result<()> {
     ));
 
     Ok(())
-}
-
-async fn add_arbitrary_secret(
-    db: &PostgresDB,
-    rng: &mut StdRng,
-    storage_key: &StorageKey,
-    user_id: &UserId,
-) -> Result<KeyId> {
-    let key_id = KeyId::generate(rng, user_id)?;
-    let (_, encrypted) = Secret::create_and_encrypt(rng, storage_key, user_id, &key_id)?;
-
-    let secret = StoredSecret::from_arbitrary_secret(key_id.clone(), user_id.clone(), encrypted)?;
-    db.add_secret(secret).await?;
-
-    Ok(key_id)
-}
-
-async fn import_signing_key(db: &PostgresDB, rng: &mut StdRng, user_id: &UserId) -> Result<KeyId> {
-    let key_id = KeyId::generate(rng, user_id)?;
-    let random_bytes = rand::thread_rng().gen::<[u8; 32]>().to_vec();
-    let import = Import::new(random_bytes)?;
-    let signing_key = import.into_signing_key(user_id, &key_id)?;
-
-    let encryption_key = RemoteStorageKey::generate(rng);
-
-    // encrypt key_pair
-    let encrypted_key_pair = encryption_key.encrypt_signing_key_pair(rng, signing_key)?;
-
-    let secret = StoredSecret::from_remote_signing_key_pair(
-        key_id.clone(),
-        encrypted_key_pair,
-        user_id.clone(),
-    )?;
-    db.add_secret(secret).await?;
-
-    Ok(key_id)
-}
-
-async fn remote_generate_signing_key(
-    db: &PostgresDB,
-    rng: &mut StdRng,
-    user_id: &UserId,
-) -> Result<KeyId> {
-    let key_id = KeyId::generate(rng, user_id)?;
-    let signing_key = SigningKeyPair::remote_generate(rng, user_id, &key_id);
-
-    let encryption_key = RemoteStorageKey::generate(rng);
-
-    // encrypt key_pair
-    let encrypted_key_pair = encryption_key.encrypt_signing_key_pair(rng, signing_key)?;
-
-    let secret = StoredSecret::from_remote_signing_key_pair(
-        key_id.clone(),
-        encrypted_key_pair,
-        user_id.clone(),
-    )?;
-    db.add_secret(secret).await?;
-    Ok(key_id)
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/operations.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/operations.rs
@@ -70,6 +70,7 @@ pub(crate) async fn check_audit_events(
         LockKeeperClient::authenticated_client(&state.account_name, &state.password, &state.config)
             .await
             .result?;
+
     // Get audit event log for the specific request
     let options = AuditEventOptions {
         request_id: Some(request_id),
@@ -83,7 +84,7 @@ pub(crate) async fn check_audit_events(
     // Get all events that match given expected values.
     let matching_events = audit_event_log
         .into_iter()
-        .filter(|event| event.status == expected_status && event.action == expected_action);
+        .filter(|event| event.status == expected_status && event.client_action == expected_action);
 
     assert_eq!(
         matching_events.count(),

--- a/lock-keeper/src/types/audit_event.rs
+++ b/lock-keeper/src/types/audit_event.rs
@@ -35,7 +35,7 @@ pub struct AuditEvent {
     /// We use [OffsetDateTime] as this is compatible with SQLx. Easily
     /// convertible to a postgres' TIMESTAMPTZ type.
     pub timestamp: OffsetDateTime,
-    pub action: ClientAction,
+    pub client_action: ClientAction,
     pub status: EventStatus,
 }
 
@@ -45,7 +45,7 @@ impl AuditEvent {
     }
 
     pub fn action(&self) -> ClientAction {
-        self.action
+        self.client_action
     }
 
     pub fn key_id(&self) -> Option<&KeyId> {

--- a/lock-keeper/src/types/operations.rs
+++ b/lock-keeper/src/types/operations.rs
@@ -25,26 +25,61 @@ use uuid::Uuid;
 use super::Message;
 
 /// Options for actions the Lock Keeper client can take.
+/// We explicitly assign discriminant values to this type, as it will be stored
+/// in the our database.
 #[derive(
     Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Display, EnumIter, EnumString, Hash,
 )]
 pub enum ClientAction {
-    Authenticate,
-    CreateStorageKey,
-    ExportSecret,
-    ExportSigningKey,
-    GenerateSecret,
-    GetUserId,
-    ImportSigningKey,
-    Logout,
-    Register,
-    RemoteGenerateSigningKey,
-    RemoteSignBytes,
-    RetrieveSecret,
-    RetrieveAuditEvents,
-    RetrieveSigningKey,
-    // System only.
-    RetrieveStorageKey,
+    Authenticate = 0,
+    CreateStorageKey = 1,
+    ExportSecret = 2,
+    ExportSigningKey = 3,
+    GenerateSecret = 4,
+    GetUserId = 5,
+    ImportSigningKey = 6,
+    Logout = 7,
+    Register = 8,
+    RemoteGenerateSigningKey = 9,
+    RemoteSignBytes = 10,
+    RetrieveSecret = 11,
+    RetrieveAuditEvents = 12,
+    RetrieveSigningKey = 13,
+    RetrieveStorageKey = 14,
+}
+
+impl TryFrom<i64> for ClientAction {
+    type Error = i64;
+
+    fn try_from(v: i64) -> Result<Self, Self::Error> {
+        match v {
+            x if x == ClientAction::Authenticate as i64 => Ok(ClientAction::Authenticate),
+            x if x == ClientAction::CreateStorageKey as i64 => Ok(ClientAction::CreateStorageKey),
+            x if x == ClientAction::ExportSecret as i64 => Ok(ClientAction::ExportSecret),
+            x if x == ClientAction::ExportSigningKey as i64 => Ok(ClientAction::ExportSigningKey),
+            x if x == ClientAction::GenerateSecret as i64 => Ok(ClientAction::GenerateSecret),
+            x if x == ClientAction::GetUserId as i64 => Ok(ClientAction::GetUserId),
+            x if x == ClientAction::ImportSigningKey as i64 => Ok(ClientAction::ImportSigningKey),
+            x if x == ClientAction::Logout as i64 => Ok(ClientAction::Logout),
+            x if x == ClientAction::Register as i64 => Ok(ClientAction::Register),
+            x if x == ClientAction::RemoteGenerateSigningKey as i64 => {
+                Ok(ClientAction::RemoteGenerateSigningKey)
+            }
+            x if x == ClientAction::RemoteSignBytes as i64 => Ok(ClientAction::RemoteSignBytes),
+            x if x == ClientAction::RetrieveSecret as i64 => Ok(ClientAction::RetrieveSecret),
+            x if x == ClientAction::RetrieveAuditEvents as i64 => {
+                Ok(ClientAction::RetrieveAuditEvents)
+            }
+            x if x == ClientAction::RetrieveSigningKey as i64 => {
+                Ok(ClientAction::RetrieveSigningKey)
+            }
+            x if x == ClientAction::RetrieveStorageKey as i64 => {
+                Ok(ClientAction::RetrieveStorageKey)
+            }
+            // Return value of offending integer.
+            _ => Err(v),
+        }
+    }
 }
 
 /// Converts a serializable Rust type to and from the RPC [`Message`] type.
@@ -133,5 +168,19 @@ impl TryFrom<&MetadataValue<Ascii>> for RequestMetadata {
         let bytes = value.as_bytes();
         let metadata = serde_json::from_slice(bytes)?;
         Ok(metadata)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::types::operations::ClientAction;
+    use strum::IntoEnumIterator;
+
+    /// Ensure our conversion function covers all cases.
+    #[test]
+    fn client_action_conversion_exhaustive() {
+        for action in ClientAction::iter() {
+            assert_eq!(action, ClientAction::try_from(action as i64).unwrap());
+        }
     }
 }

--- a/persistence/lock-keeper-session-cache-sql/src/error.rs
+++ b/persistence/lock-keeper-session-cache-sql/src/error.rs
@@ -1,4 +1,4 @@
-use std::{array::TryFromSliceError, env::VarError, path::PathBuf};
+use std::{array::TryFromSliceError, path::PathBuf};
 
 use lock_keeper_key_server::server::session_cache::SessionCacheError;
 use thiserror::Error;
@@ -41,8 +41,8 @@ pub enum ConfigError {
     ConfigFileReadFailure(std::io::Error, PathBuf),
     #[error("Fail to read TOML file contents.")]
     TomlReadFailure(#[from] toml::de::Error),
-    #[error("Failed to get database username: {0}")]
-    MissingUsername(VarError),
-    #[error("Failed to get database password: {0}")]
-    MissingPassword(VarError),
+    #[error("Missing session cache username.")]
+    MissingUsername,
+    #[error("Missing session cache password.")]
+    MissingPassword,
 }

--- a/persistence/lock-keeper-sql/src/error.rs
+++ b/persistence/lock-keeper-sql/src/error.rs
@@ -1,4 +1,4 @@
-use std::{array::TryFromSliceError, env::VarError, path::PathBuf};
+use std::{array::TryFromSliceError, path::PathBuf};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -29,8 +29,8 @@ pub enum ConfigError {
     ConfigFileReadFailure(std::io::Error, PathBuf),
     #[error("Fail to read TOML file contents.")]
     TomlReadFailure(#[from] toml::de::Error),
-    #[error("Failed to get database username: {0}")]
-    MissingUsername(VarError),
-    #[error("Failed to get database password: {0}")]
-    MissingPassword(VarError),
+    #[error("Missing database username.")]
+    MissingUsername,
+    #[error("Missing database password.")]
+    MissingPassword,
 }

--- a/persistence/migrations/1000_create_main_db_tables.sql
+++ b/persistence/migrations/1000_create_main_db_tables.sql
@@ -1,9 +1,48 @@
+-- Maps client actions to unique ID
+CREATE TABLE IF NOT EXISTS ClientActionsTypes (
+    client_action_id BIGINT PRIMARY KEY UNIQUE NOT NULL,
+    client_action VARCHAR(50) UNIQUE NOT NULL
+);
+
+-- These can be found in lock-keeper/src/types/operations.rs
+INSERT INTO ClientActionsTypes (client_action_id, client_action)
+VALUES
+    (0, 'Authenticate'),
+    (1, 'CreateStorageKey'),
+    (2, 'ExportSecret'),
+    (3, 'ExportSigningKey'),
+    (4, 'GenerateSecret'),
+    (5, 'GetUserId'),
+    (6, 'ImportSigningKey'),
+    (7, 'Logout'),
+    (8, 'Register'),
+    (9, 'RemoteGenerateSigningKey'),
+    (10, 'RemoteSignBytes'),
+    (11, 'RetrieveSecret'),
+    (12, 'RetrieveAuditEvents'),
+    (13, 'RetrieveSigningKey'),
+    (14, 'RetrieveStorageKey')
+ON CONFLICT (client_action_id) DO NOTHING;
+
+-- Maps secret types to unique ID
+CREATE TABLE IF NOT EXISTS SecretTypes (
+    secret_type_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    secret_type VARCHAR(50) UNIQUE NOT NULL
+);
+
+-- These can be found in /lock-keeper/src/types/database/secrets.rs
+INSERT INTO SecretTypes (secret_type)
+VALUES
+    ('arbitrary_secret'),
+    ('remote_signing_key'),
+    ('signing_key_pair')
+ON CONFLICT (secret_type) DO NOTHING;
+
 CREATE TABLE IF NOT EXISTS Accounts
 (
     account_id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
     user_id BYTEA UNIQUE NOT NULL,
-    -- TODO: Introduce auxiliary table for mapping account_name <-> unique integer.
-    account_name VARCHAR(30) UNIQUE NOT NULL,
+    account_name VARCHAR(50) UNIQUE NOT NULL,
     storage_key BYTEA,
     server_registration BYTEA NOT NULL
 );
@@ -11,31 +50,30 @@ CREATE TABLE IF NOT EXISTS Accounts
 CREATE TABLE IF NOT EXISTS Secrets
 (
     secret_id BIGINT GENERATED ALWAYS AS IDENTITY,
+
     key_id BYTEA UNIQUE NOT NULL,
     user_id BYTEA NOT NULL,
-    -- TODO: Use account_id from Accounts table instead of user_id.
+    -- TODO: Use account_id from Accounts table instead of user_id. See Issue #442
     -- account_id BIGINT NOT NULL,
     secret BYTEA NOT NULL,
-    secret_type TEXT NOT NULL,
-    -- TODO: Utilize this field.
+    secret_type_id BIGINT NOT NULL,
     retrieved BOOL NOT NULL,
     PRIMARY KEY (secret_id),
-    FOREIGN KEY (user_id) REFERENCES Accounts(user_id)
-    -- FOREIGN KEY (account_id) REFERENCES Accounts(account_id)
+    FOREIGN KEY (user_id) REFERENCES Accounts(user_id),
+    FOREIGN KEY (secret_type_id) REFERENCES SecretTypes(secret_type_id)
 );
 
 CREATE TABLE IF NOT EXISTS AuditEvents
 (
     audit_event_id BIGINT GENERATED ALWAYS AS IDENTITY,
-    -- TODO: Use account_id from Accounts table instead of account_name.
+    -- TODO: Use account_id from Accounts table instead of account_name. See Issue #443
     -- account_id BIGSERIAL NOT NULL,
-    account_name VARCHAR(30) NOT NULL,
+    account_name VARCHAR(50) NOT NULL,
     key_id BYTEA,
     request_id UUID NOT NULL,
-    action TEXT NOT NULL,
+    client_action_id BIGINT NOT NULL,
     event_status TEXT NOT NULL,
     timestamp TIMESTAMPTZ NOT NULL,
-    PRIMARY KEY (audit_event_id)
-    -- FOREIGN KEY (account_id) REFERENCES Accounts(account_id),
-    -- FOREIGN KEY (key_id) REFERENCES Secrets(key_id)
+    PRIMARY KEY (audit_event_id),
+    FOREIGN KEY (client_action_id) REFERENCES ClientActionsTypes(client_action_id)
 );

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -13,6 +13,22 @@
     },
     "query": "UPDATE Accounts SET storage_key=$1 WHERE user_id=$2"
   },
+  "1a5b3c8c45c335fc7175396aa3911167c5c93c1cd38ef1af25118fb9334591ce": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Bytea",
+          "Bytea",
+          "Bool",
+          "Text"
+        ]
+      }
+    },
+    "query": "INSERT INTO Secrets (key_id, user_id, secret, secret_type_id, retrieved) SELECT $1, $2, $3, SecretTypes.secret_type_id, $4 FROM SecretTypes WHERE SecretTypes.secret_type=$5"
+  },
   "2f7e466e183916bcef3e01a48bdbfd5ead68bafbdf877b7f8aa2f84595113627": {
     "describe": {
       "columns": [
@@ -98,7 +114,7 @@
     },
     "query": "INSERT INTO Session (user_id, session_key) VALUES ($1, $2) RETURNING session_id"
   },
-  "638f9e1ec3582aa0f42729cf0dcc031784b0b2d7051152bd6d638a9f0b31a975": {
+  "5113b063905dd02a364fd46625ce66fa903916312273d66d709bb47355fad6ac": {
     "describe": {
       "columns": [
         {
@@ -114,7 +130,7 @@
         {
           "name": "secret_type",
           "ordinal": 2,
-          "type_info": "Text"
+          "type_info": "Varchar"
         },
         {
           "name": "secret",
@@ -142,7 +158,7 @@
         ]
       }
     },
-    "query": "UPDATE Secrets SET retrieved=TRUE WHERE key_id=$1 AND user_id=$2 AND secret_type LIKE $3 RETURNING key_id, user_id, secret_type, secret, retrieved"
+    "query": "UPDATE Secrets SET retrieved=TRUE FROM Secrets S LEFT JOIN SecretTypes ST ON S.secret_type_id=ST.secret_type_id WHERE S.key_id=$1 AND S.user_id=$2 AND ST.secret_type LIKE $3 RETURNING S.key_id, S.user_id, ST.secret_type, S.secret, S.retrieved"
   },
   "6bb4786a839134fd11cb2e84df34b2a3bb5158c9a82c6a4f798a766077328492": {
     "describe": {
@@ -239,21 +255,22 @@
     },
     "query": "DELETE FROM Session WHERE session_id=$1"
   },
-  "a9078aa304e311b5d3459c32a2d36853a810d95f1c6bb12c4e254cd04aaa4cfb": {
+  "94a5ed04091f4775cd371b1d0e8ea292df47864e5bb2333ed0dca29526bb75d4": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
         "Left": [
+          "Varchar",
           "Bytea",
-          "Bytea",
-          "Bytea",
+          "Uuid",
+          "Int8",
           "Text",
-          "Bool"
+          "Timestamptz"
         ]
       }
     },
-    "query": "INSERT INTO Secrets (key_id, user_id, secret, secret_type, retrieved) VALUES ($1, $2, $3, $4, $5)"
+    "query": "INSERT INTO AuditEvents (account_name, key_id, request_id, client_action_id, event_status, timestamp) VALUES ($1, $2, $3, $4, $5, $6)"
   },
   "b35d2924ad509e3ac7d4adf71b571472530c61b824c9b67197bb7ecc7f6d8ecd": {
     "describe": {
@@ -288,22 +305,5 @@
       }
     },
     "query": "SELECT COUNT(1) as \"count!\" FROM Secrets WHERE key_id=$1"
-  },
-  "df4a3e36034bbfa9642e21ad88a9de82e5f1ddbcec5779ae3fb1c08f86786cfe": {
-    "describe": {
-      "columns": [],
-      "nullable": [],
-      "parameters": {
-        "Left": [
-          "Varchar",
-          "Bytea",
-          "Uuid",
-          "Text",
-          "Text",
-          "Timestamptz"
-        ]
-      }
-    },
-    "query": "INSERT INTO AuditEvents (account_name, key_id, request_id, action, event_status, timestamp) VALUES ($1, $2, $3, $4, $5, $6)"
   }
 }


### PR DESCRIPTION
Closes #435

This PR implements the following changes:
- [x] Ensure integration tests generate AuditEvents based on valid key_ids to make database happy.
- [x] Add lookup table for client actions and use it in queries.
- [x] Add lookup table for secret types and use it in queries.
- [x] Add CLI and env var options for session cache and persistent storage username and password.
- [x] Clean up database logging.