### PR TITLE
Specify format of datetime when deserializing

### DIFF
--- a/lock-keeper/src/types/audit_event.rs
+++ b/lock-keeper/src/types/audit_event.rs
@@ -134,7 +134,9 @@ impl EventType {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AuditEventOptions {
     pub key_ids: Vec<KeyId>,
+    #[serde(with = "time::serde::iso8601::option")]
     pub after_date: Option<OffsetDateTime>,
+    #[serde(with = "time::serde::iso8601::option")]
     pub before_date: Option<OffsetDateTime>,
     pub request_id: Option<Uuid>,
 }


### PR DESCRIPTION
To address errors with date filters.

I'm not sure about requiring ISO format directly in lock keeper like this, but the issue with the date filters was that the ones being passed from another server were being deserialized as just strings instead of OffsetDatetime. That went away when I added the serde tag, but I'm not sure it really addresses the problem.