### PR TITLE
Add optimized query for server encrypted blobs

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -142,7 +142,7 @@ alias = "ci-test"
 # Run the client CLI in interactive mode
 [tasks.cli]
 command = "cargo"
-args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/local/Client.toml"]
+args = ["run", "--bin", "lock-keeper-client-cli", "--", "--config", "dev/config/local/Client.toml", "${@}"]
 
 # Runs a CLI script to generate a retrieve a few keys
 [tasks.script-generate]

--- a/bin/lock-keeper-client-cli/src/cli_command.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command.rs
@@ -13,6 +13,8 @@ pub mod register;
 pub mod remote_generate;
 pub mod remote_sign;
 pub mod retrieve;
+pub mod retrieve_blob;
+pub mod store_blob;
 pub mod wait;
 
 pub use authenticate::Authenticate;
@@ -30,6 +32,8 @@ pub use register::Register;
 pub use remote_generate::RemoteGenerate;
 pub use remote_sign::RemoteSign;
 pub use retrieve::Retrieve;
+pub use retrieve_blob::RetrieveBlob;
+pub use store_blob::StoreBlob;
 pub use wait::Wait;
 
 use crate::state::State;
@@ -163,6 +167,8 @@ pub fn get_cmd_functions<F: GetCmdFunction>() -> Vec<F::FunctionSignature> {
         F::get_function::<RemoteGenerate>(),
         F::get_function::<RemoteSign>(),
         F::get_function::<Retrieve>(),
+        F::get_function::<RetrieveBlob>(),
+        F::get_function::<StoreBlob>(),
         F::get_function::<Wait>(),
     ]
 }

--- a/bin/lock-keeper-client-cli/src/cli_command/retrieve_blob.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/retrieve_blob.rs
@@ -1,0 +1,66 @@
+use std::time::{Duration, SystemTime};
+
+use crate::{cli_command::CliCommand, state::State};
+use anyhow::Error;
+use async_trait::async_trait;
+use lock_keeper_client::LockKeeperClient;
+
+#[derive(Debug)]
+pub struct RetrieveBlob {
+    name: String,
+}
+
+#[async_trait]
+impl CliCommand for RetrieveBlob {
+    async fn execute(self: Box<Self>, state: &mut State) -> Result<Duration, Error> {
+        let credentials = state.get_credentials()?;
+
+        // Authenticate user to the key server
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &credentials.account_name,
+            &credentials.password,
+            &state.config,
+        )
+        .await
+        .result?;
+
+        let entry = state.get_key_id(&self.name)?;
+
+        let now = SystemTime::now();
+        // Retrieve results for specified key.
+        let retrieve_result = lock_keeper_client
+            .retrieve_server_encrypted_blob(&entry.key_id)
+            .await
+            .result?;
+        let elapsed = now.elapsed()?;
+
+        println!("Retrieved: {}", self.name);
+        println!("{retrieve_result:?}");
+
+        let stored = state.store_entry(Some(self.name), (entry.key_id.clone(), retrieve_result))?;
+
+        println!("Updated: {stored}");
+        Ok(elapsed)
+    }
+
+    fn parse_command_args(slice: &[&str]) -> Option<Self> {
+        match slice {
+            [name] => Some(RetrieveBlob {
+                name: name.to_string(),
+            }),
+            _ => None,
+        }
+    }
+
+    fn format() -> &'static str {
+        "retrieve-blob [key_name]"
+    }
+
+    fn aliases() -> Vec<&'static str> {
+        vec!["retrieve-blob", "rb"]
+    }
+
+    fn description() -> &'static str {
+        "Retrieve a previously stored blob."
+    }
+}

