### PR TITLE
Add release number to check_session #642

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
       # Install Rust toolchain
       # action repo is here https://github.com/dtolnay/rust-toolchain
       - name: Install Rust toolchain stable
-        uses: dtolnay/rust-toolchain@1.70.0
+        uses: dtolnay/rust-toolchain@1.73.0
         with:
           # Do NOT use `toolchain` input. It will cause the cargo version specified
           # above to be ignored!

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       # Do NOT use `toolchain` input. It will cause the cargo version specified
       # above to be ignored!
       - name: Install Rust toolchain stable      
-        uses: dtolnay/rust-toolchain@1.70.0
+        uses: dtolnay/rust-toolchain@1.73.0
 
       - name: Cache
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV CONFIG="dev/config/docker/Binary.toml"
 RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
 WORKDIR /usr/src/lock-keeper-key-server
 COPY . .
+COPY ./boltlabs-release.toml /etc/bolt-labs/boltlabs-release.toml
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/src/lock-keeper-key-server/target \
     cargo install --locked --path ./bin/key-server-cli

--- a/boltlabs-release.toml
+++ b/boltlabs-release.toml
@@ -1,0 +1,2 @@
+keymgmt="develop"
+build-date="develop"

--- a/dev/config/docker-client-auth/Server.toml
+++ b/dev/config/docker-client-auth/Server.toml
@@ -3,6 +3,7 @@ port = 1114
 opaque_path = "/app/opaque"
 opaque_server_key = "/app/opaque/server_setup"
 remote_storage_key = "/app/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]

--- a/dev/config/docker/Server.toml
+++ b/dev/config/docker/Server.toml
@@ -3,6 +3,7 @@ port = 1113
 opaque_path = "/app/opaque"
 opaque_server_key = "/app/opaque/server_setup"
 remote_storage_key = "/app/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]

--- a/dev/config/local-client-auth/Server.toml
+++ b/dev/config/local-client-auth/Server.toml
@@ -3,6 +3,7 @@ port = 1114
 opaque_path = "dev/opaque"
 opaque_server_key = "dev/opaque/server_setup"
 remote_storage_key = "dev/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]

--- a/dev/config/local/Server.toml
+++ b/dev/config/local/Server.toml
@@ -3,6 +3,7 @@ port = 1113
 opaque_path = "dev/opaque"
 opaque_server_key = "dev/opaque/server_setup"
 remote_storage_key = "dev/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]

--- a/dev/config/nginx-tls/Server.toml
+++ b/dev/config/nginx-tls/Server.toml
@@ -3,6 +3,7 @@ port = 1113
 opaque_path = "/app/opaque"
 opaque_server_key = "/app/opaque/server_setup"
 remote_storage_key = "/app/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [logging]

--- a/lock-keeper-key-server/src/config.rs
+++ b/lock-keeper-key-server/src/config.rs
@@ -29,6 +29,7 @@ pub struct Config {
     pub opaque_server_setup: ServerSetup<OpaqueCipherSuite, PrivateKey<Ristretto255>>,
     pub remote_storage_key: RemoteStorageKey,
     pub logging: LoggingConfig,
+    pub release_toml_path: PathBuf,
     /// Maximum size allowed for the store sever-encrypted blob endpoint.
     /// This size  bounded by types lengths that can be represented as a u16.
     pub max_blob_size: u16,
@@ -81,6 +82,7 @@ impl Config {
             tls_config,
             opaque_server_setup,
             logging: config.logging,
+            release_toml_path: config.release_toml_path,
             max_blob_size: config.max_blob_size,
         })
     }
@@ -110,6 +112,7 @@ pub struct ConfigFile {
     pub opaque_path: PathBuf,
     pub opaque_server_key: Option<PathBuf>,
     pub logging: LoggingConfig,
+    pub release_toml_path: PathBuf,
     pub tls_config: Option<TlsConfig>,
     pub max_blob_size: u16,
 }
