### PR TITLE
Rust compiler version pin fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Install Rust toolchain stable      
         uses: dtolnay/rust-toolchain@1.70
         with:
-          toolchain: stable
+            # Do NOT use `toolchain` input. It will cause the cargo version specified
+            # above to be ignored!
+            # toolchain: stable // Do NOT use.
+            components: clippy
 
       - name: Cache
         uses: actions/cache@v2


### PR DESCRIPTION
Properly pin Rust version. Today's update broke key-mgmt :unamused: 