### PR TITLE
Make a separate database error type within the server #366

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+**/logs/

--- a/lock-keeper-key-server/src/operations/authenticate.rs
+++ b/lock-keeper-key-server/src/operations/authenticate.rs
@@ -59,15 +59,11 @@ async fn authenticate_start<DB: DataStore>(
 
     // Check that user with corresponding UserId exists and get their
     // server_registration
-    let (server_registration, user_id) = match context
-        .db
-        .find_account(&start_message.account_name)
-        .await
-        .map_err(LockKeeperServerError::database)?
-    {
-        Some(user) => user.into_parts(),
-        None => return Err(LockKeeperServerError::InvalidAccount),
-    };
+    let (server_registration, user_id) =
+        match context.db.find_account(&start_message.account_name).await? {
+            Some(user) => user.into_parts(),
+            None => return Err(LockKeeperServerError::InvalidAccount),
+        };
 
     logging::record_field("user_id", &user_id);
     debug!("User ID found.");

--- a/lock-keeper-key-server/src/operations/generate_secret.rs
+++ b/lock-keeper-key-server/src/operations/generate_secret.rs
@@ -96,11 +96,7 @@ async fn store_key<DB: DataStore>(
     )?;
 
     // Check validity of ciphertext and store in DB
-    context
-        .db
-        .add_secret(secret)
-        .await
-        .map_err(LockKeeperServerError::database)?;
+    context.db.add_secret(secret).await?;
     info!("Client's cypher text stored successfully.");
 
     // Reply with the success:true if successful

--- a/lock-keeper-key-server/src/operations/import_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/import_signing_key.rs
@@ -63,11 +63,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for ImportSigningKey {
         )?;
 
         // Check validity of ciphertext and store in DB
-        context
-            .db
-            .add_secret(secret)
-            .await
-            .map_err(LockKeeperServerError::database)?;
+        context.db.add_secret(secret).await?;
 
         // Serialize KeyId and send to client
         let reply = server::Response {

--- a/lock-keeper-key-server/src/operations/register.rs
+++ b/lock-keeper-key-server/src/operations/register.rs
@@ -51,11 +51,7 @@ async fn register_start<DB: DataStore>(
     let start_message: client::RegisterStart = channel.receive().await?;
 
     // Abort registration if UserId already exists
-    let user = context
-        .db
-        .find_account(&start_message.account_name)
-        .await
-        .map_err(LockKeeperServerError::database)?;
+    let user = context.db.find_account(&start_message.account_name).await?;
 
     match user {
         // Abort registration if UserId already exists
@@ -105,19 +101,12 @@ async fn register_finish<DB: DataStore>(
         };
 
         // If the user ID is fresh, create the new user
-        if context
-            .db
-            .find_account_by_id(&user_id)
-            .await
-            .map_err(LockKeeperServerError::database)?
-            .is_none()
-        {
+        if context.db.find_account_by_id(&user_id).await?.is_none() {
             info!("Fresh user id generated: {:?}", user_id);
             let _user = context
                 .db
                 .create_account(&user_id, account_name, &server_registration)
-                .await
-                .map_err(LockKeeperServerError::database)?;
+                .await?;
             break;
         }
     }

--- a/lock-keeper-key-server/src/operations/remote_generate_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/remote_generate_signing_key.rs
@@ -63,11 +63,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RemoteGenerateSigni
         )?;
 
         // Store key in database
-        context
-            .db
-            .add_secret(secret)
-            .await
-            .map_err(LockKeeperServerError::database)?;
+        context.db.add_secret(secret).await?;
 
         channel
             .send(server::ReturnKeyId { key_id, public_key })

--- a/lock-keeper-key-server/src/operations/remote_sign_bytes.rs
+++ b/lock-keeper-key-server/src/operations/remote_sign_bytes.rs
@@ -41,8 +41,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RemoteSignBytes {
         let encrypted_key: Encrypted<SigningKeyPair> = context
             .db
             .get_secret(user_id, &request.key_id, Default::default())
-            .await
-            .map_err(LockKeeperServerError::database)?
+            .await?
             .try_into()?;
         info!("Signing key found. Signing...");
 

--- a/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_audit_events.rs
@@ -31,8 +31,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RetrieveAuditEvents
         let audit_events = context
             .db
             .find_audit_events(account_name, request.event_type, request.options)
-            .await
-            .map_err(LockKeeperServerError::database)?;
+            .await?;
 
         let reply = server::Response {
             summary_record: audit_events,

--- a/lock-keeper-key-server/src/operations/retrieve_secret.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_secret.rs
@@ -44,8 +44,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RetrieveSecret {
         let stored_secret = context
             .db
             .get_secret(user_id, &request.key_id, secret_filter)
-            .await
-            .map_err(LockKeeperServerError::database)?;
+            .await?;
 
         let reply = server::Response {
             secret: RetrievedSecret::try_from_stored_secret(

--- a/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_storage_key.rs
@@ -31,8 +31,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RetrieveStorageKey 
         let user = context
             .db
             .find_account_by_id(user_id)
-            .await
-            .map_err(LockKeeperServerError::database)?
+            .await?
             .ok_or(LockKeeperServerError::InvalidAccount)?;
 
         // Send storage key if set

--- a/lock-keeper-key-server/src/server.rs
+++ b/lock-keeper-key-server/src/server.rs
@@ -168,8 +168,7 @@ impl<DB: DataStore> LockKeeperRpc for LockKeeperKeyServer<DB> {
         let user_id = context
             .db
             .find_account(metadata.account_name())
-            .await
-            .map_err(LockKeeperServerError::database)?
+            .await?
             .ok_or(LockKeeperServerError::InvalidAccount)?
             .user_id;
 

--- a/lock-keeper-key-server/src/server/operation.rs
+++ b/lock-keeper-key-server/src/server/operation.rs
@@ -80,9 +80,8 @@ async fn audit_event<AUTH, DB: DataStore>(
     let audit_event = context
         .db
         .create_audit_event(request_id, account_name, &context.key_id, action, status)
-        .await
-        .map_err(|e| LockKeeperServerError::Database(Box::new(e)));
+        .await;
     if let Err(e) = audit_event {
-        handle_error(channel, e).await;
+        handle_error(channel, e.into()).await;
     };
 }

--- a/lock-keeper-tests/src/error.rs
+++ b/lock-keeper-tests/src/error.rs
@@ -36,6 +36,8 @@ pub enum LockKeeperTestError {
     LockKeeperSessionCache(#[from] SessionCachePostgresError),
     #[error("SessionCacheError: {0:?}")]
     SessionCache(#[from] lock_keeper_key_server::server::session_cache::SessionCacheError),
+    #[error("DatabaseError: {0:?}")]
+    Database(#[from] lock_keeper_key_server::database::DatabaseError),
     #[error("PostgresError error: {0:?}")]
     LockKeeperPostgres(#[from] PostgresError),
     #[error("RandError: {0:?}")]

--- a/lock-keeper-tests/src/test_suites/database/secret.rs
+++ b/lock-keeper-tests/src/test_suites/database/secret.rs
@@ -1,8 +1,7 @@
 //! Integration tests for secret objects in the database
 
 use colored::Colorize;
-use lock_keeper_key_server::database::{DataStore, SecretFilter};
-use lock_keeper_postgres::PostgresError;
+use lock_keeper_key_server::database::{DataStore, DatabaseError, SecretFilter};
 use rand::{rngs::StdRng, SeedableRng};
 
 use crate::{config::TestFilters, error::Result, run_parallel, utils::TestResult};
@@ -70,19 +69,19 @@ async fn cannot_get_another_users_secrets(db: TestDatabase) -> Result<()> {
         db.db
             .get_secret(&other_user, &key_id1, Default::default())
             .await,
-        Err(PostgresError::IncorrectAssociatedKeyData)
+        Err(DatabaseError::IncorrectKeyMetadata)
     ));
     assert!(matches!(
         db.db
             .get_secret(&other_user, &key_id2, Default::default())
             .await,
-        Err(PostgresError::IncorrectAssociatedKeyData)
+        Err(DatabaseError::IncorrectKeyMetadata)
     ));
     assert!(matches!(
         db.db
             .get_secret(&other_user, &key_id3, Default::default())
             .await,
-        Err(PostgresError::IncorrectAssociatedKeyData)
+        Err(DatabaseError::IncorrectKeyMetadata)
     ));
 
     Ok(())
@@ -109,7 +108,7 @@ async fn incorrect_key_type_specified(db: TestDatabase) -> Result<()> {
         db.db
             .get_secret(&user, &key_id, SecretFilter::secret_type("Foo"))
             .await,
-        Err(PostgresError::IncorrectAssociatedKeyData)
+        Err(DatabaseError::IncorrectKeyMetadata)
     ));
 
     Ok(())

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
@@ -12,6 +12,11 @@ pub mod remote_generate;
 pub mod remote_sign;
 pub mod retrieve;
 
+pub(crate) const NO_ENTRY_FOUND: &str = "No such entry in table.";
+pub(crate) const NO_SESSION: &str = "No session for this user";
+pub(crate) const WRONG_KEY_DATA: &str =
+    "Key ID exists but associated user ID or key type were incorrect.";
+
 pub(crate) struct TestState {
     pub(crate) account_name: AccountName,
     pub(crate) password: Password,

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
@@ -9,7 +9,7 @@ use crate::{
     run_parallel,
     test_suites::end_to_end::{
         operations::{authenticate, check_audit_events, compare_status_errors},
-        test_cases::init_test_state,
+        test_cases::{init_test_state, NO_SESSION},
     },
     utils::TestResult,
 };
@@ -50,7 +50,7 @@ async fn cannot_generate_after_logout(config: Config) -> Result<()> {
     client.logout().await.result?;
 
     let res = client.generate_secret().await;
-    compare_status_errors(res, Status::unauthenticated("No session key for this user"))?;
+    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
 
     Ok(())
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
@@ -9,7 +9,7 @@ use crate::{
     run_parallel,
     test_suites::end_to_end::{
         operations::{authenticate, check_audit_events, compare_status_errors, import_signing_key},
-        test_cases::init_test_state,
+        test_cases::{init_test_state, NO_SESSION},
     },
     utils::TestResult,
 };
@@ -51,7 +51,7 @@ async fn cannot_import_after_logout(config: Config) -> Result<()> {
     client.logout().await.result?;
 
     let res = import_signing_key(&client).await;
-    compare_status_errors(res, Status::unauthenticated("No session key for this user"))?;
+    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
 
     Ok(())
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
@@ -9,7 +9,7 @@ use crate::{
     run_parallel,
     test_suites::end_to_end::{
         operations::{authenticate, check_audit_events, compare_status_errors},
-        test_cases::init_test_state,
+        test_cases::{init_test_state, NO_SESSION},
     },
     utils::TestResult,
 };
@@ -52,7 +52,7 @@ async fn cannot_remote_generate_after_logout(config: Config) -> Result<()> {
     client.logout().await.result?;
 
     let res = client.remote_generate().await;
-    compare_status_errors(res, Status::unauthenticated("No session key for this user"))?;
+    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
 
     Ok(())
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_sign.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_sign.rs
@@ -14,7 +14,7 @@ use crate::{
     run_parallel,
     test_suites::end_to_end::{
         operations::{authenticate, check_audit_events, compare_status_errors},
-        test_cases::init_test_state,
+        test_cases::{init_test_state, NO_SESSION},
     },
     utils::{self, TestResult, RNG_SEED},
 };
@@ -74,7 +74,7 @@ async fn cannot_remote_sign_after_logout(config: Config) -> Result<()> {
     let mut rng = StdRng::from_seed(*RNG_SEED);
     let data = SignableBytes(utils::random_bytes(&mut rng, 100));
     let res = client.remote_sign_bytes(res.key_id, data).await;
-    compare_status_errors(res, Status::unauthenticated("No session key for this user"))?;
+    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
 
     Ok(())
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
@@ -15,7 +15,7 @@ use crate::{
             authenticate, check_audit_events, compare_errors, compare_status_errors,
             generate_fake_key_id,
         },
-        test_cases::init_test_state,
+        test_cases::{init_test_state, NO_ENTRY_FOUND, NO_SESSION},
     },
     utils::TestResult,
 };
@@ -95,7 +95,7 @@ async fn cannot_retrieve_fake_key(config: Config) -> Result<()> {
         .retrieve_secret(&fake_key_id, RetrieveContext::LocalOnly)
         .await;
     let request_id = local_storage_res.metadata.clone().unwrap().request_id;
-    compare_errors(local_storage_res, Status::internal("Internal server error"));
+    compare_errors(local_storage_res, Status::internal(NO_ENTRY_FOUND));
     check_audit_events(
         &state,
         EventStatus::Failed,
@@ -119,7 +119,7 @@ async fn cannot_retrieve_after_logout(config: Config) -> Result<()> {
     client.logout().await.result?;
 
     let res = client.retrieve_secret(&key_id, RetrieveContext::Null).await;
-    compare_status_errors(res, Status::unauthenticated("No session key for this user"))?;
+    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
 
     Ok(())
 }


### PR DESCRIPTION
Closes #366 

This is mostly just directly passing the existing error messages from the postgres crate to the server, but I had some questions:
- Do the "no entry" and "invalid count" errors need to be split into which table they came from (e.g. "no such key" vs. "no such user") or can we assume based on where the error originates?
- @gatoWololo I mapped the "EmptyIterator" error to "InvalidAuditEventOptions" since that's the only place I saw it used - do you anticipate it being used elsewhere? Or should the one in the postgres crate also say something about the audit event options?

I also changed the "associated key data" error to say key "metadata" instead since associated data is a thing on its own, but I'm not really sure about using the word "metadata" either.