### PR TITLE
Disable test environments that we don't use #605

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,17 +27,15 @@ dependencies = ["teardown", "start"]
 [tasks.start-server-attached]
 command = "docker"
 args = ["compose", "up",
-        "--build", "postgres", "nginx", "key_server", "ks_client_auth", "ks_nginx",
+        "--build", "postgres", "key_server",
         "--attach", "key_server", 
-        "--attach", "ks_client_auth",
-        "--attach", "ks_nginx",
 ]
 
 # Start a key server in the background
 [tasks.start-server-detached]
 command = "docker"
 args = ["compose", "up", 
-        "--build", "postgres", "nginx", "key_server", "ks_client_auth", "ks_nginx",
+        "--build", "postgres", "key_server",
         "--wait",
 ]
 

--- a/dev/config/TestEnvironments.toml
+++ b/dev/config/TestEnvironments.toml
@@ -1,3 +1,1 @@
 standard = "./dev/config/local/Client.toml"
-client_auth = "./dev/config/local-client-auth/Client.toml"
-nginx = "./dev/config/nginx-tls/Client.toml"

--- a/dev/config/TestEnvironmentsFull.toml
+++ b/dev/config/TestEnvironmentsFull.toml
@@ -1,0 +1,3 @@
+standard = "./dev/config/local/Client.toml"
+client_auth = "./dev/config/local-client-auth/Client.toml"
+nginx = "./dev/config/nginx-tls/Client.toml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,6 @@ services:
       stdin_open: true
       tty: true
 
-  nginx:
-    image: nginx:latest
-    container_name: nginx_tls
-    restart: always
-    ports:
-      - 1115:1115
-    depends_on:
-      - "ks_nginx"
-    volumes:
-      - ./dev/config/nginx-tls/nginx.conf:/etc/nginx/nginx.conf
-      - ./dev/test-pki/gen/certs/server.key:/etc/ssl/certs/server.key
-      - ./dev/test-pki/gen/certs/server.chain:/etc/ssl/certs/server.crt
-
   key_server:
     build: .
     restart: always
@@ -44,36 +31,3 @@ services:
       - "postgres"
     stdin_open: true
     tty: true 
-
-  ks_client_auth:
-    build: .
-    restart: always
-    volumes:
-      - ./dev:/app
-    environment:
-      CONFIG: "/app/config/docker-client-auth/Binary.toml"
-    ports:
-      - "1114:1114"
-    healthcheck:
-      test: "sh ./healthcheck.sh http://localhost:1114"
-      interval: 10s
-      timeout: 5s
-    depends_on:
-      - "postgres"
-    stdin_open: true
-    tty: true
-
-  ks_nginx:
-    build: .
-    volumes:
-      - ./dev:/app
-    environment:
-      CONFIG: "/app/config/nginx-tls/Binary.toml"
-    healthcheck:
-      test: "sh ./healthcheck.sh http://localhost:1113"
-      interval: 10s
-      timeout: 5s
-    depends_on:
-      - "postgres"
-    stdin_open: true
-    tty: true

--- a/lock-keeper-tests/src/config.rs
+++ b/lock-keeper-tests/src/config.rs
@@ -8,7 +8,6 @@ use crate::{error::LockKeeperTestError, utils, Cli};
 
 pub const STANDARD_CONFIG_NAME: &str = "standard";
 pub const CLIENT_AUTH_CONFIG_NAME: &str = "client_auth";
-pub const REQUIRED_CONFIGS: &[&str] = &[STANDARD_CONFIG_NAME, CLIENT_AUTH_CONFIG_NAME];
 
 /// Contains test configs for all environments defined in the test environment
 /// configuration file. This allows us to use specific configs for certain tests
@@ -39,21 +38,6 @@ impl TryFrom<Cli> for Environments {
             configs.insert(name, client_config);
         }
 
-        // Set required configs based on simple flag
-        let required_configs = if cli.standard_only {
-            &[STANDARD_CONFIG_NAME]
-        } else {
-            REQUIRED_CONFIGS
-        };
-
-        for required_config in required_configs {
-            if !configs.contains_key(*required_config) {
-                return Err(LockKeeperTestError::MissingRequiredConfig(
-                    required_config.to_string(),
-                ));
-            }
-        }
-
         Ok(Self { configs, filters })
     }
 }
@@ -82,8 +66,8 @@ impl Environments {
         self.config(STANDARD_CONFIG_NAME)
     }
 
-    pub fn client_auth_config(&self) -> Result<&Config, LockKeeperTestError> {
-        self.config(CLIENT_AUTH_CONFIG_NAME)
+    pub fn client_auth_config(&self) -> Option<&Config> {
+        self.configs.get(CLIENT_AUTH_CONFIG_NAME)
     }
 }
 

--- a/lock-keeper-tests/src/error.rs
+++ b/lock-keeper-tests/src/error.rs
@@ -8,8 +8,6 @@ pub type Result<T> = std::result::Result<T, LockKeeperTestError>;
 pub enum LockKeeperTestError {
     #[error("\"--standard-only\" flag can only be used when `--test-type=e2e`")]
     StandardOnlyFlag,
-    #[error("Client config missing for required environment: \"{0}\". Check TestEnvironments.toml if you're using the default environment config.")]
-    MissingRequiredConfig(String),
     #[error("Invalid test type: {0}")]
     InvalidTestType(String),
     #[error("One or more test cases failed.")]

--- a/lock-keeper-tests/src/test_suites/client_auth.rs
+++ b/lock-keeper-tests/src/test_suites/client_auth.rs
@@ -34,7 +34,7 @@ async fn client_auth_not_required(environments: Environments) -> Result<()> {
 }
 
 async fn client_auth_required(environments: Environments) -> Result<()> {
-    let result = LockKeeperClient::health(environments.client_auth_config()?).await;
+    let result = LockKeeperClient::health(environments.client_auth_config().unwrap()).await;
     assert!(result.is_ok());
 
     Ok(())
@@ -42,7 +42,7 @@ async fn client_auth_required(environments: Environments) -> Result<()> {
 
 async fn client_auth_required_not_provided(environments: Environments) -> Result<()> {
     // Point to client auth server but remove auth from client
-    let mut client_config = environments.client_auth_config()?.clone();
+    let mut client_config = environments.client_auth_config().unwrap().clone();
     client_config.tls_config = environments.standard_config()?.tls_config.clone();
 
     assert!(LockKeeperClient::health(&client_config).await.is_err());
@@ -53,7 +53,11 @@ async fn client_auth_required_not_provided(environments: Environments) -> Result
 async fn client_auth_not_required_but_provided(environments: Environments) -> Result<()> {
     // Point to no auth client but add auth
     let mut client_config = environments.standard_config()?.clone();
-    client_config.tls_config = environments.client_auth_config()?.tls_config.clone();
+    client_config.tls_config = environments
+        .client_auth_config()
+        .unwrap()
+        .tls_config
+        .clone();
 
     let result = LockKeeperClient::health(&client_config).await;
     assert!(result.is_ok());


### PR DESCRIPTION
This PR disables integration tests for the environments we don't use. This should make CI testing times around 1/3 of what they were before.

#605 