--- a/bin/lock-keeper-client-cli/src/cli_command/store_blob.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command/store_blob.rs
@@ -1,0 +1,67 @@
+use std::time::{Duration, SystemTime};
+
+use crate::{cli_command::CliCommand, state::State};
+use anyhow::Error;
+use async_trait::async_trait;
+use lock_keeper_client::LockKeeperClient;
+
+#[derive(Debug)]
+pub struct StoreBlob {
+    blob: String,
+    name: Option<String>,
+}
+
+#[async_trait]
+impl CliCommand for StoreBlob {
+    async fn execute(self: Box<Self>, state: &mut State) -> Result<Duration, Error> {
+        let credentials = state.get_credentials()?;
+
+        // Authenticate user to the key server
+        let lock_keeper_client = LockKeeperClient::authenticated_client(
+            &credentials.account_name,
+            &credentials.password,
+            &state.config,
+        )
+        .await
+        .result?;
+
+        let now = SystemTime::now();
+        // If successful, proceed to generate a secret with the established session
+        let key_id = lock_keeper_client
+            .store_server_encrypted_blob(self.blob.into_bytes())
+            .await
+            .result?;
+        let elapsed = now.elapsed()?;
+
+        // Store Key Id
+        let stored = state.store_entry(self.name, key_id)?;
+        println!("Stored blob with id: {stored}");
+        Ok(elapsed)
+    }
+
+    fn parse_command_args(slice: &[&str]) -> Option<Self> {
+        match slice {
+            [blob, name] => Some(StoreBlob {
+                blob: blob.to_string(),
+                name: Some(name.to_string()),
+            }),
+            [blob] => Some(StoreBlob {
+                blob: blob.to_string(),
+                name: None,
+            }),
+            _ => None,
+        }
+    }
+
+    fn format() -> &'static str {
+        "store-blob [key_name (optional)]"
+    }
+
+    fn aliases() -> Vec<&'static str> {
+        vec!["store-blob", "blob", "sb"]
+    }
+
+    fn description() -> &'static str {
+        "Store an arbitrary blob of bytes."
+    }
+}

