### PR TITLE
Added a non-wrapped error for invalid sessions

### DIFF
--- a/lock-keeper-client/src/error.rs
+++ b/lock-keeper-client/src/error.rs
@@ -27,6 +27,8 @@ pub enum LockKeeperClientError {
     InvalidLogin,
     #[error("Invalid key retrieved")]
     InvalidKeyRetrieved,
+    #[error("Session is expired or invalid")]
+    InvalidSession,
     #[error("An unauthenticated channel is needed for this action")]
     UnauthenticatedChannelNeeded,
     #[error("An authenticated channel is needed for this action")]
@@ -70,6 +72,7 @@ impl From<Status> for LockKeeperClientError {
         match (status.code(), status.message()) {
             (Code::InvalidArgument, "Account already registered") => Self::AccountAlreadyRegistered,
             (Code::InvalidArgument, "Invalid account") => Self::InvalidAccount,
+            (Code::Unauthenticated, _) => Self::InvalidSession,
             (Code::Unknown, "connection error: received fatal alert: CertificateRequired") => {
                 Self::ClientAuthMissing
             }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases.rs
@@ -13,7 +13,6 @@ pub mod remote_sign;
 pub mod retrieve;
 
 pub(crate) const NO_ENTRY_FOUND: &str = "No such entry in table.";
-pub(crate) const NO_SESSION: &str = "No session for this user";
 pub(crate) const WRONG_KEY_DATA: &str =
     "Key ID exists but associated user ID or key type were incorrect.";
 

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/generate.rs
@@ -1,15 +1,14 @@
 use colored::Colorize;
 use lock_keeper::types::{audit_event::EventStatus, operations::ClientAction};
-use lock_keeper_client::Config;
-use tonic::Status;
+use lock_keeper_client::{Config, LockKeeperClientError};
 
 use crate::{
     config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
-        operations::{authenticate, check_audit_events, compare_status_errors},
-        test_cases::{init_test_state, NO_SESSION},
+        operations::{authenticate, check_audit_events},
+        test_cases::init_test_state,
     },
     utils::TestResult,
 };
@@ -52,7 +51,10 @@ async fn cannot_generate_after_logout(config: Config) -> Result<()> {
     client.logout().await.result?;
 
     let res = client.generate_secret().await;
-    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
+    assert!(matches!(
+        res.result,
+        Err(LockKeeperClientError::InvalidSession)
+    ));
 
     Ok(())
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/import.rs
@@ -1,15 +1,14 @@
 use colored::Colorize;
 use lock_keeper::types::{audit_event::EventStatus, operations::ClientAction};
-use lock_keeper_client::Config;
-use tonic::Status;
+use lock_keeper_client::{Config, LockKeeperClientError};
 
 use crate::{
     config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
-        operations::{authenticate, check_audit_events, compare_status_errors, import_signing_key},
-        test_cases::{init_test_state, NO_SESSION},
+        operations::{authenticate, check_audit_events, import_signing_key},
+        test_cases::init_test_state,
     },
     utils::TestResult,
 };
@@ -52,7 +51,10 @@ async fn cannot_import_after_logout(config: Config) -> Result<()> {
     client.logout().await.result?;
 
     let res = import_signing_key(&client).await;
-    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
+    assert!(matches!(
+        res.result,
+        Err(LockKeeperClientError::InvalidSession)
+    ));
 
     Ok(())
 }

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/remote_generate.rs
@@ -1,15 +1,14 @@
 use colored::Colorize;
 use lock_keeper::types::{audit_event::EventStatus, operations::ClientAction};
-use lock_keeper_client::Config;
-use tonic::Status;
+use lock_keeper_client::{Config, LockKeeperClientError};
 
 use crate::{
     config::TestFilters,
     error::Result,
     run_parallel,
     test_suites::end_to_end::{
-        operations::{authenticate, check_audit_events, compare_status_errors},
-        test_cases::{init_test_state, NO_SESSION},
+        operations::{authenticate, check_audit_events},
+        test_cases::init_test_state,
     },
     utils::TestResult,
 };
@@ -53,7 +52,10 @@ async fn cannot_remote_generate_after_logout(config: Config) -> Result<()> {
     client.logout().await.result?;
 
     let res = client.remote_generate().await;
-    compare_status_errors(res, Status::unauthenticated(NO_SESSION))?;
+    assert!(matches!(
+        res.result,
+        Err(LockKeeperClientError::InvalidSession)
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds a specific client error for invalid session. This allows a consumer to dispatch on invalid authentication errors without importing `tonic`.