### PR TITLE
Added docker image for fully set up database

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -8,10 +8,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  KEY_SERVER_IMAGE_NAME: ${{ github.repository_owner }}/lock-keeper-key-server
+  TEST_DB_IMAGE_NAME: ${{ github.repository_owner }}/lock-keeper-test-db
 
 jobs:
-  build-and-push-images:
+  build-and-push-key-server-image:
     runs-on: ubuntu-latest
 
     permissions:
@@ -35,7 +36,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.KEY_SERVER_IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=sha
@@ -44,6 +45,43 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+
+  build-and-push-test-db-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: metadata
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.TEST_DB_IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./persistence
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
 
   postgres:
-      image: postgres
+      build: ./persistence
       restart: always
       environment:
         # The container will create a postgres user with this name and password. We use these to connect to our DB.
@@ -11,11 +11,6 @@ services:
         - POSTGRES_PASSWORD=test_password
       ports:
         - "5432:5432"
-      volumes:
-          # This postgres image will automatically look in the `/docker-entrypoint-initdb.d/` directory for any
-          # SQL files and execute them during container initialization. So our container will be all set up after
-          # it runs this script.
-          - ./persistence/migrations/:/docker-entrypoint-initdb.d/
       stdin_open: true
       tty: true
 

--- a/persistence/Dockerfile
+++ b/persistence/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:latest
+
+COPY ./migrations/ /docker-entrypoint-initdb.d/


### PR DESCRIPTION
This PR creates a separate Docker image for a database that includes our migrations and pushes this image to the container registry.

This will allow us to use the key server and database in other projects without having to run migrations on the DB.