### PR TITLE
http2_only in builder to be able to connect to aws deployment

### DIFF
--- a/lock-keeper-client/src/client.rs
+++ b/lock-keeper-client/src/client.rs
@@ -121,7 +121,7 @@ impl LockKeeperClient {
             .enable_http2()
             .build();
 
-        let client = hyper::Client::builder().build(connector);
+        let client = hyper::Client::builder().http2_only(true).build(connector);
         let rpc_client = LockKeeperRpcClient::with_origin(client, config.server_uri.clone());
 
         Ok(rpc_client)


### PR DESCRIPTION
We need to force http2_only to avoid HTTP version error that I've only seen appearing in the AWS deployment.