### PR TITLE
Make TLS optional in the client

### DIFF
--- a/lock-keeper-client/src/api.rs
+++ b/lock-keeper-client/src/api.rs
@@ -44,7 +44,14 @@ pub struct LocalStorage<T> {
     pub material: T,
 }
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T>
+where
+    T: Clone,
+    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T::Error: Into<tonic::codegen::StdError>,
+    T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
+{
     /// Ping the server to make sure it is running and reachable
     pub async fn health(config: &Config) -> Result<(), LockKeeperClientError> {
         use lock_keeper::rpc::HealthCheck;

--- a/lock-keeper-client/src/api/authenticate.rs
+++ b/lock-keeper-client/src/api/authenticate.rs
@@ -17,7 +17,7 @@ use opaque_ke::{ClientLogin, ClientLoginFinishParameters, ClientLoginStartResult
 use rand::rngs::StdRng;
 use tokio::sync::Mutex;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T> {
     pub(crate) async fn handle_authentication(
         mut channel: Channel<Unauthenticated>,
         rng: Arc<Mutex<StdRng>>,

--- a/lock-keeper-client/src/api/create_storage_key.rs
+++ b/lock-keeper-client/src/api/create_storage_key.rs
@@ -1,6 +1,6 @@
 use crate::{
     channel::{Authenticated, Channel},
-    client::LockKeeperClient,
+    client::{LockKeeperClient, LockKeeperRpcClientInner},
     LockKeeperClientError,
 };
 use lock_keeper::{
@@ -14,12 +14,12 @@ use rand::{rngs::StdRng, CryptoRng, RngCore};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<LockKeeperRpcClientInner<T>> {
     /// Creates a storage key and sends it to the key server
-    pub(crate) async fn handle_create_storage_key<T: CryptoRng + RngCore>(
+    pub(crate) async fn handle_create_storage_key<R: CryptoRng + RngCore>(
         &self,
         mut channel: Channel<Authenticated<StdRng>>,
-        rng: Arc<Mutex<T>>,
+        rng: Arc<Mutex<R>>,
         master_key: MasterKey,
     ) -> Result<(), LockKeeperClientError> {
         let user_id = self.user_id().clone();

--- a/lock-keeper-client/src/api/generate_secret.rs
+++ b/lock-keeper-client/src/api/generate_secret.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::LocalStorage,
     channel::{Authenticated, Channel},
-    LockKeeperClient, LockKeeperClientError,
+    LockKeeperClient, LockKeeperClientError, client::LockKeeperRpcClientInner,
 };
 use lock_keeper::{
     crypto::{KeyId, Secret, StorageKey},
@@ -21,7 +21,7 @@ pub struct GenerateResult {
     pub local_storage: LocalStorage<Secret>,
 }
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<LockKeeperRpcClientInner<T>> {
     pub(crate) async fn handle_generate_secret(
         &self,
         mut channel: Channel<Authenticated<StdRng>>,

--- a/lock-keeper-client/src/api/get_user_id.rs
+++ b/lock-keeper-client/src/api/get_user_id.rs
@@ -6,7 +6,7 @@ use lock_keeper::types::{database::account::UserId, operations::get_user_id::ser
 
 use rand::rngs::StdRng;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T> {
     pub(crate) async fn handle_get_user_id(
         mut channel: Channel<Authenticated<StdRng>>,
     ) -> Result<UserId, LockKeeperClientError> {

--- a/lock-keeper-client/src/api/import.rs
+++ b/lock-keeper-client/src/api/import.rs
@@ -8,7 +8,7 @@ use lock_keeper::{
 };
 use rand::rngs::StdRng;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T> {
     pub(crate) async fn handle_import_signing_key(
         &self,
         mut channel: Channel<Authenticated<StdRng>>,

--- a/lock-keeper-client/src/api/register.rs
+++ b/lock-keeper-client/src/api/register.rs
@@ -18,7 +18,7 @@ use rand::rngs::StdRng;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T> {
     pub(crate) async fn handle_registration(
         mut channel: Channel<Unauthenticated>,
         rng: Arc<Mutex<StdRng>>,

--- a/lock-keeper-client/src/api/remote_generate_signing_key.rs
+++ b/lock-keeper-client/src/api/remote_generate_signing_key.rs
@@ -9,7 +9,7 @@ use lock_keeper::{
 use rand::rngs::StdRng;
 use serde::{Deserialize, Serialize};
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T> {
     pub(crate) async fn handle_remote_generate_signing_key(
         &self,
         mut channel: Channel<Authenticated<StdRng>>,

--- a/lock-keeper-client/src/api/remote_sign_bytes.rs
+++ b/lock-keeper-client/src/api/remote_sign_bytes.rs
@@ -8,7 +8,7 @@ use lock_keeper::{
 };
 use rand::rngs::StdRng;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T> {
     pub(crate) async fn handle_remote_sign_bytes(
         &self,
         mut channel: Channel<Authenticated<StdRng>>,

--- a/lock-keeper-client/src/api/retrieve.rs
+++ b/lock-keeper-client/src/api/retrieve.rs
@@ -1,7 +1,7 @@
 use crate::{
     api::LocalStorage,
     channel::{Authenticated, Channel},
-    LockKeeperClient, LockKeeperClientError,
+    LockKeeperClient, LockKeeperClientError, client::LockKeeperRpcClientInner,
 };
 use lock_keeper::{
     crypto::{Encrypted, KeyId, Secret, SigningKeyPair},
@@ -13,7 +13,7 @@ use lock_keeper::{
 use rand::rngs::StdRng;
 use uuid::Uuid;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<LockKeeperRpcClientInner<T>> {
     /// Handles the retrieval of arbitrary secrets
     /// ([`lock_keeper::crypto::Secret`]) only.
     pub(crate) async fn handle_retrieve_secret(

--- a/lock-keeper-client/src/api/retrieve_audit_events.rs
+++ b/lock-keeper-client/src/api/retrieve_audit_events.rs
@@ -8,7 +8,7 @@ use lock_keeper::types::{
 };
 use rand::rngs::StdRng;
 
-impl LockKeeperClient {
+impl<T> LockKeeperClient<T> {
     pub(crate) async fn handle_retrieve_audit_events(
         &self,
         mut channel: Channel<Authenticated<StdRng>>,

--- a/lock-keeper-client/src/error.rs
+++ b/lock-keeper-client/src/error.rs
@@ -14,6 +14,8 @@ pub enum LockKeeperClientError {
     ClientAuthMissing,
     #[error("Private key was not provided.")]
     PrivateKeyMissing,
+    #[error("HTTPS connector was requested but TLS settings were missing from config.")]
+    TlsConfigMissing,
 
     #[error("Account already registered")]
     AccountAlreadyRegistered,


### PR DESCRIPTION
Jay mentioned that disabling TLS could be useful for troubleshooting in the future. Our current client code doesn't seem to work for `http` and it's not as simple as it sounds to make it work.