### PR TITLE
Add key IDs to key operation contexts #471

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -107,9 +107,10 @@ args = ["doc", "--all-features", "--no-deps", "--document-private-items", "--wor
 # -- Database Tasks --
 
 # Update the `sqlx-data.json` file
-[tasks.refresh-db-cache]
+[tasks.sqlx-prepare]
+env = { "DATABASE_URL" = "postgres://test:test_password@localhost:5432/test" }
 command = "cargo"
-args = ["sqlx", "prepare", "--database-url", "postgres://test:test_password@localhost:5432/test", "--merged"]
+args = ["sqlx", "prepare", "--merged"]
 
 # Connect to test database using `psql`
 [tasks.test-db]

--- a/lock-keeper-key-server/src/operations/remote_generate_signing_key.rs
+++ b/lock-keeper-key-server/src/operations/remote_generate_signing_key.rs
@@ -44,6 +44,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RemoteGenerateSigni
             info!("Generated key ID: {:?}", key_id);
             (key_id, key_pair)
         };
+        context.key_id = Some(key_id.clone());
 
         let public_key = key_pair.public_key();
 

--- a/lock-keeper-key-server/src/operations/remote_sign_bytes.rs
+++ b/lock-keeper-key-server/src/operations/remote_sign_bytes.rs
@@ -36,6 +36,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RemoteSignBytes {
     ) -> Result<(), LockKeeperServerError> {
         info!("Starting remote sign protocol.");
         let request: client::RequestRemoteSign = channel.receive().await?;
+        context.key_id = Some(request.key_id.clone());
 
         let account_id = channel.account_id();
 

--- a/lock-keeper-tests/src/main.rs
+++ b/lock-keeper-tests/src/main.rs
@@ -146,5 +146,11 @@ async fn run_integration_tests(
         report_test_results(&session_cache_results)
     );
 
-    Ok([config_file_results, database_results, client_auth_results].concat())
+    Ok([
+        config_file_results,
+        database_results,
+        client_auth_results,
+        session_cache_results,
+    ]
+    .concat())
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/operations.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/operations.rs
@@ -64,6 +64,7 @@ pub(crate) async fn check_audit_events(
     expected_status: EventStatus,
     expected_action: ClientAction,
     request_id: Uuid,
+    key_id: Option<KeyId>,
 ) -> Result<(), LockKeeperClientError> {
     // Authenticate to LockKeeperClient
     let lock_keeper_client =
@@ -82,9 +83,11 @@ pub(crate) async fn check_audit_events(
         .result?;
 
     // Get all events that match given expected values.
-    let matching_events = audit_event_log
-        .into_iter()
-        .filter(|event| event.status == expected_status && event.client_action == expected_action);
+    let matching_events = audit_event_log.into_iter().filter(|event| {
+        event.key_id == key_id
+            && event.status == expected_status
+            && event.client_action == expected_action
+    });
 
     assert_eq!(
         matching_events.count(),

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/authenticate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/authenticate.rs
@@ -42,6 +42,7 @@ async fn multiple_sessions_from_same_client_allowed(config: Config) -> Result<()
         EventStatus::Successful,
         ClientAction::Authenticate,
         request_id,
+        None,
     )
     .await?;
 
@@ -65,6 +66,7 @@ async fn cannot_authenticate_with_wrong_password(config: Config) -> Result<()> {
         EventStatus::Failed,
         ClientAction::Authenticate,
         request_id,
+        None,
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/export.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/export.rs
@@ -57,6 +57,7 @@ async fn export_works(config: Config) -> Result<()> {
         EventStatus::Successful,
         ClientAction::ExportSecret,
         request_id,
+        Some(key_id),
     )
     .await?;
 
@@ -76,6 +77,7 @@ async fn cannot_export_fake_key(config: Config) -> Result<()> {
         EventStatus::Failed,
         ClientAction::ExportSecret,
         request_id,
+        Some(fake_key_id),
     )
     .await?;
 
@@ -95,6 +97,7 @@ async fn cannot_export_signing_key_as_secret(config: Config) -> Result<()> {
         EventStatus::Failed,
         ClientAction::ExportSecret,
         request_id,
+        Some(key_id),
     )
     .await?;
 
@@ -137,6 +140,7 @@ async fn export_signing_key_works(config: Config) -> Result<()> {
         EventStatus::Successful,
         ClientAction::ExportSigningKey,
         request_id,
+        Some(key_id),
     )
     .await?;
 
@@ -156,6 +160,7 @@ async fn cannot_export_fake_signing_key(config: Config) -> Result<()> {
         EventStatus::Failed,
         ClientAction::ExportSigningKey,
         request_id,
+        Some(fake_key_id),
     )
     .await?;
 
@@ -178,6 +183,7 @@ async fn cannot_export_secret_as_signing_key(config: Config) -> Result<()> {
         EventStatus::Failed,
         ClientAction::ExportSigningKey,
         request_id,
+        Some(key_id),
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
@@ -32,11 +32,13 @@ async fn generate_works(config: Config) -> Result<()> {
 
     let generate_result = client.generate_secret().await;
     let request_id = generate_result.metadata.unwrap().request_id;
+    let key_id = generate_result.result?.key_id;
     check_audit_events(
         &state,
         EventStatus::Successful,
         ClientAction::GenerateSecret,
         request_id,
+        Some(key_id),
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
@@ -32,12 +32,13 @@ async fn import_works(config: Config) -> Result<()> {
 
     let import_res = import_signing_key(&client).await;
     let request_id = import_res.metadata.unwrap().request_id;
-    assert!(import_res.result.is_ok());
+    let key_id = import_res.result?.0;
     check_audit_events(
         &state,
         EventStatus::Successful,
         ClientAction::ImportSigningKey,
         request_id,
+        Some(key_id),
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/register.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/register.rs
@@ -46,6 +46,7 @@ async fn register_works(config: Config) -> Result<()> {
         EventStatus::Successful,
         ClientAction::Register,
         metadata.request_id,
+        None,
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
@@ -32,13 +32,14 @@ async fn remote_generate_works(config: Config) -> Result<()> {
 
     let remote_gen_res = client.remote_generate().await;
     let request_id = remote_gen_res.metadata.clone().unwrap().request_id;
-    assert!(remote_gen_res.result.is_ok());
+    let key_id = remote_gen_res.result?.key_id;
 
     check_audit_events(
         &state,
         EventStatus::Successful,
         ClientAction::RemoteGenerateSigningKey,
         request_id,
+        Some(key_id),
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_sign.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_sign.rs
@@ -57,6 +57,7 @@ async fn remote_sign_works(config: Config) -> Result<()> {
         EventStatus::Successful,
         ClientAction::RemoteSignBytes,
         request_id,
+        Some(key_id),
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/retrieve.rs
@@ -56,6 +56,7 @@ async fn retrieve_local_only_works(config: Config) -> Result<()> {
         EventStatus::Successful,
         ClientAction::RetrieveSecret,
         request_id,
+        Some(key_id),
     )
     .await?;
 
@@ -80,6 +81,7 @@ async fn retrieve_null_works(config: Config) -> Result<()> {
         EventStatus::Successful,
         ClientAction::RetrieveSecret,
         request_id,
+        Some(key_id),
     )
     .await?;
 
@@ -101,6 +103,7 @@ async fn cannot_retrieve_fake_key(config: Config) -> Result<()> {
         EventStatus::Failed,
         ClientAction::RetrieveSecret,
         request_id,
+        Some(fake_key_id),
     )
     .await?;
 

--- a/lock-keeper-tests/src/test_suites/session_cache.rs
+++ b/lock-keeper-tests/src/test_suites/session_cache.rs
@@ -46,11 +46,13 @@ pub async fn run_tests(filters: &TestFilters) -> Result<Vec<TestResult>> {
 pub async fn new_cache(expiration: &str) -> Result<PostgresSessionCache> {
     let config_str = format!(
         r#"
-        username = 'test' 
+        username = 'test'
         password = 'test_password'
-        address = 'localhost'
+        address = 'localhost:5432'
         db_name = 'test'
         max_connections = 5
+        connection_retries = 5
+        connection_retry_delay = "5s"
         connection_timeout = "3s"
         session_expiration = "{expiration}"
         "#,


### PR DESCRIPTION
Closes #471 

Also changed the sqlx-prepare task name, added session cache tests to the integration test return value, and added a key ID check to e2e audit event tests. I thought about making an integration test for this (instead of e2e), but we don't have the LockKeeperClient there to take key actions with the key before checking the audit for it.