--- a/bin/lock-keeper-client-cli/src/storage.rs
+++ b/bin/lock-keeper-client-cli/src/storage.rs
@@ -200,6 +200,7 @@ pub enum DataType {
     None,
     ArbitraryKey(LocalStorage<Secret>),
     Export(Export),
+    Blob(Vec<u8>),
 }
 
 impl DataType {
@@ -209,6 +210,7 @@ impl DataType {
             DataType::None => "None",
             DataType::ArbitraryKey(_) => "ArbitraryKey",
             DataType::Export(_) => "Export",
+            DataType::Blob(_) => "Blob",
         };
 
         String::from(t)
@@ -243,6 +245,7 @@ impl Display for Entry {
             DataType::Export(export) => {
                 writeln!(f, "Export Data: {}", hex::encode(&export.key_material))?
             }
+            DataType::Blob(blob) => writeln!(f, "Blob: {}", hex::encode(blob))?,
         }
 
         Ok(())
@@ -271,5 +274,11 @@ impl From<KeyId> for Entry {
 impl From<GenerateResult> for Entry {
     fn from(result: GenerateResult) -> Self {
         (result.key_id, result.local_storage).into()
+    }
+}
+
+impl From<(KeyId, Vec<u8>)> for Entry {
+    fn from((key_id, blob): (KeyId, Vec<u8>)) -> Self {
+        Entry::new(key_id, DataType::Blob(blob))
     }
 }

--- a/lock-keeper-key-server/src/operations/retrieve_server_encrypted_blob.rs
+++ b/lock-keeper-key-server/src/operations/retrieve_server_encrypted_blob.rs
@@ -1,7 +1,7 @@
 use crate::{
     server::{
         channel::{Authenticated, Channel},
-        database::{DataStore, SecretFilter},
+        database::DataStore,
         Context, Operation,
     },
     LockKeeperServerError,
@@ -9,10 +9,7 @@ use crate::{
 use async_trait::async_trait;
 use lock_keeper::{
     crypto::{DataBlob, Encrypted},
-    types::{
-        database::secrets::secret_types::SERVER_ENCRYPTED_BLOB,
-        operations::retrieve_server_encrypted_blob::{client, server},
-    },
+    types::operations::retrieve_server_encrypted_blob::{client, server},
     LockKeeperError,
 };
 use rand::rngs::StdRng;
@@ -42,11 +39,7 @@ impl<DB: DataStore> Operation<Authenticated<StdRng>, DB> for RetrieveServerEncry
 
         let stored_secret = context
             .db
-            .get_secret(
-                account_id,
-                &request.key_id,
-                SecretFilter::secret_type(SERVER_ENCRYPTED_BLOB),
-            )
+            .get_server_encrypted_blob(account_id, &request.key_id)
             .await?;
 
         let blob: Encrypted<DataBlob> =

--- a/lock-keeper-key-server/src/server/database.rs
+++ b/lock-keeper-key-server/src/server/database.rs
@@ -81,6 +81,17 @@ pub trait DataStore: Send + Sync + 'static {
         filter: SecretFilter,
     ) -> Result<StoredSecret, DatabaseError>;
 
+    /// Get a [`StoredSecret`] with a `SecretType` of `server_encrypted_blob`.
+    /// This method different from `get_secret` by using a simplified
+    /// interface tailored to the use case of stored blobs. Implementations
+    /// can use simplified and more efficient database queries for this
+    /// method.
+    async fn get_server_encrypted_blob(
+        &self,
+        account_id: AccountId,
+        key_id: &KeyId,
+    ) -> Result<StoredSecret, DatabaseError>;
+
     /// Delete a [`StoredSecret`] from an [`Account`]'s list of secrets.
     async fn delete_secret(
         &self,

--- a/persistence/lock-keeper-sql/src/api.rs
+++ b/persistence/lock-keeper-sql/src/api.rs
@@ -11,7 +11,7 @@ use lock_keeper::{
         audit_event::{AuditEvent, AuditEventOptions, EventStatus, EventType},
         database::{
             account::{Account, AccountId, AccountName, UserId},
-            secrets::StoredSecret,
+            secrets::{secret_types::SERVER_ENCRYPTED_BLOB, StoredSecret},
         },
         operations::ClientAction,
     },
@@ -71,6 +71,16 @@ impl DataStore for PostgresDB {
         filter: SecretFilter,
     ) -> Result<StoredSecret, DatabaseError> {
         Ok(self.get_secret_impl(account_id, key_id, filter).await?)
+    }
+
+    async fn get_server_encrypted_blob(
+        &self,
+        account_id: AccountId,
+        key_id: &KeyId,
+    ) -> Result<StoredSecret, DatabaseError> {
+        Ok(self
+            .get_server_encrypted_blob_impl(account_id, key_id)
+            .await?)
     }
 
     async fn delete_secret(
@@ -328,9 +338,9 @@ impl PostgresDB {
             SecretDB,
             "UPDATE Secrets \
                 SET retrieved=TRUE \
-             FROM Secrets S LEFT JOIN SecretTypes ST \
-                ON S.secret_type_id=ST.secret_type_id \
-             WHERE S.key_id=$1 AND S.account_id=$2 AND ST.secret_type LIKE $3 \
+             FROM Secrets S INNER JOIN SecretTypes ST \
+                ON S.secret_type_id=ST.secret_type_id AND ST.secret_type LIKE $3 \
+             WHERE S.key_id=$1 AND S.account_id=$2 \
              RETURNING S.key_id, S.account_id, ST.secret_type, S.secret, S.retrieved",
             key_id.as_bytes(),
             account_id.0,
@@ -363,6 +373,36 @@ impl PostgresDB {
                     _ => Err(PostgresError::InvalidRowCountFound),
                 }
             }
+            Some(secret_db) => Ok(secret_db.try_into()?),
+        }
+    }
+
+    /// This function provides a simplified query for server encrypted blobs.
+    #[instrument(skip_all, err(Debug), fields(key_id=?key_id))]
+    pub(crate) async fn get_server_encrypted_blob_impl(
+        &self,
+        account_id: AccountId,
+        key_id: &KeyId,
+    ) -> Result<StoredSecret, PostgresError> {
+        debug!("Fetching user secret.");
+
+        // Join tables to map secret_type to the corresponding secret_type_id.
+        // Update the retrieved value on Secrets.retrieved
+        let secret_db: Option<SecretDB> = sqlx::query_as!(
+            SecretDB,
+            "SELECT S.key_id, S.account_id, ST.secret_type, S.secret, S.retrieved
+             FROM Secrets S INNER JOIN SecretTypes ST
+                ON S.secret_type_id=ST.secret_type_id AND ST.secret_type = $3
+             WHERE S.key_id=$1 AND S.account_id=$2",
+            key_id.as_bytes(),
+            account_id.0,
+            SERVER_ENCRYPTED_BLOB
+        )
+        .fetch_optional(&self.connection_pool)
+        .await?;
+
+        match secret_db {
+            None => Err(PostgresError::NoEntry),
             Some(secret_db) => Ok(secret_db.try_into()?),
         }
     }

--- a/persistence/migrations/1002_key_index.sql
+++ b/persistence/migrations/1002_key_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_secrets_key_account
+    ON Secrets USING btree
+    (key_id ASC NULLS LAST, account_id ASC NULLS LAST);

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -209,52 +209,6 @@
     },
     "query": "DELETE FROM Session WHERE session_id=$1"
   },
-  "80a65d1c4a01b551f1d51c6653fa0b11db7c19989f7d173236d18aee81cf23aa": {
-    "describe": {
-      "columns": [
-        {
-          "name": "key_id",
-          "ordinal": 0,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "account_id",
-          "ordinal": 1,
-          "type_info": "Int8"
-        },
-        {
-          "name": "secret_type",
-          "ordinal": 2,
-          "type_info": "Varchar"
-        },
-        {
-          "name": "secret",
-          "ordinal": 3,
-          "type_info": "Bytea"
-        },
-        {
-          "name": "retrieved",
-          "ordinal": 4,
-          "type_info": "Bool"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ],
-      "parameters": {
-        "Left": [
-          "Bytea",
-          "Int8",
-          "Text"
-        ]
-      }
-    },
-    "query": "UPDATE Secrets SET retrieved=TRUE FROM Secrets S LEFT JOIN SecretTypes ST ON S.secret_type_id=ST.secret_type_id WHERE S.key_id=$1 AND S.account_id=$2 AND ST.secret_type LIKE $3 RETURNING S.key_id, S.account_id, ST.secret_type, S.secret, S.retrieved"
-  },
   "a21d7af271ced00fee3c25d1411292882da68f5c1602979a761ca29aaa2b1ba0": {
     "describe": {
       "columns": [],
@@ -325,6 +279,52 @@
     },
     "query": "SELECT COUNT(1) as \"count!\" FROM Secrets WHERE key_id=$1"
   },
+  "d1733695dd39f77175e8d8222d953358ee6dd312890a7d5e9a1778483b8ed20a": {
+    "describe": {
+      "columns": [
+        {
+          "name": "key_id",
+          "ordinal": 0,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "account_id",
+          "ordinal": 1,
+          "type_info": "Int8"
+        },
+        {
+          "name": "secret_type",
+          "ordinal": 2,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "secret",
+          "ordinal": 3,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "retrieved",
+          "ordinal": 4,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Text"
+        ]
+      }
+    },
+    "query": "SELECT S.key_id, S.account_id, ST.secret_type, S.secret, S.retrieved\n             FROM Secrets S INNER JOIN SecretTypes ST\n                ON S.secret_type_id=ST.secret_type_id AND ST.secret_type = $3\n             WHERE S.key_id=$1 AND S.account_id=$2"
+  },
   "e97f51eea5136f5c4632dc4e9d1a73f5715d84ab053d3c643f50a6599d1ad924": {
     "describe": {
       "columns": [
@@ -345,5 +345,51 @@
       }
     },
     "query": "INSERT INTO Session (account_id, session_key) VALUES ($1, $2) RETURNING session_id"
+  },
+  "f61fe815139ed1623edf26f839c75c2c7642bd699819ec921abd47bd4749b72b": {
+    "describe": {
+      "columns": [
+        {
+          "name": "key_id",
+          "ordinal": 0,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "account_id",
+          "ordinal": 1,
+          "type_info": "Int8"
+        },
+        {
+          "name": "secret_type",
+          "ordinal": 2,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "secret",
+          "ordinal": 3,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "retrieved",
+          "ordinal": 4,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea",
+          "Int8",
+          "Text"
+        ]
+      }
+    },
+    "query": "UPDATE Secrets SET retrieved=TRUE FROM Secrets S INNER JOIN SecretTypes ST ON S.secret_type_id=ST.secret_type_id AND ST.secret_type LIKE $3 WHERE S.key_id=$1 AND S.account_id=$2 RETURNING S.key_id, S.account_id, ST.secret_type, S.secret, S.retrieved"
   }
 }


### PR DESCRIPTION
This PR adds a separate query for server-encrypted blobs with a much faster database query.
It also adds blob support to the client CLI.

This new query makes a few changes:
1. Removes the `UPDATE` from blob queries which makes this query a simple read that can happen in parallel.
2. `INNER` join instead of `LEFT` join which filters results before doing the join.
3. Adds an index on (key_id, account_id) which should speed up the WHERE clause.
4. Replaces `LIKE` with `=` for the `secret_type` which could speed up comparison in some cases.

The old query takes around 600ms on average. The new query takes around 300µs on average.