### PR TITLE
518 replace deprecated GitHub actions

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,7 +35,7 @@ jobs:
       # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable
-        uses: dtolnay/rust-toolchain@1.67
+        uses: dtolnay/rust-toolchain@1.70
         with:
           toolchain: stable
           components: clippy                

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,20 +32,13 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Install toolchain
+      # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable
         uses: dtolnay/rust-toolchain@1.67
         with:
           toolchain: stable
           components: clippy                
-
-      # tptodo: remove
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: 1.67
-      #     components: clippy
-      #     default: true
 
       - name: Build documentation in current branch
         run: cargo doc --all-features --no-deps --document-private-items --workspace

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -32,11 +32,18 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Install toolchain
-      - uses: actions-rs/toolchain@v1
+      # action repo is here https://github.com/dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@1.67
         with:
-          toolchain: 1.67
-          components: clippy
-          default: true
+          toolchain: stable
+          components: clippy                
+
+      # tptodo: remove
+      # - uses: actions-rs/toolchain@v1
+      #   with:
+      #     toolchain: 1.67
+      #     components: clippy
+      #     default: true
 
       - name: Build documentation in current branch
         run: cargo doc --all-features --no-deps --document-private-items --workspace

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,8 +3,9 @@
 name: Publish Docs
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop,  ]
 
 jobs:
   build:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,7 +34,8 @@ jobs:
 
       # Install toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
-      - uses: dtolnay/rust-toolchain@1.67
+      - name: Install Rust toolchain stable
+        uses: dtolnay/rust-toolchain@1.67
         with:
           toolchain: stable
           components: clippy                

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable      
-        uses: dtolnay/rust-toolchain@1.67
+        uses: dtolnay/rust-toolchain@1.70
         with:
           toolchain: stable
           components: clippy                

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,7 +43,7 @@ jobs:
       # Install toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable      
-      - uses: dtolnay/rust-toolchain@1.67
+        uses: dtolnay/rust-toolchain@1.67
         with:
           toolchain: stable
           components: clippy                

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@
 name: Rust
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main, develop ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,18 +26,31 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       # Install nightly toolchain
-      - uses: actions-rs/toolchain@v1
+      # action repo is here https://github.com/dtolnay/rust-toolchain      
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
-          profile: minimal
-          components: rustfmt
+          components: rustfmt                
+
+      # tptodo: remove
+      # - uses: actions-rs/toolchain@v1
+      #   with:
+      #     toolchain: nightly
+      #     profile: minimal
+      #     components: rustfmt
 
       # Install toolchain
-      - uses: actions-rs/toolchain@v1
+      # action repo is here https://github.com/dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@1.67
         with:
-          toolchain: 1.67
-          components: clippy
-          default: true
+          toolchain: stable
+          components: clippy                
+
+      # tptodo: remove
+      # - uses: actions-rs/toolchain@v1
+      #   with:
+      #     toolchain: 1.67
+      #     components: clippy
+      #     default: true
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,8 +27,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       # Install nightly toolchain
-      # action repo is here https://github.com/dtolnay/rust-toolchain      
-      - uses: dtolnay/rust-toolchain@nightly
+      # action repo is here https://github.com/dtolnay/rust-toolchain  
+      - name: Install Rust toolchain nightly
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt                
 
@@ -41,6 +42,7 @@ jobs:
 
       # Install toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
+      - name: Install Rust toolchain stable      
       - uses: dtolnay/rust-toolchain@1.67
         with:
           toolchain: stable

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,34 +26,20 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
-      # Install nightly toolchain
+      # Install Rust nightly toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain  
       - name: Install Rust toolchain nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt                
 
-      # tptodo: remove
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: nightly
-      #     profile: minimal
-      #     components: rustfmt
-
-      # Install toolchain
+      # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable      
         uses: dtolnay/rust-toolchain@1.67
         with:
           toolchain: stable
           components: clippy                
-
-      # tptodo: remove
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: 1.67
-      #     components: clippy
-      #     default: true
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,16 +20,12 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable      
         uses: dtolnay/rust-toolchain@1.67
         with:
           toolchain: stable
-
-      # tptodo: remove
-      # - uses: actions-rs/toolchain@v1
-      #   with:
-      #     toolchain: 1.67
 
       - name: Cache
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # action repo is here https://github.com/dtolnay/rust-toolchain
-      - uses: dtolnay/rust-toolchain@1.67
+      - name: Install Rust toolchain stable      
+        uses: dtolnay/rust-toolchain@1.67
         with:
           toolchain: stable
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable      
-        uses: dtolnay/rust-toolchain@1.67
+        uses: dtolnay/rust-toolchain@1.70
         with:
           toolchain: stable
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,15 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rs/toolchain@v1
+      # action repo is here https://github.com/dtolnay/rust-toolchain
+      - uses: dtolnay/rust-toolchain@1.67
         with:
-          toolchain: 1.67
+          toolchain: stable
+
+      # tptodo: remove
+      # - uses: actions-rs/toolchain@v1
+      #   with:
+      #     toolchain: 1.67
 
       - name: Cache
         uses: actions/cache@v2

--- a/bin/lock-keeper-client-cli/src/cli_command.rs
+++ b/bin/lock-keeper-client-cli/src/cli_command.rs
@@ -84,7 +84,7 @@ pub trait CliCommand: Debug {
     where
         Self: Sized,
     {
-        let mut split: _ = s.trim().split(' ');
+        let mut split = s.trim().split(' ');
 
         let command = split
             .next()


### PR DESCRIPTION
Closes #518

I replaced the Action we use to build the Rust toolchain because:

- it is outdated and not maintained
- it uses deprecated Action features that will be discontinued soon by GitHub
