### PR TITLE
Properly pin Rust toolchain's compiler version.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,11 +35,13 @@ jobs:
 
       # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
-      - name: Install Rust toolchain stable      
-        uses: dtolnay/rust-toolchain@1.70
+      - name: Install Rust toolchain stable
+        uses: dtolnay/rust-toolchain@1.70.0
         with:
-          toolchain: stable
-          components: clippy                
+          # Do NOT use `toolchain` input. It will cause the cargo version specified
+          # above to be ignored!
+          # toolchain: stable // Do NOT use.
+          components: clippy
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Install Rust toolchain stable      
         uses: dtolnay/rust-toolchain@1.70
         with:
-          toolchain: stable
+          # Do NOT use `toolchain` input. It will cause the cargo version specified
+          # above to be ignored!
+          # toolchain: stable // Do NOT use.
+          components: clippy
 
       - name: Cache
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable      
-        uses: dtolnay/rust-toolchain@1.70
+        uses: dtolnay/rust-toolchain@1.70.0
         with:
           # Do NOT use `toolchain` input. It will cause the cargo version specified
           # above to be ignored!


### PR DESCRIPTION
Properly pin Rust compiler version. Today's update broke it.