### PR TITLE
Updates feature flags for `time` to fix cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0.85"
 serde_with = "1"
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1"
-time = { version = "0.3.17", features = ["parsing", "serde"]}
+time = { version = "0.3.17", features = ["macros", "serde", "serde-human-readable"] }
 tokio = { version = "1", features = ["full"] }
 tokio-rustls = "0.23"
 tokio-stream = "0.1"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -67,6 +67,11 @@ args = ["run", "--bin", "lock-keeper-tests", "--", "--standard-only", "--test-ty
 command = "cargo"
 args = ["run", "--bin", "lock-keeper-tests", "--", "--test-type", "integration"]
 
+# Run integration tests and print all errors even for tests that pass.
+[tasks.integration-debug]
+command = "cargo"
+args = ["run", "--bin", "lock-keeper-tests", "--", "--test-type", "integration", "--print-errors"]
+
 # Run all tests that require a server to be running in Docker.
 [tasks.all-tests]
 command = "cargo"


### PR DESCRIPTION
The CLI currently doesn't compile due to some macro errors.

This PR also adds a cli flag to the test crate to enable error logging. Without this flag, the test results are full of error messages for tests that we expect to fail.