### PR TITLE
Clean up error handling in server CLI main.

### DIFF
--- a/bin/key-server-cli/src/config.rs
+++ b/bin/key-server-cli/src/config.rs
@@ -1,5 +1,6 @@
 //! Config for key server binary.
 
+use lock_keeper_key_server::LockKeeperServerError;
 use serde::{Deserialize, Serialize};
 use std::{
     path::{Path, PathBuf},
@@ -15,10 +16,10 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn from_file(config_path: impl AsRef<Path>) -> Self {
-        let config_string =
-            std::fs::read_to_string(&config_path).expect("Unable to read from config file.");
-        Self::from_str(&config_string).expect("Unable to convert config to TOML.")
+    pub fn from_file(config_path: impl AsRef<Path>) -> Result<Self, LockKeeperServerError> {
+        let config_string = std::fs::read_to_string(&config_path)
+            .map_err(|e| LockKeeperServerError::FileIo(e, config_path.as_ref().to_path_buf()))?;
+        Ok(Self::from_str(&config_string)?)
     }
 }
 

--- a/lock-keeper-key-server/src/config.rs
+++ b/lock-keeper-key-server/src/config.rs
@@ -33,7 +33,8 @@ impl Config {
         private_key_bytes: Option<Vec<u8>>,
         remote_storage_key_bytes: Option<Vec<u8>>,
     ) -> Result<Self, LockKeeperServerError> {
-        let config_string = std::fs::read_to_string(&config_path)?;
+        let config_string = std::fs::read_to_string(&config_path)
+            .map_err(|e| LockKeeperServerError::FileIo(e, config_path.as_ref().to_path_buf()))?;
         let config_file = ConfigFile::from_str(&config_string)?;
         Self::from_config_file(config_file, private_key_bytes, remote_storage_key_bytes)
     }


### PR DESCRIPTION
- Closes #459.
- Adds extra error variant for `LockKeeperServerError` for reporting file IO failures.
- Uses display for errors propegated up to main.
- Adds more explicit messages for remaining unwrap failures in main.rs.