### PR TITLE
Bump k256 version to 0.13.1

### DIFF
--- a/lock-keeper/Cargo.toml
+++ b/lock-keeper/Cargo.toml
@@ -37,7 +37,7 @@ zeroize.workspace = true
 anyhow = "1.0"
 chacha20poly1305 = "0.10"
 hkdf = "0.12"
-k256 = { version = "0.11", features = ["ecdsa", "pem", "serde"] }
+k256 = { version = "0.13.1", features = ["ecdsa", "pem", "serde"] }
 sha3 = "0.10"
 hex = "0.4"
 

--- a/lock-keeper/src/crypto/generic.rs
+++ b/lock-keeper/src/crypto/generic.rs
@@ -393,7 +393,7 @@ impl ParseBytes {
     /// Take next two bytes and convert them into a u16.
     pub fn take_bytes_as_u16(&mut self) -> Result<u16, CryptoError> {
         let &[f, s] = self.take_bytes(size_of::<u16>())? else {
-            return Err(CryptoError::ConversionError)
+            return Err(CryptoError::ConversionError);
         };
         Ok(u16::from_be_bytes([f, s]))
     }

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -7,9 +7,7 @@ use crate::{
     types::database::account::UserId,
     LockKeeperError,
 };
-use k256::{
-    ecdsa::{self, signature::DigestVerifier, VerifyingKey},
-};
+use k256::ecdsa::{self, signature::DigestVerifier, VerifyingKey};
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha3::Digest;
@@ -461,7 +459,7 @@ mod test {
         types::database::account::UserId,
         LockKeeperError,
     };
-    use k256::{ecdsa};
+    use k256::ecdsa;
 
     /* Public and private key pairs used for testing. These keys were generated
        as follows using the `openssl` command line utility:

--- a/lock-keeper/src/crypto/signing_key.rs
+++ b/lock-keeper/src/crypto/signing_key.rs
@@ -687,7 +687,6 @@ splX1fSP5u6QfX3Cq3Kn4kLo6IpjkTwtCfltYzuKEHLb7ROXSYdV
     #[test]
     fn signing_works() {
         let mut rng = rand::thread_rng();
-
         let signing_key = SigningKeyPair::generate(&mut rng, &AssociatedData::new());
         let public_key = signing_key.public_key();
 
@@ -696,6 +695,28 @@ splX1fSP5u6QfX3Cq3Kn4kLo6IpjkTwtCfltYzuKEHLb7ROXSYdV
             .map(|len| -> Vec<u8> { std::iter::repeat_with(|| rng.gen()).take(len).collect() })
             .map(|msg| (msg.sign(&signing_key), msg))
             .all(|(sig, msg)| msg.verify(&public_key, &sig).is_ok()));
+    }
+
+    #[test]
+    fn signature_from_der_works() {
+        const MESSAGE: &str = "Hello World!";
+        // Create a signature and convert it to der format.
+        let mut rng = rand::thread_rng();
+        let signing_key = SigningKeyPair::generate(&mut rng, &AssociatedData::new());
+        let signature = signing_key.signing_key.sign(MESSAGE);
+        let der = signature.to_der();
+
+        // Make new signature from der and verify.
+        let signature2 = Signature::from_der(&der).expect("Failed to read from der.");
+        let public_key = signing_key.public_key();
+        public_key
+            .verify(MESSAGE, &signature2)
+            .expect("Verification failed.");
+
+        assert_eq!(
+            signature, signature2,
+            "Signature mismatch after conversion."
+        );
     }
 
     #[test]

--- a/lock-keeper/src/crypto/signing_private_key.rs
+++ b/lock-keeper/src/crypto/signing_private_key.rs
@@ -1,8 +1,11 @@
+use std::str::FromStr;
 use crate::crypto::{CryptoError, Signature, SigningPublicKey};
 use k256::{
     ecdsa,
-    ecdsa::{recoverable, signature::DigestSigner},
+    ecdsa::{signature::DigestSigner},
+    ecdsa::RecoveryId,
 };
+use k256::ecdsa::VerifyingKey;
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha3::Digest;
@@ -33,7 +36,7 @@ pub struct RecoverableSignatureParts {
 }
 
 impl RecoverableSignature {
-    fn new(signature: Signature, recovery_id: recoverable::Id) -> Self {
+    fn new(signature: Signature, recovery_id: RecoveryId) -> Self {
         RecoverableSignature {
             signature,
             recovery_id: u8::from(recovery_id),
@@ -47,15 +50,11 @@ impl RecoverableSignature {
         &self,
         message: impl AsRef<[u8]>,
     ) -> Result<SigningPublicKey, CryptoError> {
-        let recovery_id = recoverable::Id::new(self.recovery_id)?;
-        let signature = recoverable::Signature::new(&self.signature.0, recovery_id)?;
-
+        let recovery_id = RecoveryId::try_from(self.recovery_id)?;
         let mut digest = sha3::Keccak256::new();
         digest.update(message);
 
-        let pk = signature
-            .recover_verifying_key_from_digest(digest)
-            .map_err(CryptoError::Signature)?;
+        let pk = VerifyingKey::recover_from_digest(digest, &self.signature.0, recovery_id)?;
         Ok(SigningPublicKey::from(pk))
     }
 
@@ -83,7 +82,7 @@ impl SigningPrivateKey {
     /// Create a `[SigningPrivateKey]` from the bytes emitted by a previous call
     /// to `[SigningPrivateKey::as_bytes]`
     pub fn from_bytes(key_material: &[u8]) -> Result<Self, CryptoError> {
-        let key = ecdsa::SigningKey::from_bytes(key_material)
+        let key = ecdsa::SigningKey::try_from(key_material)
             .map_err(|_| CryptoError::ConversionError)?;
         Ok(Self(key))
     }
@@ -104,7 +103,7 @@ impl SigningPrivateKey {
 
     /// Retrieve the public portion of the key.
     pub fn public_key(&self) -> SigningPublicKey {
-        SigningPublicKey::from(self.0.verifying_key())
+        SigningPublicKey::from(*self.0.verifying_key())
     }
 
     /// Sign a message returning a `[Signature]`. This function will hash the
@@ -117,13 +116,12 @@ impl SigningPrivateKey {
 
     /// Sign a message returning a `[RecoverableSignature]`. This function will
     /// hash the message using SHA3-256 (Keccak).
-    pub fn sign_recoverable(&self, message: impl AsRef<[u8]>) -> RecoverableSignature {
+    pub fn sign_recoverable(&self, message: impl AsRef<[u8]>) -> Result<RecoverableSignature, CryptoError> {
         let digest = sha3::Keccak256::new_with_prefix(message);
-        let signature: recoverable::Signature = self.0.sign_digest(digest);
+        let (signature, recovery_id) = self.0.sign_digest_recoverable(digest)?;
 
         // Convert `recoverable::Signature` into regular `Signature`.
-        let regular_sig = Signature(ecdsa::Signature::from(signature));
-        RecoverableSignature::new(regular_sig, signature.recovery_id())
+        Ok(RecoverableSignature::new(Signature(signature), recovery_id))
     }
 
     /// Get the underlying `[ecdsa::SigningKey]`. WARNING: This function should
@@ -133,12 +131,33 @@ impl SigningPrivateKey {
     pub fn to_k256_signing_key(self) -> ecdsa::SigningKey {
         self.0.clone()
     }
+
+
+    /// Deserialize PKCS#8-encoded private key from PEM.
+    // Keys in this format begin with the following delimiter:
+    // -----BEGIN PRIVATE KEY-----
+    pub fn from_pkcs8_pem(pem: &str) -> Result<Self, CryptoError> {
+        let key = ecdsa::SigningKey::from_str(pem)?;
+        Ok(Self(key))
+    }
 }
 
 #[cfg(test)]
 mod test {
     use crate::crypto::signing_private_key::SigningPrivateKey;
     use rand::rngs::OsRng;
+
+    #[test]
+    fn from_pkcs8_pem_works(){
+    const TEST_PRIVATE_KEY: &str = r#"
+-----BEGIN PRIVATE KEY-----
+MIGEAgEAMBAGByqGSM49AgEGBSuBBAAKBG0wawIBAQQg5X2FE2dAPaL6hD6hAN93
+6Gd61wZkW5i00WrrIQVt9P2hRANCAAQR/D8w6a2hucXfogqLpZw3+xJs/aet1ITd
+splX1fSP5u6QfX3Cq3Kn4kLo6IpjkTwtCfltYzuKEHLb7ROXSYdV
+-----END PRIVATE KEY-----
+"#;
+        assert!(SigningPrivateKey::from_pkcs8_pem(TEST_PRIVATE_KEY).is_ok(), "Failed to parse given private key.");
+}
 
     #[test]
     fn signing_and_verification_works() -> anyhow::Result<()> {
@@ -170,7 +189,7 @@ mod test {
     fn signing_and_verification_works_recoverable_sig() -> anyhow::Result<()> {
         let message = b"Hello World!";
         let key = SigningPrivateKey::generate(&mut OsRng);
-        let signature = key.sign_recoverable(message);
+        let signature = key.sign_recoverable(message)?;
 
         let recovered_public_key = signature.recover_verifying_key(message)?;
         recovered_public_key.verify(message, signature.to_standard())?;
@@ -184,7 +203,7 @@ mod test {
         let message2 = b"Goodbye World!";
 
         let key = SigningPrivateKey::generate(&mut OsRng);
-        let signature = key.sign_recoverable(message);
+        let signature = key.sign_recoverable(message)?;
 
         let recovered_public_key = signature.recover_verifying_key(message2)?;
 


### PR DESCRIPTION
Please ignore the name of this branch :no_mouth: 

- Add `from_pkcs8_pem` method to `SigningPrivateKey`.
- Add `from_der` to `Signature` type.

Closes #528 
Closes #527 