@@ -214,6 +217,7 @@ mod tests {
             opaque_path = "tests/gen/opaque"
             opaque_server_key = "tests/gen/opaque/server_setup"
             remote_storage_key = "test_sse.key"
+            release_toml_path = "./boltlabs-release.toml
             max_blob_size = 1024
 
             [tls_config]
@@ -238,6 +242,7 @@ mod tests {
             opaque_path,
             opaque_server_key,
             logging,
+            release_toml_path,
             max_blob_size,
         } = ConfigFile::from_str(config_str).unwrap();
 
@@ -246,6 +251,7 @@ mod tests {
         assert_eq!(address, IpAddr::from_str("127.0.0.2").unwrap());
         assert_eq!(port, 1114);
         assert_eq!(remote_storage_key, Some(PathBuf::from("test_sse.key")));
+        assert_eq!(release_toml_path, PathBuf::from("./boltlabs-release.toml"));
         assert_eq!(tls_config.private_key, Some(PathBuf::from("test.key")));
         assert_eq!(tls_config.certificate_chain, PathBuf::from("test.crt"));
         assert!(!tls_config.client_auth);

--- a/lock-keeper-key-server/src/config.rs
+++ b/lock-keeper-key-server/src/config.rs
@@ -217,7 +217,7 @@ mod tests {
             opaque_path = "tests/gen/opaque"
             opaque_server_key = "tests/gen/opaque/server_setup"
             remote_storage_key = "test_sse.key"
-            release_toml_path = "./boltlabs-release.toml
+            release_toml_path = "./boltlabs-release.toml"
             max_blob_size = 1024
 
             [tls_config]

--- a/lock-keeper-tests/src/test_suites/config_files.rs
+++ b/lock-keeper-tests/src/test_suites/config_files.rs
@@ -176,6 +176,7 @@ port = 1114
 opaque_path = "dev/opaque"
 opaque_server_key = "dev/opaque/server_setup"
 remote_storage_key = "dev/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]
@@ -195,6 +196,7 @@ address = "127.0.0.1"
 port = 1114
 opaque_path = "dev/opaque"
 opaque_server_key = "dev/opaque/server_setup"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]
@@ -215,6 +217,7 @@ address = "127.0.0.1"
 port = 1114
 opaque_path = "dev/opaque"
 remote_storage_key = "dev/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]
@@ -236,6 +239,7 @@ port = 1114
 opaque_path = "dev/opaque"
 opaque_server_key = "dev/opaque/server_setup"
 remote_storage_key = "dev/remote-storage-key/gen/remote_storage.key"
+release_toml_path = "./boltlabs-release.toml"
 max_blob_size = 1024
 
 [tls_config]

--- a/lock-keeper-tests/src/test_suites/end_to_end/test_cases/check_session.rs
+++ b/lock-keeper-tests/src/test_suites/end_to_end/test_cases/check_session.rs
@@ -1,5 +1,4 @@
 use colored::Colorize;
-use lock_keeper::rpc::SessionStatus;
 use lock_keeper_client::Config;
 
 use crate::{
@@ -26,13 +25,12 @@ async fn check_session_with_valid_session(config: Config) -> Result<()> {
     let state = init_test_state(&config).await?;
     let client = authenticate(&state).await.result?;
 
-    let res = client.check_session().await;
-    assert!(matches!(
-        res,
-        Ok(SessionStatus {
-            is_session_valid: true
-        })
-    ));
+    let res = client.check_session().await?;
+    let key_mgmt_version = String::from("develop");
+    let build_date = String::from("develop");
+    assert!(res.is_session_valid);
+    assert_eq!(res.key_mgmt_version, key_mgmt_version);
+    assert_eq!(res.build_date, build_date);
 
     Ok(())
 }
@@ -43,13 +41,12 @@ async fn check_session_with_invalid_session(config: Config) -> Result<()> {
 
     client.logout().await.result?;
 
-    let res = client.check_session().await;
-    assert!(matches!(
-        res,
-        Ok(SessionStatus {
-            is_session_valid: false
-        })
-    ));
+    let res = client.check_session().await?;
+    let key_mgmt_version = String::from("develop");
+    let build_date = String::from("develop");
+    assert!(!res.is_session_valid);
+    assert_eq!(res.key_mgmt_version, key_mgmt_version);
+    assert_eq!(res.build_date, build_date);
 
     Ok(())
 }

--- a/lock-keeper/proto/lock_keeper_rpc.proto
+++ b/lock-keeper/proto/lock_keeper_rpc.proto
@@ -29,4 +29,6 @@ message Empty {}
 
 message SessionStatus {
   bool is_session_valid = 1;
+  string key_mgmt_version = 2;
+  string build_date = 3;
 }


### PR DESCRIPTION
#642 

I removed the `[release]` heading from the example toml because otherwise I think I would have had to make an extra level of nesting in the Rust type for it. I also made the hyphen in "build-date" an underscore instead.