### PR TITLE
Implement AsRef<[u8]> for KeyId

### DIFF
--- a/lock-keeper/src/crypto.rs
+++ b/lock-keeper/src/crypto.rs
@@ -286,6 +286,12 @@ impl TryFrom<&[u8]> for KeyId {
     }
 }
 
+impl AsRef<[u8]> for KeyId {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl KeyId {
     /// Generate a new, random `KeyId` for the given [`UserId`].
     ///
@@ -333,12 +339,6 @@ impl Debug for KeyId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let hex = hex::encode(*self.0);
         f.debug_tuple("KeyId").field(&hex).finish()
-    }
-}
-
-impl From<KeyId> for HexBytes {
-    fn from(key_id: KeyId) -> Self {
-        (*key_id.0).into()
     }
 }
 


### PR DESCRIPTION
It's time for this madness to stop. We shouldn't have to allocate a vector and turn this into an iterator to get its bytes.

current:
```
    let key_id: HexBytes = maestro
        .client
        .remote_generate()
        .await
        .result?
        .key_id
        .into_iter()
        .collect::<Vec<u8>>()
        .into();
```

desired:
```
    let key_id = maestro
        .client
        .remote_generate()
        .await
        .result?
        .key_id
        .as_ref()
        .into();
```

There's no misuse resistance in the current implementation where `into_iter` is the only option.