### PR TITLE
Add no-config option to client cli

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -144,27 +144,27 @@ alias = "ci-test"
 # Run the client CLI in interactive mode
 [tasks.cli]
 command = "cargo"
-args = ["run", "--bin", "lock-keeper-client-cli"]
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/local/Client.toml"]
 
 # Runs a CLI script to generate a retrieve a few keys
 [tasks.script-generate]
 command = "cargo"
-args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/generate.lk"]
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/local/Client.toml", "--script-file", "dev/cli-scripts/generate.lk"]
 
 # Runs a CLI script to remotely generate a signing key and sign some data
 [tasks.script-sign]
 command = "cargo"
-args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/sign.lk"]
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/local/Client.toml", "--script-file", "dev/cli-scripts/sign.lk"]
 
 # Runs a CLI script to export a remotely generated signing key
 [tasks.script-export]
 command = "cargo"
-args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/export.lk"]
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/local/Client.toml", "--script-file", "dev/cli-scripts/export.lk"]
 
 # Runs a CLI script to import and then export a signing key
 [tasks.script-import]
 command = "cargo"
-args = ["run", "--bin", "lock-keeper-client-cli", "--", "--script-file", "dev/cli-scripts/import.lk"]
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/local/Client.toml", "--script-file", "dev/cli-scripts/import.lk"]
 
 # Runs all scripts
 [tasks.all-scripts]

--- a/bin/lock-keeper-client-cli/src/cli.rs
+++ b/bin/lock-keeper-client-cli/src/cli.rs
@@ -1,13 +1,37 @@
 //! Command-line arguments
 
+use anyhow::anyhow;
 use clap::Parser;
+use lock_keeper_client::{
+    config::{ClientAuth, ConfigFile},
+    Config,
+};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 pub struct Cli {
     /// Location of client config file.
-    #[clap(long, default_value = "dev/config/local/Client.toml")]
-    pub config: PathBuf,
+    /// If this arg is not provided, the `uri` and `ca-chain` args must be
+    /// provided.
+    #[clap(long)]
+    pub config: Option<PathBuf>,
+
+    /// Server URI.
+    #[clap(long = "uri", conflicts_with = "config", requires = "ca-chain")]
+    pub server_uri: Option<String>,
+    /// Location of the file containing the signing CA chain for the server.
+    #[clap(long, conflicts_with = "config", requires = "server-uri")]
+    pub ca_chain: Option<PathBuf>,
+
+    /// Client's signing CA chain.
+    /// Only needed when client auth is enabled on the server.
+    #[clap(long, conflicts_with = "config", requires = "private-key")]
+    pub client_chain: Option<PathBuf>,
+    /// Client's private key.
+    /// Only needed when client auth is enabled on the server.
+    #[clap(long, conflicts_with = "config", requires = "client-chain")]
+    pub private_key: Option<PathBuf>,
+
     /// Directory where persistent storage files will be saved.
     #[clap(long, default_value = "dev/lk_client_cli_data")]
     pub storage_path: PathBuf,
@@ -17,4 +41,37 @@ pub struct Cli {
     /// Sequence of CLI commands separated by a semicolon or newline
     #[clap(long, conflicts_with = "script-file")]
     pub script: Option<String>,
+}
+
+impl Cli {
+    pub fn client_config(&self) -> anyhow::Result<Config> {
+        if let Some(config) = &self.config {
+            return Ok(Config::from_file(config, None)?);
+        }
+
+        let server_uri = self.server_uri.as_ref().ok_or(anyhow!(
+            "If `config` argument is not provided, `uri` must be provided"
+        ))?;
+        let ca_chain = self.ca_chain.as_ref().ok_or(anyhow!(
+            "If `config` argument is not provided, `ca_chain` must be provided"
+        ))?;
+
+        let client_auth = if let (Some(certificate_chain), Some(private_key)) =
+            (&self.client_chain, &self.private_key)
+        {
+            Some(ClientAuth {
+                certificate_chain: certificate_chain.clone(),
+                private_key: Some(private_key.clone()),
+            })
+        } else {
+            None
+        };
+
+        let config_file = ConfigFile {
+            server_uri: server_uri.clone(),
+            ca_chain: ca_chain.clone(),
+            client_auth,
+        };
+        Ok(Config::from_config_file(config_file, None)?)
+    }
 }

--- a/bin/lock-keeper-client-cli/src/cli_command/get_audit_events.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/get_audit_events.rs
@@ -166,7 +166,7 @@ fn parse_date(date_str: &str) -> Result<OffsetDateTime, Error> {
     match OffsetDateTime::parse(date_str, &Iso8601::DEFAULT) {
         Ok(date) => Ok(date),
         Err(_) => {
-            let iso_format = format!("{}T00:00:00Z", date_str);
+            let iso_format = format!("{date_str}T00:00:00Z");
             match OffsetDateTime::parse(&iso_format, &Iso8601::DEFAULT) {
                 Ok(date) => Ok(date),
                 Err(e) => Err(anyhow!("Invalid date format {:?}", e)),

--- a/bin/lock-keeper-client-cli/src/main.rs
+++ b/bin/lock-keeper-client-cli/src/main.rs
@@ -8,7 +8,6 @@ mod storage;
 use std::str::FromStr;
 
 use clap::Parser;
-use lock_keeper_client::Config;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
@@ -17,7 +16,8 @@ use crate::scripting::Script;
 #[tokio::main]
 pub async fn main() {
     let cli = cli::Cli::parse();
-    let config = Config::from_file(&cli.config, None).unwrap();
+
+    let config = cli.client_config().unwrap();
     let script = parse_script(&cli).unwrap();
 
     tracing_subscriber::fmt::Subscriber::builder()

--- a/lock-keeper-client/src/config.rs
+++ b/lock-keeper-client/src/config.rs
@@ -49,7 +49,6 @@ impl std::fmt::Debug for Config {
 /// Client configuration file format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-#[non_exhaustive]
 pub struct ConfigFile {
     pub server_uri: String,
     pub ca_chain: PathBuf,
@@ -58,7 +57,6 @@ pub struct ConfigFile {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-#[non_exhaustive]
 pub struct ClientAuth {
     pub certificate_chain: PathBuf,
     /// The private key can be provided as a file or passed to the


### PR DESCRIPTION
This PR removes the default config path from the client CLI and adds the option to provide a URI and signing CA chain directly from the command line. This will make the CLI much more usable outside of lock keeper.