### PR TITLE
AccountName::from_str now uses standard error type

### DIFF
--- a/lock-keeper/src/types/database/account.rs
+++ b/lock-keeper/src/types/database/account.rs
@@ -157,7 +157,7 @@ impl AsRef<str> for AccountName {
 }
 
 impl FromStr for AccountName {
-    type Err = ();
+    type Err = LockKeeperError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(AccountName(s.to_string()))


### PR DESCRIPTION
You have a couple choices for how to handle `()` as an error type when you're consuming this from another crate.

You can implement `From<()>` for your crate's error type, which is an objectively terrible idea.

You can `unwrap` or `expect` the error because you know it's safe. This means that you can't easily audit the repo for `unwrap` and `expect` because now there are valid uses for them.

We could also switch it to `std::convert::Infallible` which is a more appropriate pattern, but this still just encourages `unwrap` or `expect` instead of just using `?`.

So I gave it the normal error type so that we can treat it like any other `from_str`.