### PR TITLE
Add FileIO Error variant to `LockKeeperError`.

### DIFF
--- a/lock-keeper/src/crypto/storage_key.rs
+++ b/lock-keeper/src/crypto/storage_key.rs
@@ -28,7 +28,8 @@ impl RemoteStorageKey {
     /// Returns the remote storage key found in the file at the given
     /// path
     pub fn read_from_file(path: impl AsRef<Path>) -> Result<Self, LockKeeperError> {
-        let bytes = std::fs::read(path)?;
+        let bytes = std::fs::read(&path)
+            .map_err(|e| LockKeeperError::FileIo(e, path.as_ref().to_path_buf()))?;
         Self::from_bytes(&bytes)
     }
 

--- a/lock-keeper/src/infrastructure/pem_utils.rs
+++ b/lock-keeper/src/infrastructure/pem_utils.rs
@@ -8,7 +8,8 @@ use crate::LockKeeperError;
 
 /// Returns all certificates in the pemfile at the given path
 pub fn read_certificates(path: impl AsRef<Path>) -> Result<Vec<Certificate>, LockKeeperError> {
-    let fd = std::fs::File::open(path.as_ref())?;
+    let fd = std::fs::File::open(path.as_ref())
+        .map_err(|e| LockKeeperError::FileIo(e, path.as_ref().to_path_buf()))?;
     let mut buf = std::io::BufReader::new(&fd);
     let certs = rustls_pemfile::certs(&mut buf)?
         .into_iter()
@@ -20,7 +21,8 @@ pub fn read_certificates(path: impl AsRef<Path>) -> Result<Vec<Certificate>, Loc
 
 /// Returns the first private key found in the pemfile at the given path
 pub fn read_private_key_from_file(path: impl AsRef<Path>) -> Result<PrivateKey, LockKeeperError> {
-    let bytes = std::fs::read(path)?;
+    let bytes = std::fs::read(&path)
+        .map_err(|e| LockKeeperError::FileIo(e, path.as_ref().to_path_buf()))?;
     read_private_key_from_bytes(&bytes)
 }
 


### PR DESCRIPTION
I think we are catching all the file reads now.