### PR TITLE
Explicit integer conversions for encrypting data.

### DIFF
--- a/lock-keeper/src/types/operations/retrieve_secret.rs
+++ b/lock-keeper/src/types/operations/retrieve_secret.rs
@@ -48,7 +48,7 @@ impl RetrievedSecret {
                 Ok(Self {
                     key_id,
                     secret_type,
-                    bytes: key.into(),
+                    bytes: key.try_into()?,
                 })
             }
             &_ => Err(LockKeeperError::InvalidSecretType),


### PR DESCRIPTION
 Changes crypto module to use TryFrom calls instead of as and propagate errors. This way, in the future, this will be an error instead of a silent failure.

 Makes progress towards #473.