### PR TITLE
Bump version to 2.5.0 and fix missing config error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
 
 [[package]]
 name = "key-server-cli"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "base64 0.13.1",
  "clap",
@@ -1311,7 +1311,7 @@ checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock-keeper"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "lock-keeper-client"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "lock-keeper-client-cli"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "lock-keeper-key-server"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "argon2",
  "async-trait",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "lock-keeper-postgres"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "lock-keeper-session-cache-sql"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "lock-keeper-tests"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "base64 0.13.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["dev/generate-opaque-server-setup"]
 
 [workspace.package]
-version = "2.4.0"
+version = "2.5.0"
 
 [workspace.dependencies]
 argon2 = "0.4"

--- a/persistence/lock-keeper-session-cache-sql/src/error.rs
+++ b/persistence/lock-keeper-session-cache-sql/src/error.rs
@@ -41,7 +41,7 @@ impl From<Error> for SessionCacheError {
 pub enum ConfigError {
     #[error("Could not read config file {1}. Error: {0}.")]
     ConfigFileReadFailure(std::io::Error, PathBuf),
-    #[error("Fail to read TOML file contents.")]
+    #[error("Failed to read TOML file contents: {0}")]
     TomlReadFailure(#[from] toml::de::Error),
     #[error("Missing session cache username.")]
     MissingUsername,

--- a/persistence/lock-keeper-sql/src/error.rs
+++ b/persistence/lock-keeper-sql/src/error.rs
@@ -30,7 +30,7 @@ pub enum PostgresError {
 pub enum ConfigError {
     #[error("Could not read config file {1}. Error: {0}.")]
     ConfigFileReadFailure(std::io::Error, PathBuf),
-    #[error("Fail to read TOML file contents.")]
+    #[error("Failed to read TOML file contents: {0}")]
     TomlReadFailure(#[from] toml::de::Error),
     #[error("Missing database username.")]
     MissingUsername,


### PR DESCRIPTION
This PR fixes the missing error message for the `ConfigError` error variant. It also bumps the version to 2.5.0.