### PR TITLE
Stop regenerating certs on server restart #503

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,9 @@ jobs:
           command: install
           args: --debug cargo-make
 
+      - name: Initialize certs and keys
+        run: cargo make init
+
       - name: Start Server
         run: cargo make start
           

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -32,7 +32,6 @@ args = ["compose", "up",
         "--attach", "ks_client_auth",
         "--attach", "ks_nginx",
 ]
-dependencies = ["certs", "remote-storage-key"]
 
 # Start a key server in the background
 [tasks.start-server-detached]
@@ -41,7 +40,6 @@ args = ["compose", "up",
         "--build", "postgres", "nginx", "key_server", "ks_client_auth", "ks_nginx",
         "--wait",
 ]
-dependencies = ["certs", "remote-storage-key"]
 
 # Stop a key server running in the background.
 [tasks.stop-server]
@@ -169,6 +167,10 @@ args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/
 # Runs all scripts
 [tasks.all-scripts]
 dependencies = ["script-generate", "script-sign", "script-export", "script-import"]
+
+# Run all initial tasks required to start LockKeeper
+[tasks.init]
+dependencies = ["certs", "remote-storage-key"]
 
 # Generate certificates in the dev/certs/gen directory
 [tasks.certs]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,13 @@ cargo test --all-features --doc
 
 Integration tests are separated into two categories, end-to-end tests and general integration tests. Both categories require the key server to be running.
 
-Start the server running in the background. This will compile the project from scratch the first time you run it so it will take a while. It should be faster for future runs.
+Before running Lock Keeper for the first time, you will need to generate the necessary certs and keys for the key server. 
+```bash
+cargo make init
+```
+Any time you need to refresh your certs and keys, you can run this command again.
+
+Then, start the server running in the background. This will compile the project from scratch the first time you run it so it will take a while. It should be faster for future runs.
 ```bash
 cargo make start
 ```


### PR DESCRIPTION
Closes #503 

I did this one the same way as what was done for Maestro, so there are no committed certs/keys here. I can switch it to match the ticket if that is the preference.