### PR TITLE
update encryption primitive #563

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,17 +39,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm"
-version = "0.10.2"
+name = "aes-gcm-siv"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
  "aes",
  "cipher",
  "ctr",
- "ghash",
+ "polyval",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -946,16 +947,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,7 +1313,7 @@ checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 name = "lock-keeper"
 version = "1.8.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm-siv",
  "anyhow",
  "argon2",
  "async-trait",

--- a/lock-keeper/Cargo.toml
+++ b/lock-keeper/Cargo.toml
@@ -34,7 +34,7 @@ zeroize.workspace = true
 
 
 # Other dependencies
-aes-gcm = "0.10.2" # Used for encryption/decryption of sharded keys.
+aes-gcm-siv = "0.11" # Used for encryption/decryption of sharded keys.
 anyhow = "1.0"
 chacha20poly1305 = "0.10"
 hkdf = "0.12"

--- a/lock-keeper/src/crypto/generic.rs
+++ b/lock-keeper/src/crypto/generic.rs
@@ -105,7 +105,7 @@ impl AssociatedData {
     }
 
     pub(super) fn with_bytes(self, ad: impl IntoIterator<Item = u8>) -> Self {
-        AssociatedData(self.0.into_iter().chain(ad.into_iter()).collect())
+        AssociatedData(self.0.into_iter().chain(ad).collect())
     }
 }
 


### PR DESCRIPTION
Updates encryption library from AES-GCM to AES-GCM-SIV.

I tested locally and did some integration testing and it seems to work fine.

See #563