### PR TITLE
Add date filters to CLI audit event function #434

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0.85"
 serde_with = "1"
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1"
-time = { version = "0.3.17", features = ["serde"]}
+time = { version = "0.3.17", features = ["parsing", "serde"]}
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.23"
 tokio-stream = "0.1"

--- a/bin/lock-keeper-client-cli/Cargo.toml
+++ b/bin/lock-keeper-client-cli/Cargo.toml
@@ -15,6 +15,7 @@ clap.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+time.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true

--- a/bin/lock-keeper-client-cli/src/cli_command/get_audit_events.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/get_audit_events.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Error};
 use async_trait::async_trait;
 use lock_keeper::types::audit_event::{AuditEventOptions, EventType};
 use lock_keeper_client::LockKeeperClient;
+use time::{format_description::well_known::Iso8601, OffsetDateTime};
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -15,6 +16,8 @@ pub struct GetAuditEvents {
     event_type: EventType,
     key_names: Vec<String>,
     request_id: Option<Uuid>,
+    before_date: Option<OffsetDateTime>,
+    after_date: Option<OffsetDateTime>,
 }
 
 #[async_trait]
@@ -28,7 +31,8 @@ impl CliCommand for GetAuditEvents {
         let options = AuditEventOptions {
             key_ids,
             request_id: self.request_id,
-            ..Default::default()
+            before_date: self.before_date,
+            after_date: self.after_date,
         };
 
         let credentials = state.get_credentials()?;
@@ -66,12 +70,16 @@ impl CliCommand for GetAuditEvents {
                 event_type: EventType::All,
                 key_names: vec![],
                 request_id: None,
+                before_date: None,
+                after_date: None,
             }),
             options => {
                 let mut result = GetAuditEvents {
                     event_type: EventType::All,
                     key_names: vec![],
                     request_id: None,
+                    before_date: None,
+                    after_date: None,
                 };
 
                 for option in options {
@@ -89,6 +97,12 @@ impl CliCommand for GetAuditEvents {
                         }
                         ParsedAuditEventOption::RequestId(request_id) => {
                             result.request_id = Some(request_id);
+                        }
+                        ParsedAuditEventOption::BeforeDate(before) => {
+                            result.before_date = Some(before);
+                        }
+                        ParsedAuditEventOption::AfterDate(before) => {
+                            result.after_date = Some(before);
                         }
                     }
                 }
@@ -140,13 +154,24 @@ fn parse_option(text: &str) -> Result<ParsedAuditEventOption, Error> {
             Ok(ParsedAuditEventOption::KeyNames(key_names))
         }
         "request-id" => Ok(ParsedAuditEventOption::RequestId(option_value.parse()?)),
-        "before" => {
-            anyhow::bail!("`before` option is not implemented");
-        }
-        "after" => {
-            anyhow::bail!("`after` option is not implemented");
-        }
+        "before" => Ok(ParsedAuditEventOption::BeforeDate(parse_date(
+            option_value,
+        )?)),
+        "after" => Ok(ParsedAuditEventOption::AfterDate(parse_date(option_value)?)),
         _ => anyhow::bail!(ERROR_MESSAGE),
+    }
+}
+
+fn parse_date(date_str: &str) -> Result<OffsetDateTime, Error> {
+    match OffsetDateTime::parse(date_str, &Iso8601::DEFAULT) {
+        Ok(date) => Ok(date),
+        Err(_) => {
+            let iso_format = format!("{}T00:00:00Z", date_str);
+            match OffsetDateTime::parse(&iso_format, &Iso8601::DEFAULT) {
+                Ok(date) => Ok(date),
+                Err(e) => Err(anyhow!("Invalid date format {:?}", e)),
+            }
+        }
     }
 }
 
@@ -154,4 +179,6 @@ enum ParsedAuditEventOption {
     EventType(EventType),
     KeyNames(Vec<String>),
     RequestId(Uuid),
+    BeforeDate(OffsetDateTime),
+    AfterDate(OffsetDateTime),
 }


### PR DESCRIPTION
Closes #434 

Not sure if there is a cleaner way to do the error handling in the parse_date function?